### PR TITLE
Disable `sanitizeResources` in `Deno.test`

### DIFF
--- a/engine/runtime/runtime.ts
+++ b/engine/runtime/runtime.ts
@@ -91,6 +91,7 @@ export class Runtime {
 
 			// TODO: https://github.com/rivet-gg/open-game-services-engine/issues/35
 			sanitizeOps: false,
+			sanitizeResources: false,
 
 			async fn() {
 				const runtime = new Runtime(config);


### PR DESCRIPTION
(Prisma does odd stuff with timeouts and intervals, which count as resources rather than ops.)