### PR TITLE
Fix minor typescript issue with engine `test`.

### DIFF
--- a/engine/runtime/error_test.ts
+++ b/engine/runtime/error_test.ts
@@ -21,6 +21,7 @@ Deno.test("error", async () => {
 		runtime,
 		newTrace({ internalTest: {} }),
 		"test_module",
+		undefined,
 	);
 
 	// Create error


### PR DESCRIPTION
When the signature for `ModuleContext` was changed, the runtime test `error_test.ts` was never updated.

Because `error_test.ts` doesn't use a DB, `undefined` works well enough.