### PR TITLE
Implement Proxying for `ctx` (`ctx.modules.name.script(req)` is `ctx.call("name", "script", req)`)

### DIFF
--- a/engine/runtime/context.ts
+++ b/engine/runtime/context.ts
@@ -2,7 +2,7 @@ import { Runtime } from "./runtime.ts";
 import { Trace } from "./trace.ts";
 import { RuntimeError } from "./error.ts";
 import { appendTraceEntry } from "./trace.ts";
-import { BaseModuleProxyBuilder } from "./proxy.ts";
+import { buildRegistryProxy } from "./proxy.ts";
 
 import type { RegistryCallFn } from "@ogs/helpers/registry.d.ts";
 
@@ -78,7 +78,7 @@ export class Context {
 	};
 
 	public get modules() {
-		return BaseModuleProxyBuilder.buildProxyForRegistry(this.runtime.config.modules, this);
+		return buildRegistryProxy(this.runtime.config.modules, this);
 	}
 
 	public async tryCallRaw(moduleName: string, scriptName: string, req: unknown): Promise<object | null> {

--- a/engine/runtime/proxy.ts
+++ b/engine/runtime/proxy.ts
@@ -5,80 +5,124 @@ import type {
 } from "@ogs/helpers/registry.d.ts";
 import { Context, Module } from "@ogs/runtime";
 
-type MappedProxy = {
+/**
+ * Typed module accessor
+ */
+type MappedProxy = Readonly<{
 	[K in keyof RegistryType]: MappedModuleProxy<K>;
-};
+}>;
 type MappedNullProxy = {
 	[K in keyof RegistryType]: null;
 };
 
-type MappedModuleProxy<Module extends keyof RegistryType> = {
+/**
+ * Typed module-specific script accessor
+ */
+type MappedModuleProxy<Module extends keyof RegistryType> = Readonly<{
 	[K in keyof RegistryType[Module]]: (
 		request: RequestOf<RegistryType[Module][K]>,
 	) => Promise<ResponseOf<RegistryType[Module][K]>>;
-};
+}>;
 type MappedModuleNullProxy<Module extends keyof RegistryType> = {
 	[K in keyof RegistryType[Module]]: null;
 };
 
-export class BaseModuleProxyBuilder {
-	public static buildProxyForRegistry(
-		modules: Record<string, Module>,
-		ctx: Context,
-	) {
-		const target: MappedNullProxy = {} as any;
-		for (const k of Object.keys(modules)) {
-			target[k as keyof RegistryType] = null;
-		}
-
-		const handler: ProxyHandler<MappedProxy> = {
-			get: function (_, property) {
-				if (Object.hasOwn(modules, property as string)) {
-					return ModuleProxyBuilder.buildProxyForRegistry(
-						modules,
-						ctx,
-						property as keyof RegistryType,
-					);
-				}
-			},
-		};
-
-		return new Proxy(target as unknown as MappedProxy, handler);
+/**
+ * Builds a proxy for the entire registry, with the keys of the modules mapped
+ * to script proxies using [`buildModuleProxy`]({@link buildModuleProxy})
+ */
+export function buildRegistryProxy(
+	modules: Record<string, Module>,
+	ctx: Context,
+): MappedProxy {
+	/**
+	 * Proxies require the accessed key on the object to be defined, so we
+	 * create this object with all the module names mapped to null.
+	 */
+	const target: MappedNullProxy = {} as any;
+	for (const k of Object.keys(modules)) {
+		target[k as keyof RegistryType] = null;
 	}
+
+	/**
+	 * A handler object that will return a proxy for the accessed module.
+	 * 
+	 * Object.hasOwn is used here to default to `undefined` just in case the
+	 * object is somehow improperly accessed.
+	 */
+	const handler: ProxyHandler<MappedProxy> = {
+		get: function (_, property) {
+			if (Object.hasOwn(modules, property as string)) {
+				return buildModuleProxy(
+					modules,
+					ctx,
+					property as keyof RegistryType,
+				);
+			}
+		},
+	};
+
+	// Create and return the proxy with the keys of the modules, with
+	// accesses being intercepted and mapped by the proxy handler.
+	//
+	// `target as unknown as MappedProxy` is used to bypass the type check
+	// because null (typeof target[moduleName]) is not a sub or super type
+	// of `MappedModuleProxy<T>`.
+	return new Proxy(target as unknown as MappedProxy, handler);
 }
 
-class ModuleProxyBuilder {
-	public static buildProxyForRegistry<
-		ModuleName extends keyof RegistryType & string,
-	>(
-		modules: Record<string, Module>,
-		ctx: Context,
-		moduleName: ModuleName,
-	) {
-		const accessedModule = modules[moduleName];
-		if (!accessedModule) throw new Error(`Module not found: ${moduleName}`);
+/**
+ * Builds a proxy for a specific module (`ModuleName`), with the keys of the
+ * scripts mapped to on-the-fly generated call functions
+ */
+function buildModuleProxy<ModuleName extends keyof RegistryType & string>(
+	modules: Record<string, Module>,
+	ctx: Context,
+	moduleName: ModuleName,
+): MappedModuleProxy<ModuleName> {
+	// Although this should never throw an error, double-checking never hurt anyone
+	const accessedModule = modules[moduleName] as Module | undefined;
+	if (!accessedModule) throw new Error(`Module not found: ${moduleName}`);
 
-		const target: MappedModuleNullProxy<ModuleName> = {} as any;
-		for (const k of Object.keys(accessedModule.scripts)) {
-			target[k as keyof RegistryType[ModuleName]] = null;
-		}
-
-		const handler: ProxyHandler<MappedModuleProxy<ModuleName>> = {
-			get: function (_, property) {
-				if (Object.hasOwn(accessedModule.scripts, property as string)) {
-					return (req: unknown) =>
-						ctx.call(
-							moduleName as ModuleName,
-							property as keyof RegistryType[ModuleName] & string,
-							req as any,
-						);
-				}
-			},
-		};
-
-		return new Proxy(
-			target as unknown as MappedModuleProxy<ModuleName>,
-			handler,
-		);
+	/**
+	 * Proxies require the accessed key on the object to be defined, so we
+	 * create this object with all the script names in module `ModuleName`
+	 * mapped to null. 
+	 */
+	const target: MappedModuleNullProxy<ModuleName> = {} as any;
+	for (const k of Object.keys(accessedModule.scripts)) {
+		target[k as keyof RegistryType[ModuleName]] = null;
 	}
+
+	/**
+	 * A handler object that will return a bound call function for the
+	 * accessed script.
+	 * 
+	 * Object.hasOwn is used here to default to `undefined` just in case the
+	 * object is somehow improperly accessed.
+	 */
+	const handler: ProxyHandler<MappedModuleProxy<ModuleName>> = {
+		get: function (_, property) {
+			if (Object.hasOwn(accessedModule.scripts, property as string)) {
+				return (req: unknown) =>
+					ctx.call(
+						moduleName as ModuleName,
+						property as keyof RegistryType[ModuleName] & string,
+						req as any,
+					);
+			}
+		},
+	};
+
+	// Create and return the proxy with the keys of the scripts, with
+	// accesses being intercepted and mapped by the proxy handler, returning
+	// prebound and typed call functions.
+	//
+	// `target as unknown as MappedModuleProxy<ModuleName>` is again used to
+	// bypass the type check because null (typeof target[scriptName]) is not
+	// a sub or super type of `(req: Promise<unknown>) => Promise<unknown>`.
+	return new Proxy(
+		target as unknown as MappedModuleProxy<ModuleName>,
+		handler,
+	);
 }


### PR DESCRIPTION
Fixes OSGE-44

Along with PR 50, Addresses #2.

Does not address `dependencies` restrictions in #31