### PR TITLE
fix(setup): Create `artifacts` folder if it doesn't already exist

### DIFF
--- a/src/artifacts/build_runtime_archive.ts
+++ b/src/artifacts/build_runtime_archive.ts
@@ -20,6 +20,11 @@ for (const file of files) {
 	archiveFiles[file] = await Deno.readTextFile(join(rootSrc, file));
 }
 
+
+// Create artifacts folder if it doesn't already exist
+await Deno.mkdir(join(rootSrc, "artifacts"), { recursive: true });
+
+// Write schema to file
 await Deno.writeTextFile(
 	join(rootSrc, "artifacts", "runtime_archive.json"),
 	JSON.stringify(archiveFiles),

--- a/src/artifacts/build_schema.ts
+++ b/src/artifacts/build_schema.ts
@@ -2,13 +2,13 @@
 //
 // Generates schema JSON from the module & project config
 
-import { join } from "../deps.ts";
 import { tjs } from "./deps.ts";
+import { dirname as parent, join } from "../deps.ts";
 
 const dirname = import.meta.dirname;
 if (!dirname) throw new Error("Missing dirname");
 
-await Deno.mkdir(join(dirname, "..", "..", "artifacts")).catch(e => {
+await Deno.mkdir(join(dirname, "..", "..", "artifacts")).catch((e) => {
 	if (!(e instanceof Deno.errors.AlreadyExists)) throw e;
 });
 
@@ -70,5 +70,9 @@ for (const { name, type } of CONFIGS) {
 	});
 	if (schema == null) throw new Error("Failed to generate schema");
 
+	// Create artifacts folder if it doesn't already exist
+	await Deno.mkdir(parent(schemaPath), { recursive: true });
+
+	// Write schema to file
 	await Deno.writeTextFile(schemaPath, JSON.stringify(schema, null, "\t"));
 }


### PR DESCRIPTION
Fixes OGBE-66

This is really only applicable for the first time starting open-source development, but it's good to have that more streamined.