### PR TITLE
fix(gen)!: Fix misc generated files and imports

### DIFF
--- a/src/build/entrypoint.ts
+++ b/src/build/entrypoint.ts
@@ -15,8 +15,8 @@ export async function generateEntrypoint(project: Project, opts: BuildOpts) {
 	if (opts.dbDriver == DbDriver.NodePostgres) {
 		imports += `
 		// Import Prisma adapter for Postgres
-		import pg from "https://esm.sh/pg@^8.11.3";
-		import { PrismaPg } from "https://esm.sh/@prisma/adapter-pg@^5.9.1";
+		import pg from "npm:pg@^8.11.3";
+		import { PrismaPg } from "npm:@prisma/adapter-pg@^5.9.1";
 		`;
 	} else if (opts.dbDriver == DbDriver.NeonServerless) {
 		imports += `

--- a/src/build/gen.ts
+++ b/src/build/gen.ts
@@ -22,22 +22,22 @@ export async function compileModuleHelper(
 	let dbImports = "";
 	if (module.db) {
 		dbImports = dedent`
-		import prisma from "./prisma/esm.js";
-		export { prisma };
-		export const Prisma = prisma.Prisma;
-	`;
+			import prisma from "./prisma/esm.js";
+			export { prisma };
+			export const Prisma = prisma.Prisma;
+		`;
 	}
 
 	const source = dedent`
 		import { ModuleContext as ModuleContextInner } from "${runtimePath}";
-		import { ${module.name}$$Registry as RegistryTypeInner } from "./registry.d.ts";
+		import { Registry as RegistryTypeInner } from "./registry.d.ts";
 		
 		${dbImports}
 		
 		export { RuntimeError } from "${runtimePath}";
 		export type ModuleContext = ModuleContextInner<RegistryTypeInner, ${
-		module.db ? "prisma.PrismaClient" : "undefined"
-	}};
+			module.db ? "prisma.PrismaClient" : "undefined"
+		}>;
 	`;
 
 	// Write source
@@ -62,8 +62,8 @@ export async function compileTestHelper(
 		export * from "./mod.ts";
 		
 		export type TestContext = TestContextInner<RegistryTypeInner, ${
-		module.db ? "module.prisma.PrismaClient" : "undefined"
-	}};
+			module.db ? "module.prisma.PrismaClient" : "undefined"
+		}>;
 		
 		export type TestFn = (ctx: TestContext) => Promise<void>;
 		
@@ -96,8 +96,8 @@ export async function compileScriptHelper(
 		export * from "../mod.ts";
 		
 		export type ScriptContext = ScriptContextInner<RegistryTypeInner, ${
-		module.db ? "module.prisma.PrismaClient" : "undefined"
-	}};
+			module.db ? "module.prisma.PrismaClient" : "undefined"
+		}>;
 	`;
 
 	// Write source

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -81,6 +81,13 @@ export const buildCommand = new Command<GlobalOpts>()
 				);
 			}
 		}
+		if (opts.runtime == Runtime.Deno) {
+			if (opts.outputFormat != Format.Native) {
+				throw new ValidationError(
+					`\`format\` must be "native" if \`runtime\` is "deno".`,
+				);
+			}
+		}
 
 		await build(project, {
 			format: opts.outputFormat!,

--- a/src/runtime/deps.ts
+++ b/src/runtime/deps.ts
@@ -3,7 +3,7 @@ export {
 	Transaction,
 } from "https://deno.land/x/postgres@v0.17.2/mod.ts";
 
-import Ajv from "https://esm.sh/ajv@^8.12.0";
+import * as Ajv from "https://esm.sh/ajv@^8.12.0";
 export { Ajv };
 
 import addFormats from "https://esm.sh/ajv-formats@^2.1.1";


### PR DESCRIPTION
For some reason, the `esm.sh` versions of `pg` and `@prisma/adapter-pg` just straight up don't work.

Additionally, there were some issues with the migration to `dedent`, and the `Ajv` default import is not the same as its `*` import.