### PR TITLE
chore: replace old/new cache with diffs for the current process

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,6 +4,11 @@
 		"cli:run": "deno task artifacts:build:all && deno task cli:run:dirty",
 		"cli:run:dirty": "deno run -A --check src/cli/main.ts --path tests/basic",
 
+		// Specific CLI tasks
+		"cli:run:build": "deno task cli:run build",
+		"cli:run:clean_build": "deno task artifacts:build:all && deno task cli:run:dirty clean && deno task cli:run build",
+
+
 		// Compiles the CLI to a binary
 		"cli:compile": "deno task artifacts:build:all && deno compile --check --allow-net --allow-read --allow-env --allow-run --allow-write --allow-sys --output _gen/cli src/cli/main.ts",
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,7 +9,9 @@ import { lintCommand } from "./commands/lint.ts";
 import { formatCommand } from "./commands/format.ts";
 import { initCommand } from "./commands/init.ts";
 import { cleanCommand } from "./commands/clean.ts";
+import { cleanupAllPools } from "../utils/worker_pool.ts";
 
+// Run command
 const command = new Command();
 command.action(() => command.showHelp())
 	.globalOption("-p, --path <path>", "Path to project root")
@@ -32,5 +34,8 @@ command.action(() => command.showHelp())
 			console.error(error);
 		}
 		Deno.exit(error instanceof ValidationError ? error.exitCode : 1);
-	})
-	.parse(Deno.args);
+	});
+await command.parse(Deno.args);
+
+// Cleanup
+cleanupAllPools();

--- a/src/utils/worker_pool.ts
+++ b/src/utils/worker_pool.ts
@@ -163,7 +163,7 @@ export function shutdownPool(pool: WorkerPool<unknown, unknown>) {
 	GLOBAL_STATE.allPools.delete(pool);
 }
 
-export function shutdownAllPools() {
+export function cleanupAllPools() {
 	GLOBAL_STATE.shutdown = true;
 	for (const pool of GLOBAL_STATE.allPools) {
 		shutdownPool(pool);


### PR DESCRIPTION
Required in order to be able to use parts of the build cache for non-build commands. Otherwise `newCache` is overwritten with an empty cache and the next cache has to build from scratch.

