### PR TITLE
chore: Add drivers to docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,19 @@
         ]
       },
       {
+        "group": "Drivers",
+        "icon": "database",
+        "pages": [
+          "drivers/overview",
+          "drivers/rivet",
+          "drivers/file-system",
+          "drivers/memory",
+          "drivers/redis",
+          "drivers/cloudflare-workers",
+          "drivers/building-drivers"
+        ]
+      },
+      {
         "group": "Reference",
         "pages": [
           "general/authentication",
@@ -143,20 +156,7 @@
   "_temp": [
               "general/architecture",
               "general/registry",
-              "general/webhooks",
-    {
-      "group": "Drivers",
-      "icon": "database",
-      "pages": [
-        "drivers/overview",
-        "drivers/rivet",
-        "drivers/cloudflare-workers",
-        "drivers/file-system",
-        "drivers/memory",
-        "drivers/redis",
-        "drivers/building-drivers"
-      ]
-    }
+              "general/webhooks"
   ],
   "contextual": {
    "options": [

--- a/docs/drivers/file-system.mdx
+++ b/docs/drivers/file-system.mdx
@@ -4,6 +4,8 @@ description: Local file system storage for development
 icon: file-system
 ---
 
+The file system driver stores actor state in local files and is the default driver for RivetKit. Data persists between restarts but will not scale across multiple servers.
+
 <Steps>
 <Step title="Install RivetKit">
 
@@ -39,8 +41,9 @@ export const registry = setup({
 <Step title="Setup Server">
 
 ```ts server.ts
+import { Hono } from "hono";
 import { registry } from "./registry";
-import { createFileSystemDriver } from "@rivetkit/actor/file-system";
+import { createFileSystemDriver } from "@rivetkit/actor";
 
 const { client, serve } = registry.createServer({
 	driver: createFileSystemDriver()
@@ -70,7 +73,3 @@ npx tsx --watch server.ts
 </Step>
 
 </Steps>
-
-<Info>
-The file system driver stores actor state in local files. Data persists between restarts but will not scale across multiple servers.
-</Info>

--- a/docs/drivers/file-system.mdx
+++ b/docs/drivers/file-system.mdx
@@ -1,0 +1,76 @@
+---
+title: File System Driver
+description: Local file system storage for development
+icon: file-system
+---
+
+<Steps>
+<Step title="Install RivetKit">
+
+```sh
+npm install @rivetkit/actor
+```
+
+</Step>
+
+<Step title="Create Registry">
+
+```ts registry.ts
+import { actor, setup } from "@rivetkit/actor";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, amount: number = 1) => {
+			c.state.count += amount;
+			return c.state.count;
+		},
+		getCount: (c) => c.state.count,
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});
+```
+
+</Step>
+
+<Step title="Setup Server">
+
+```ts server.ts
+import { registry } from "./registry";
+import { createFileSystemDriver } from "@rivetkit/actor/file-system";
+
+const { client, serve } = registry.createServer({
+	driver: createFileSystemDriver()
+});
+
+// Setup your web framework
+const app = new Hono();
+
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+	return c.json({ count: newCount });
+});
+
+serve(app);
+```
+
+</Step>
+
+<Step title="Run Server">
+
+```sh
+npx tsx --watch server.ts
+```
+
+</Step>
+
+</Steps>
+
+<Info>
+The file system driver stores actor state in local files. Data persists between restarts but will not scale across multiple servers.
+</Info>

--- a/docs/drivers/memory.mdx
+++ b/docs/drivers/memory.mdx
@@ -1,0 +1,74 @@
+---
+title: Memory Driver
+description: In-memory storage for development and testing
+icon: memory
+---
+
+<Steps>
+<Step title="Install RivetKit">
+
+```sh
+npm install @rivetkit/actor
+```
+
+</Step>
+
+<Step title="Create Registry">
+
+```ts registry.ts
+import { actor, setup } from "@rivetkit/actor";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, amount: number = 1) => {
+			c.state.count += amount;
+			return c.state.count;
+		},
+		getCount: (c) => c.state.count,
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});
+```
+
+</Step>
+
+<Step title="Setup Server">
+
+```ts server.ts
+import { registry } from "./registry";
+
+// Memory driver is used by default
+const { client, serve } = registry.createServer();
+
+// Setup your web framework
+const app = new Hono();
+
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+	return c.json({ count: newCount });
+});
+
+serve(app);
+```
+
+</Step>
+
+<Step title="Run Server">
+
+```sh
+npx tsx --watch server.ts
+```
+
+</Step>
+
+</Steps>
+
+<Warning>
+The memory driver stores data in RAM and will be lost when the process restarts. Use only for development and testing.
+</Warning>

--- a/docs/drivers/memory.mdx
+++ b/docs/drivers/memory.mdx
@@ -4,6 +4,8 @@ description: In-memory storage for development and testing
 icon: memory
 ---
 
+The memory driver stores data in RAM and will be lost when the process restarts. It must be explicitly configured and should only be used for development and testing.
+
 <Steps>
 <Step title="Install RivetKit">
 
@@ -39,10 +41,13 @@ export const registry = setup({
 <Step title="Setup Server">
 
 ```ts server.ts
+import { Hono } from "hono";
 import { registry } from "./registry";
+import { createMemoryDriver } from "@rivetkit/actor";
 
-// Memory driver is used by default
-const { client, serve } = registry.createServer();
+const { client, serve } = registry.createServer({
+	driver: createMemoryDriver()
+});
 
 // Setup your web framework
 const app = new Hono();
@@ -68,7 +73,3 @@ npx tsx --watch server.ts
 </Step>
 
 </Steps>
-
-<Warning>
-The memory driver stores data in RAM and will be lost when the process restarts. Use only for development and testing.
-</Warning>

--- a/docs/drivers/overview.mdx
+++ b/docs/drivers/overview.mdx
@@ -1,1 +1,90 @@
-TODO: Comparison
+---
+title: Drivers Overview
+description: Choose the right storage and coordination driver for your needs
+icon: layers
+---
+
+Drivers handle actor state persistence, management, and coordination in RivetKit. Each driver is optimized for different environments and use cases.
+
+<CardGroup cols={2}>
+<Card title="Memory Driver" icon="memory" href="/drivers/memory">
+  In-memory storage for development and testing. Data is lost on restart.
+</Card>
+
+<Card title="File System Driver" icon="file-system" href="/drivers/file-system">
+  Local file system storage. Default driver with data persistence between restarts.
+</Card>
+
+<Card title="Redis Driver" icon="redis" href="/drivers/redis">
+  Production-ready Redis storage with scaling support across multiple instances.
+</Card>
+
+<Card title="Rivet Driver" icon="rivet-bg" href="/drivers/rivet">
+  Cloud platform with automatic scaling, persistence, and global distribution.
+</Card>
+</CardGroup>
+
+## Dynamic Configuration
+
+You can dynamically configure drivers based on environment variables to use different drivers for development vs production:
+
+```ts server.ts
+import { Hono } from "hono";
+import { registry } from "./registry";
+import { createFileSystemDriver, createMemoryDriver } from "@rivetkit/actor";
+import { createRedisDriver } from "@rivetkit/redis";
+import Redis from "ioredis";
+
+// Dynamic driver configuration
+function createDriver() {
+  const env = process.env.NODE_ENV;
+  
+  if (env === "production") {
+    // Use Redis for production
+    const redis = new Redis({
+      host: process.env.REDIS_HOST || "localhost",
+      port: parseInt(process.env.REDIS_PORT || "6379"),
+    });
+    return createRedisDriver(redis, registry);
+  } else if (env === "test") {
+    // Use memory driver for testing
+    return createMemoryDriver();
+  } else {
+    // Use file system driver for development (default)
+    return createFileSystemDriver();
+  }
+}
+
+const { client, serve } = registry.createServer({
+  driver: createDriver()
+});
+
+// Setup your web framework
+const app = new Hono();
+
+app.post("/increment/:name", async (c) => {
+  const name = c.req.param("name");
+  const counter = client.counter.getOrCreate(name);
+  const newCount = await counter.increment(1);
+  return c.json({ count: newCount });
+});
+
+serve(app);
+```
+
+## Environment Variables
+
+You can also use the `RIVETKIT_DRIVER` environment variable to automatically select a driver:
+
+```sh
+# Use file system driver (default)
+RIVETKIT_DRIVER=file-system npm run dev
+
+# Use memory driver
+RIVETKIT_DRIVER=memory npm run dev
+
+# Use Rivet cloud driver
+RIVETKIT_DRIVER=rivet npm run dev
+```
+
+When no explicit driver is configured, RivetKit will use the file system driver by default.

--- a/docs/drivers/redis.mdx
+++ b/docs/drivers/redis.mdx
@@ -4,6 +4,8 @@ description: Production-ready Redis storage and coordination
 icon: redis
 ---
 
+The Redis driver provides production-ready persistence and can scale across multiple server instances. It requires a Redis server to be running.
+
 <Steps>
 <Step title="Install Dependencies">
 
@@ -40,8 +42,9 @@ export const registry = setup({
 <Step title="Setup Server">
 
 ```ts server.ts
+import { Hono } from "hono";
 import { registry } from "./registry";
-import { RedisActorDriver, RedisManagerDriver } from "@rivetkit/redis";
+import { createRedisDriver } from "@rivetkit/redis";
 import Redis from "ioredis";
 
 // Create Redis client
@@ -51,11 +54,7 @@ const redis = new Redis({
 });
 
 const { client, serve } = registry.createServer({
-	driver: {
-		topology: "standalone",
-		actor: new RedisActorDriver(redis),
-		manager: new RedisManagerDriver(redis, registry),
-	}
+	driver: createRedisDriver(redis, registry)
 });
 
 // Setup your web framework
@@ -82,7 +81,3 @@ npx tsx --watch server.ts
 </Step>
 
 </Steps>
-
-<Info>
-The Redis driver provides production-ready persistence and can scale across multiple server instances. Requires a Redis server to be running.
-</Info>

--- a/docs/drivers/redis.mdx
+++ b/docs/drivers/redis.mdx
@@ -1,0 +1,88 @@
+---
+title: Redis Driver
+description: Production-ready Redis storage and coordination
+icon: redis
+---
+
+<Steps>
+<Step title="Install Dependencies">
+
+```sh
+npm install @rivetkit/actor @rivetkit/redis ioredis
+npm install -D @types/ioredis
+```
+
+</Step>
+
+<Step title="Create Registry">
+
+```ts registry.ts
+import { actor, setup } from "@rivetkit/actor";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, amount: number = 1) => {
+			c.state.count += amount;
+			return c.state.count;
+		},
+		getCount: (c) => c.state.count,
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});
+```
+
+</Step>
+
+<Step title="Setup Server">
+
+```ts server.ts
+import { registry } from "./registry";
+import { RedisActorDriver, RedisManagerDriver } from "@rivetkit/redis";
+import Redis from "ioredis";
+
+// Create Redis client
+const redis = new Redis({
+	host: "localhost",
+	port: 6379,
+});
+
+const { client, serve } = registry.createServer({
+	driver: {
+		topology: "standalone",
+		actor: new RedisActorDriver(redis),
+		manager: new RedisManagerDriver(redis, registry),
+	}
+});
+
+// Setup your web framework
+const app = new Hono();
+
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+	return c.json({ count: newCount });
+});
+
+serve(app);
+```
+
+</Step>
+
+<Step title="Run Server">
+
+```sh
+npx tsx --watch server.ts
+```
+
+</Step>
+
+</Steps>
+
+<Info>
+The Redis driver provides production-ready persistence and can scale across multiple server instances. Requires a Redis server to be running.
+</Info>

--- a/docs/drivers/rivet.mdx
+++ b/docs/drivers/rivet.mdx
@@ -4,6 +4,8 @@ description: Deploy and scale with Rivet cloud platform
 icon: rivet-bg
 ---
 
+The Rivet driver automatically handles scaling, persistence, and global distribution when deployed to the Rivet platform.
+
 <Steps>
 <Step title="Install RivetKit">
 
@@ -39,6 +41,7 @@ export const registry = setup({
 <Step title="Setup Server">
 
 ```ts server.ts
+import { Hono } from "hono";
 import { registry } from "./registry";
 
 const { client, serve } = registry.createServer();
@@ -84,7 +87,3 @@ Your endpoint will be available at your Rivet project URL.
 </Step>
 
 </Steps>
-
-<Info>
-The Rivet driver automatically handles scaling, persistence, and global distribution when deployed to the Rivet platform.
-</Info>

--- a/docs/drivers/rivet.mdx
+++ b/docs/drivers/rivet.mdx
@@ -1,0 +1,90 @@
+---
+title: Rivet Driver
+description: Deploy and scale with Rivet cloud platform
+icon: rivet-bg
+---
+
+<Steps>
+<Step title="Install RivetKit">
+
+```sh
+npm install @rivetkit/actor
+```
+
+</Step>
+
+<Step title="Create Registry">
+
+```ts registry.ts
+import { actor, setup } from "@rivetkit/actor";
+
+export const counter = actor({
+	state: { count: 0 },
+	actions: {
+		increment: (c, amount: number = 1) => {
+			c.state.count += amount;
+			return c.state.count;
+		},
+		getCount: (c) => c.state.count,
+	},
+});
+
+export const registry = setup({
+	use: { counter },
+});
+```
+
+</Step>
+
+<Step title="Setup Server">
+
+```ts server.ts
+import { registry } from "./registry";
+
+const { client, serve } = registry.createServer();
+
+// Setup your web framework
+const app = new Hono();
+
+app.post("/increment/:name", async (c) => {
+	const name = c.req.param("name");
+	const counter = client.counter.getOrCreate(name);
+	const newCount = await counter.increment(1);
+	return c.json({ count: newCount });
+});
+
+serve(app);
+```
+
+</Step>
+
+<Step title="Configure Rivet">
+
+Create a `rivet.json` configuration file:
+
+```json rivet.json
+{
+  "rivetkit": {
+    "registry": "src/registry.ts",
+    "server": "src/server.ts"
+  }
+}
+```
+
+</Step>
+
+<Step title="Deploy">
+
+```sh
+npx rivet-cli deploy
+```
+
+Your endpoint will be available at your Rivet project URL.
+
+</Step>
+
+</Steps>
+
+<Info>
+The Rivet driver automatically handles scaling, persistence, and global distribution when deployed to the Rivet platform.
+</Info>

--- a/packages/actor/src/mod.ts
+++ b/packages/actor/src/mod.ts
@@ -1,1 +1,3 @@
 export * from "@rivetkit/core";
+export { createMemoryDriver } from "@rivetkit/core/drivers/memory";
+export { createFileSystemDriver } from "@rivetkit/core/drivers/file-system";

--- a/packages/drivers/redis/src/mod.ts
+++ b/packages/drivers/redis/src/mod.ts
@@ -1,3 +1,17 @@
+import type { DriverConfig, Registry } from "@rivetkit/core";
+import type Redis from "ioredis";
+import { RedisActorDriver } from "./actor";
+import { RedisManagerDriver } from "./manager";
+import { RedisCoordinateDriver } from "./coordinate";
+
 export { RedisActorDriver } from  "./actor";
 export { RedisManagerDriver } from "./manager";
 export { RedisCoordinateDriver } from "./coordinate";
+
+export function createRedisDriver(redis: Redis, registry?: Registry<any>): DriverConfig {
+	return {
+		topology: "standalone",
+		actor: new RedisActorDriver(redis),
+		manager: new RedisManagerDriver(redis, registry),
+	};
+}


### PR DESCRIPTION
Fixes #1055

Added barebones documentation for the 4 driver pages that were previously blank:

- memory driver (development)
- file-system driver (local persistence)
- redis driver (production storage)
- rivet driver (cloud deployment)

Each page includes minimal setup steps with code examples referenced from the backend quickstart. Also moved the drivers section from _temp to the main sidebar navigation.