### PR TITLE
feat: add warning system for mixing actor handles and connections

### DIFF
--- a/packages/core/src/client/actor-conn.ts
+++ b/packages/core/src/client/actor-conn.ts
@@ -8,6 +8,7 @@ import * as cbor from "cbor-x";
 import type { EventSource } from "eventsource";
 import pRetry from "p-retry";
 import type { CloseEvent, WebSocket } from "ws";
+import { removeConnectionFromTracking } from "./actor-handle";
 import type { ActorDefinitionActions } from "./actor-common";
 import {
 	ACTOR_CONNS_SYMBOL,
@@ -748,6 +749,9 @@ enc
 
 		// Remove from registry
 		this.#client[ACTOR_CONNS_SYMBOL].delete(this);
+
+		// Remove from connection tracking
+		removeConnectionFromTracking(this.#actorQuery, this.#params, this);
 
 		// Disconnect transport cleanly
 		if (!this.#transport) {

--- a/packages/core/src/client/actor-handle.ts
+++ b/packages/core/src/client/actor-handle.ts
@@ -13,38 +13,33 @@ import {
 import { logger } from "./log";
 
 /**
- * Global registry of actor handles that have established connections.
- * Maps from a unique handle identifier to whether connections exist.
- */
-const ACTIVE_CONNECTIONS = new Map<string, Set<ActorConnRaw>>();
-
-/**
- * Generates a unique identifier for an actor handle based on its query and parameters.
+ * Generates a unique identifier for an actor handle based on actor name and key.
  */
 function generateHandleIdentifier(
 	actorQuery: ActorQuery,
-	params: unknown,
 ): string {
-	return JSON.stringify({ query: actorQuery, params });
+	if ("getForKey" in actorQuery) {
+		return JSON.stringify([actorQuery.getForKey.name, actorQuery.getForKey.key]);
+	} else if ("getOrCreateForKey" in actorQuery) {
+		return JSON.stringify([actorQuery.getOrCreateForKey.name, actorQuery.getOrCreateForKey.key]);
+	} else if ("getForId" in actorQuery) {
+		// For ID-based queries, use a synthetic actor name and the ID as key
+		return JSON.stringify(["__id__", actorQuery.getForId.actorId]);
+	} else if ("create" in actorQuery) {
+		return JSON.stringify([actorQuery.create.name, actorQuery.create.key]);
+	} else {
+		assertUnreachable(actorQuery);
+	}
 }
 
-/**
- * Removes a connection from the global tracking registry.
- * Should be called when a connection is disposed.
- */
-export function removeConnectionFromTracking(
-	actorQuery: ActorQuery,
-	params: unknown,
-	conn: ActorConnRaw,
-): void {
-	const handleIdentifier = generateHandleIdentifier(actorQuery, params);
-	const connections = ACTIVE_CONNECTIONS.get(handleIdentifier);
-	if (connections) {
-		connections.delete(conn);
-		if (connections.size === 0) {
-			ACTIVE_CONNECTIONS.delete(handleIdentifier);
-		}
-	}
+
+export interface ActorHandleRawOptions {
+	client: ClientRaw;
+	driver: ClientDriver;
+	params: unknown;
+	encodingKind: Encoding;
+	actorQuery: ActorQuery;
+	silenceConnectionWarnings?: boolean;
 }
 
 /**
@@ -59,8 +54,9 @@ export class ActorHandleRaw {
 	#encodingKind: Encoding;
 	#actorQuery: ActorQuery;
 	#params: unknown;
-	#silenceWarnings: boolean;
+	#silenceConnectionWarnings: boolean;
 	#handleIdentifier: string;
+	#activeConnections = new Set<ActorConnRaw>();
 
 	/**
 	 * Do not call this directly.
@@ -69,21 +65,14 @@ export class ActorHandleRaw {
 	 *
 	 * @protected
 	 */
-	public constructor(
-		client: any,
-		driver: ClientDriver,
-		params: unknown,
-		encodingKind: Encoding,
-		actorQuery: ActorQuery,
-		silenceWarnings = false,
-	) {
-		this.#client = client;
-		this.#driver = driver;
-		this.#encodingKind = encodingKind;
-		this.#actorQuery = actorQuery;
-		this.#params = params;
-		this.#silenceWarnings = silenceWarnings;
-		this.#handleIdentifier = generateHandleIdentifier(actorQuery, params);
+	public constructor(opts: ActorHandleRawOptions) {
+		this.#client = opts.client;
+		this.#driver = opts.driver;
+		this.#encodingKind = opts.encodingKind;
+		this.#actorQuery = opts.actorQuery;
+		this.#params = opts.params;
+		this.#silenceConnectionWarnings = opts.silenceConnectionWarnings ?? false;
+		this.#handleIdentifier = generateHandleIdentifier(opts.actorQuery);
 	}
 
 	/**
@@ -102,18 +91,15 @@ export class ActorHandleRaw {
 		signal?: AbortSignal;
 	}): Promise<Response> {
 		// Check for active connections and warn if they exist
-		if (!this.#silenceWarnings) {
-			const activeConnections = ACTIVE_CONNECTIONS.get(this.#handleIdentifier);
-			if (activeConnections && activeConnections.size > 0) {
-				logger().warn(
-					"calling stateless rpc on handle while connection is open - this may cause race conditions",
-					{
-						action: opts.name,
-						activeConnections: activeConnections.size,
-						query: this.#actorQuery,
-					},
-				);
-			}
+		if (!this.#silenceConnectionWarnings && this.#activeConnections.size > 0) {
+			logger().warn(
+				"calling stateless rpc on handle while connection is open - this may cause race conditions",
+				{
+					action: opts.name,
+					activeConnections: this.#activeConnections.size,
+					query: this.#actorQuery,
+				},
+			);
 		}
 
 		return await this.#driver.action<Args, Response>(
@@ -144,13 +130,11 @@ export class ActorHandleRaw {
 			this.#params,
 			this.#encodingKind,
 			this.#actorQuery,
+			() => this.#activeConnections.delete(conn),
 		);
 
-		// Track this connection in the global registry
-		if (!ACTIVE_CONNECTIONS.has(this.#handleIdentifier)) {
-			ACTIVE_CONNECTIONS.set(this.#handleIdentifier, new Set());
-		}
-		ACTIVE_CONNECTIONS.get(this.#handleIdentifier)!.add(conn);
+		// Track this connection in the handle's registry
+		this.#activeConnections.add(conn);
 
 		return this.#client[CREATE_ACTOR_CONN_PROXY](
 			conn,
@@ -187,6 +171,7 @@ export class ActorHandleRaw {
 			assertUnreachable(this.#actorQuery);
 		}
 	}
+
 }
 
 /**

--- a/packages/core/src/client/actor-handle.ts
+++ b/packages/core/src/client/actor-handle.ts
@@ -13,6 +13,41 @@ import {
 import { logger } from "./log";
 
 /**
+ * Global registry of actor handles that have established connections.
+ * Maps from a unique handle identifier to whether connections exist.
+ */
+const ACTIVE_CONNECTIONS = new Map<string, Set<ActorConnRaw>>();
+
+/**
+ * Generates a unique identifier for an actor handle based on its query and parameters.
+ */
+function generateHandleIdentifier(
+	actorQuery: ActorQuery,
+	params: unknown,
+): string {
+	return JSON.stringify({ query: actorQuery, params });
+}
+
+/**
+ * Removes a connection from the global tracking registry.
+ * Should be called when a connection is disposed.
+ */
+export function removeConnectionFromTracking(
+	actorQuery: ActorQuery,
+	params: unknown,
+	conn: ActorConnRaw,
+): void {
+	const handleIdentifier = generateHandleIdentifier(actorQuery, params);
+	const connections = ACTIVE_CONNECTIONS.get(handleIdentifier);
+	if (connections) {
+		connections.delete(conn);
+		if (connections.size === 0) {
+			ACTIVE_CONNECTIONS.delete(handleIdentifier);
+		}
+	}
+}
+
+/**
  * Provides underlying functions for stateless {@link ActorHandle} for action calls.
  * Similar to ActorConnRaw but doesn't maintain a connection.
  *
@@ -24,6 +59,8 @@ export class ActorHandleRaw {
 	#encodingKind: Encoding;
 	#actorQuery: ActorQuery;
 	#params: unknown;
+	#silenceWarnings: boolean;
+	#handleIdentifier: string;
 
 	/**
 	 * Do not call this directly.
@@ -38,12 +75,15 @@ export class ActorHandleRaw {
 		params: unknown,
 		encodingKind: Encoding,
 		actorQuery: ActorQuery,
+		silenceWarnings = false,
 	) {
 		this.#client = client;
 		this.#driver = driver;
 		this.#encodingKind = encodingKind;
 		this.#actorQuery = actorQuery;
 		this.#params = params;
+		this.#silenceWarnings = silenceWarnings;
+		this.#handleIdentifier = generateHandleIdentifier(actorQuery, params);
 	}
 
 	/**
@@ -61,6 +101,21 @@ export class ActorHandleRaw {
 		args: Args;
 		signal?: AbortSignal;
 	}): Promise<Response> {
+		// Check for active connections and warn if they exist
+		if (!this.#silenceWarnings) {
+			const activeConnections = ACTIVE_CONNECTIONS.get(this.#handleIdentifier);
+			if (activeConnections && activeConnections.size > 0) {
+				logger().warn(
+					"calling stateless rpc on handle while connection is open - this may cause race conditions",
+					{
+						action: opts.name,
+						activeConnections: activeConnections.size,
+						query: this.#actorQuery,
+					},
+				);
+			}
+		}
+
 		return await this.#driver.action<Args, Response>(
 			undefined,
 			this.#actorQuery,
@@ -90,6 +145,12 @@ export class ActorHandleRaw {
 			this.#encodingKind,
 			this.#actorQuery,
 		);
+
+		// Track this connection in the global registry
+		if (!ACTIVE_CONNECTIONS.has(this.#handleIdentifier)) {
+			ACTIVE_CONNECTIONS.set(this.#handleIdentifier, new Set());
+		}
+		ACTIVE_CONNECTIONS.get(this.#handleIdentifier)!.add(conn);
 
 		return this.#client[CREATE_ACTOR_CONN_PROXY](
 			conn,

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -103,13 +103,19 @@ export interface QueryOptions {
  * Options for getting a actor by ID.
  * @typedef {QueryOptions} GetWithIdOptions
  */
-export interface GetWithIdOptions extends QueryOptions {}
+export interface GetWithIdOptions extends QueryOptions {
+	/** Silence warnings when using handles with active connections. */
+	silenceWarnings?: boolean;
+}
 
 /**
  * Options for getting a actor.
  * @typedef {QueryOptions} GetOptions
  */
-export interface GetOptions extends QueryOptions {}
+export interface GetOptions extends QueryOptions {
+	/** Silence warnings when using handles with active connections. */
+	silenceWarnings?: boolean;
+}
 
 /**
  * Options for getting or creating a actor.
@@ -121,6 +127,8 @@ export interface GetOrCreateOptions extends QueryOptions {
 	createInRegion?: string;
 	/** Input data to pass to the actor. */
 	createWithInput?: unknown;
+	/** Silence warnings when using handles with active connections. */
+	silenceWarnings?: boolean;
 }
 
 /**
@@ -133,6 +141,8 @@ export interface CreateOptions extends QueryOptions {
 	region?: string;
 	/** Input data to pass to the actor. */
 	input?: unknown;
+	/** Silence warnings when using handles with active connections. */
+	silenceWarnings?: boolean;
 }
 
 /**
@@ -256,7 +266,11 @@ export class ClientRaw {
 			},
 		};
 
-		const handle = this.#createHandle(opts?.params, actorQuery);
+		const handle = this.#createHandle(
+			opts?.params,
+			actorQuery,
+			opts?.silenceWarnings,
+		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
 
@@ -290,7 +304,11 @@ export class ClientRaw {
 			},
 		};
 
-		const handle = this.#createHandle(opts?.params, actorQuery);
+		const handle = this.#createHandle(
+			opts?.params,
+			actorQuery,
+			opts?.silenceWarnings,
+		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
 
@@ -327,7 +345,11 @@ export class ClientRaw {
 			},
 		};
 
-		const handle = this.#createHandle(opts?.params, actorQuery);
+		const handle = this.#createHandle(
+			opts?.params,
+			actorQuery,
+			opts?.silenceWarnings,
+		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
 
@@ -385,20 +407,29 @@ export class ClientRaw {
 				actorId,
 			},
 		} satisfies ActorQuery;
-		const handle = this.#createHandle(opts?.params, getForIdQuery);
+		const handle = this.#createHandle(
+			opts?.params,
+			getForIdQuery,
+			opts?.silenceWarnings,
+		);
 
 		const proxy = createActorProxy(handle) as ActorHandle<AD>;
 
 		return proxy;
 	}
 
-	#createHandle(params: unknown, actorQuery: ActorQuery): ActorHandleRaw {
+	#createHandle(
+		params: unknown,
+		actorQuery: ActorQuery,
+		silenceWarnings = false,
+	): ActorHandleRaw {
 		return new ActorHandleRaw(
 			this,
 			this.#driver,
 			params,
 			this.#encodingKind,
 			actorQuery,
+			silenceWarnings,
 		);
 	}
 

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -105,7 +105,7 @@ export interface QueryOptions {
  */
 export interface GetWithIdOptions extends QueryOptions {
 	/** Silence warnings when using handles with active connections. */
-	silenceWarnings?: boolean;
+	silenceConnectionWarnings?: boolean;
 }
 
 /**
@@ -114,7 +114,7 @@ export interface GetWithIdOptions extends QueryOptions {
  */
 export interface GetOptions extends QueryOptions {
 	/** Silence warnings when using handles with active connections. */
-	silenceWarnings?: boolean;
+	silenceConnectionWarnings?: boolean;
 }
 
 /**
@@ -128,7 +128,7 @@ export interface GetOrCreateOptions extends QueryOptions {
 	/** Input data to pass to the actor. */
 	createWithInput?: unknown;
 	/** Silence warnings when using handles with active connections. */
-	silenceWarnings?: boolean;
+	silenceConnectionWarnings?: boolean;
 }
 
 /**
@@ -142,7 +142,7 @@ export interface CreateOptions extends QueryOptions {
 	/** Input data to pass to the actor. */
 	input?: unknown;
 	/** Silence warnings when using handles with active connections. */
-	silenceWarnings?: boolean;
+	silenceConnectionWarnings?: boolean;
 }
 
 /**
@@ -269,7 +269,7 @@ export class ClientRaw {
 		const handle = this.#createHandle(
 			opts?.params,
 			actorQuery,
-			opts?.silenceWarnings,
+			opts?.silenceConnectionWarnings,
 		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
@@ -307,7 +307,7 @@ export class ClientRaw {
 		const handle = this.#createHandle(
 			opts?.params,
 			actorQuery,
-			opts?.silenceWarnings,
+			opts?.silenceConnectionWarnings,
 		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
@@ -348,7 +348,7 @@ export class ClientRaw {
 		const handle = this.#createHandle(
 			opts?.params,
 			actorQuery,
-			opts?.silenceWarnings,
+			opts?.silenceConnectionWarnings,
 		);
 		return createActorProxy(handle) as ActorHandle<AD>;
 	}
@@ -410,7 +410,7 @@ export class ClientRaw {
 		const handle = this.#createHandle(
 			opts?.params,
 			getForIdQuery,
-			opts?.silenceWarnings,
+			opts?.silenceConnectionWarnings,
 		);
 
 		const proxy = createActorProxy(handle) as ActorHandle<AD>;
@@ -421,16 +421,16 @@ export class ClientRaw {
 	#createHandle(
 		params: unknown,
 		actorQuery: ActorQuery,
-		silenceWarnings = false,
+		silenceConnectionWarnings = false,
 	): ActorHandleRaw {
-		return new ActorHandleRaw(
-			this,
-			this.#driver,
+		return new ActorHandleRaw({
+			client: this,
+			driver: this.#driver,
 			params,
-			this.#encodingKind,
+			encodingKind: this.#encodingKind,
 			actorQuery,
-			silenceWarnings,
-		);
+			silenceConnectionWarnings,
+		});
 	}
 
 	[CREATE_ACTOR_CONN_PROXY]<AD extends AnyActorDefinition>(


### PR DESCRIPTION
Adds warning system to detect and alert users when mixing actor handle and connection usage patterns that may cause race conditions.

## Changes
- Add global connection tracking to detect when handles have active connections
- Log warning when calling stateless RPCs on handles with active connections
- Add silenceWarnings option to all handle creation methods
- Properly clean up connection tracking when connections are disposed

Closes #1061