### PR TITLE
fix(cloudflare-workers): always mount registry router

### DIFF
--- a/packages/drivers/cloudflare-workers/src/handler.ts
+++ b/packages/drivers/cloudflare-workers/src/handler.ts
@@ -80,9 +80,7 @@ export function createServer<R extends Registry<any>>(
 			const app = hono ?? new Hono();
 
 			// Mount registry router at /registry
-			if (!hono) {
-				app.route("/registry", serverOutput.hono);
-			}
+			app.route("/registry", serverOutput.hono);
 
 			// Create Cloudflare handler
 			const handler = {


### PR DESCRIPTION
https://www.rivet.gg/docs/hosting-providers/cloudflare-workers

The registry doesn't get mounted if an instance of `Hono` is passed into `createHandler`.

I'm assuming that since the docs don't reference mounting the `/registry` route manually, that it should be included automatically even with a Hono instance defined by the user. Correct me if I'm wrong—this default behavior makes sense to me.