### PR TITLE
feat(examples): add drizzle example

### DIFF
--- a/examples/drizzle/README.md
+++ b/examples/drizzle/README.md
@@ -1,6 +1,6 @@
-# Hono Integration for RivetKit
+# Drizzle Integration for RivetKit
 
-Example project demonstrating Hono web framework integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Drizzle ORM integration with [RivetKit](https://rivetkit.org).
 
 [Learn More →](https://github.com/rivet-gg/rivetkit)
 
@@ -16,17 +16,15 @@ Example project demonstrating Hono web framework integration with [RivetKit](htt
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
-cd rivetkit/examples/hono
-npm install
+cd rivetkit/examples/drizzle
+pnpm install
 ```
 
 ### Development
-
 ```sh
-npm run dev
+pnpm run dev
 ```
-
-Open your browser to http://localhost:3000 to see the Hono server with RivetKit integration.
+Open your browser to https://studio.rivet.gg/ to see your RivetKit server.
 
 ## License
 

--- a/examples/drizzle/drizzle/0000_flippant_bloodstrike.sql
+++ b/examples/drizzle/drizzle/0000_flippant_bloodstrike.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `messages_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`sender` text NOT NULL,
+	`text` text NOT NULL,
+	`timestamp` integer NOT NULL
+);

--- a/examples/drizzle/drizzle/0000_wonderful_iron_patriot.sql
+++ b/examples/drizzle/drizzle/0000_wonderful_iron_patriot.sql
@@ -1,8 +1,0 @@
-CREATE TABLE `users_table` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`name` text NOT NULL,
-	`age` integer NOT NULL,
-	`email` text NOT NULL
-);
---> statement-breakpoint
-CREATE UNIQUE INDEX `users_table_email_unique` ON `users_table` (`email`);

--- a/examples/drizzle/drizzle/meta/0000_snapshot.json
+++ b/examples/drizzle/drizzle/meta/0000_snapshot.json
@@ -1,11 +1,11 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "22f3d49c-97d5-46ca-b0f1-99950c3efec7",
+  "id": "cb13fd0c-ec74-4b9d-b939-8ad091b0dca1",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
-    "users_table": {
-      "name": "users_table",
+    "messages_table": {
+      "name": "messages_table",
       "columns": {
         "id": {
           "name": "id",
@@ -14,35 +14,29 @@
           "notNull": true,
           "autoincrement": true
         },
-        "name": {
-          "name": "name",
+        "sender": {
+          "name": "sender",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
         },
-        "age": {
-          "name": "age",
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
         }
       },
-      "indexes": {
-        "users_table_email_unique": {
-          "name": "users_table_email_unique",
-          "columns": ["email"],
-          "isUnique": true
-        }
-      },
+      "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},

--- a/examples/drizzle/drizzle/meta/_journal.json
+++ b/examples/drizzle/drizzle/meta/_journal.json
@@ -5,15 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1750711614205,
-      "tag": "0000_wonderful_iron_patriot",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1750716663518,
-      "tag": "0001_rich_susan_delgado",
+      "when": 1755196233006,
+      "tag": "0000_flippant_bloodstrike",
       "breakpoints": true
     }
   ]

--- a/examples/drizzle/drizzle/migrations.js
+++ b/examples/drizzle/drizzle/migrations.js
@@ -1,4 +1,4 @@
-import m0000 from "./0000_wonderful_iron_patriot.sql";
+import m0000 from "./0000_flippant_bloodstrike.sql";
 import journal from "./meta/_journal.json";
 
 export default {

--- a/examples/drizzle/package.json
+++ b/examples/drizzle/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "example-sqlite",
+  "name": "example-drizzle",
   "version": "0.9.9",
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx --watch src/server.ts",
+    "dev": "tsx --loader @rivetkit/sql-loader --watch src/server.ts",
     "check-types": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^22.13.9",
-    "rivetkit": "workspace:*",
+    "@rivetkit/sql-loader": "workspace:*",
     "tsx": "^3.12.7",
     "typescript": "^5.5.2"
   },
   "dependencies": {
     "@rivetkit/db": "workspace:*",
+    "@rivetkit/actor": "workspace:*",
     "drizzle-kit": "^0.31.2",
     "drizzle-orm": "^0.44.2"
   },

--- a/examples/drizzle/src/db/schema.ts
+++ b/examples/drizzle/src/db/schema.ts
@@ -1,9 +1,8 @@
-// import { int, sqliteTable, text } from "@rivetkit/db/drizzle";
+import { int, sqliteTable, text } from "@rivetkit/db/drizzle";
 
-// export const usersTable = sqliteTable("users_table", {
-// 	id: int().primaryKey({ autoIncrement: true }),
-// 	name: text().notNull(),
-// 	age: int().notNull(),
-// 	email: text().notNull().unique(),
-// 	email2: text().notNull().unique(),
-// });
+export const messagesTable = sqliteTable("messages_table", {
+	id: int().primaryKey({ autoIncrement: true }),
+	sender: text().notNull(),
+	text: text().notNull(),
+	timestamp: int().notNull(),
+});

--- a/examples/drizzle/src/registry.ts
+++ b/examples/drizzle/src/registry.ts
@@ -1,25 +1,32 @@
-// import { actor, setup } from "rivetkit";
-// import { db } from "@rivetkit/db/drizzle";
-// import * as schema from "./db/schema";
-// import migrations from "../drizzle/migrations";
+import { actor, setup } from "@rivetkit/actor";
+import { db } from "@rivetkit/db/drizzle";
+import { desc } from "drizzle-orm";
+import migrations from "../drizzle/migrations";
+import * as schema from "./db/schema";
 
-// export const counter = actor({
-// 	db: db({ schema, migrations }),
-// 	state: {
-// 		count: 0,
-// 	},
-// 	onAuth: () => {
-// 		// Configure auth here
-// 	},
-// 	actions: {
-// 		increment: (c, x: number) => {
-// 			// createState or state fix fix fix
-// 			c.db.c.state.count += x;
-// 			return c.state.count;
-// 		},
-// 	},
-// });
+export const chat = actor({
+	db: db({ schema, migrations }),
+	onAuth: () => {},
+	actions: {
+		// Callable functions from clients: https://rivet.gg/docs/actors/actions
+		sendMessage: async (c, sender: string, text: string) => {
+			const message = { sender, text, timestamp: Date.now() };
+			// State changes are automatically persisted
+			await c.db.insert(schema.messagesTable).values(message);
+			// Send events to all connected clients: https://rivet.gg/docs/actors/events
+			c.broadcast("newMessage", message);
+			return message;
+		},
 
-// export const registry = setup({
-// 	use: { counter },
-// });
+		getHistory: (c) =>
+			c.db
+				.select()
+				.from(schema.messagesTable)
+				.orderBy(desc(schema.messagesTable.timestamp))
+				.limit(100),
+	},
+});
+
+export const registry = setup({
+	use: { chat },
+});

--- a/examples/drizzle/src/server.ts
+++ b/examples/drizzle/src/server.ts
@@ -1,7 +1,3 @@
-// import { registry } from "./registry";
-// import { createMemoryDriver } from "@rivetkit/memory";
-// import { serve } from "@rivetkit/nodejs";
+import { registry } from "./registry";
 
-// serve(registry, {
-// 	driver: createMemoryDriver(),
-// });
+registry.runServer();

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -17,14 +17,16 @@ export type DatabaseProvider<DB extends RawAccess> = {
 	onMigrate: (client: DB) => void | Promise<void>;
 };
 
-type ExecuteFunction = (
-	query: string,
-	...args: unknown[]
-) => Promise<unknown[]>;
+type PrepareFunction = (query: string, ...args: unknown[]) => Statement;
+
+type Statement = {
+	all(...args: unknown[]): Promise<unknown[]>;
+	run(...args: unknown[]): Promise<unknown>;
+};
 
 export type RawAccess = {
 	/**
-	 * Executes a raw SQL query.
+	 * Prepares a raw SQL query.
 	 */
-	execute: ExecuteFunction;
+	prepare: PrepareFunction;
 };

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -4,7 +4,7 @@
  * running raw SQL commands.
  */
 export type SQLiteShim = {
-	exec: (query: string, ...args: unknown[]) => unknown[];
+	exec: (query: string, ...args: unknown[]) => Promise<unknown[] | unknown>;
 };
 
 export function isSQLiteShim<T>(conn: unknown): conn is SQLiteShim & T {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
 
   examples/drizzle:
     dependencies:
+      '@rivetkit/actor':
+        specifier: workspace:*
+        version: link:../../packages/actor
       '@rivetkit/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -384,12 +387,12 @@ importers:
         specifier: ^0.44.2
         version: 0.44.2(@cloudflare/workers-types@4.20250619.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.2)
     devDependencies:
+      '@rivetkit/sql-loader':
+        specifier: workspace:*
+        version: link:../../packages/misc/sql-loader
       '@types/node':
         specifier: ^22.13.9
         version: 22.15.32
-      rivetkit:
-        specifier: workspace:*
-        version: link:../../packages/rivetkit
       tsx:
         specifier: ^3.12.7
         version: 3.14.0


### PR DESCRIPTION
Closes FRONT-764

### TL;DR

Updated the Drizzle example to implement a functional chat application with message storage and retrieval.

### What changed?

- Fixed the README to correctly reference Drizzle ORM instead of Hono
- Replaced the users table schema with a messages table for storing chat messages
- Implemented actor functionality with `sendMessage` and `getHistory` actions
- Added SQL migration files for the messages table structure
- Updated package.json to use the SQL loader and added actor dependency
- Enabled the server implementation to run the registry

### How to test?

1. Clone the repository
2. Navigate to the example directory: `cd rivetkit/examples/drizzle`
3. Install dependencies: `pnpm install`
4. Start the development server: `pnpm run dev`
5. Open the Rivet Studio at <https://studio.rivet.gg/> to interact with the chat application

### Why make this change?

This change provides a complete, working example of Drizzle ORM integration with RivetKit, demonstrating how to:

- Define and migrate database schemas
- Implement actor-based state management
- Create actions for sending and retrieving messages
- Broadcast events to connected clients

The example now serves as a practical reference for developers looking to build real-time applications with persistent storage using RivetKit and Drizzle.