### PR TITLE
feat(examples): add sqlite example

### DIFF
--- a/examples/sqlite/README.md
+++ b/examples/sqlite/README.md
@@ -1,0 +1,31 @@
+# SQLite Integration for RivetKit
+
+Example project demonstrating SQLite integration with [RivetKit](https://rivetkit.org).
+
+[Learn More →](https://github.com/rivet-gg/rivetkit)
+
+[Discord](https://rivet.gg/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-gg/rivetkit/issues)
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js
+
+### Installation
+
+```sh
+git clone https://github.com/rivet-gg/rivetkit
+cd rivetkit/examples/sqlite
+pnpm install
+```
+
+### Development
+```sh
+pnpm run dev
+```
+Open your browser to https://studio.rivet.gg/ to see your RivetKit server.
+
+## License
+
+Apache 2.0

--- a/examples/sqlite/package.json
+++ b/examples/sqlite/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "example-sqlite",
+  "version": "0.9.9",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx --watch src/server.ts",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.9",
+    "tsx": "^3.12.7",
+    "typescript": "^5.5.2"
+  },
+  "dependencies": {
+    "@rivetkit/db": "workspace:*",
+    "@rivetkit/actor": "workspace:*"
+  },
+  "stableVersion": "0.8.0"
+}

--- a/examples/sqlite/src/registry.ts
+++ b/examples/sqlite/src/registry.ts
@@ -1,0 +1,43 @@
+import { actor, setup } from "@rivetkit/actor";
+import { db } from "@rivetkit/db";
+
+export const chat = actor({
+	onAuth: () => {},
+	db: db({
+		onMigrate: async (c) => {
+			await c
+				.prepare(`CREATE TABLE IF NOT EXISTS messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				sender TEXT NOT NULL,
+				text TEXT NOT NULL,
+				timestamp INTEGER NOT NULL
+			)`)
+				.run();
+		},
+	}),
+	actions: {
+		// Callable functions from clients: https://rivet.gg/docs/actors/actions
+		sendMessage: async (c, sender: string, text: string) => {
+			const message = { sender, text, timestamp: Date.now() };
+			// State changes are automatically persisted
+			await c.db
+				.prepare(
+					`INSERT INTO messages (sender, text, timestamp) VALUES (?, ?, ?)`,
+					[sender, text, message.timestamp],
+				)
+				.run();
+			// Send events to all connected clients: https://rivet.gg/docs/actors/events
+			c.broadcast("newMessage", message);
+			return message;
+		},
+
+		getHistory: (c) =>
+			c.db
+				.prepare(`SELECT * FROM messages ORDER BY timestamp DESC LIMIT 100`)
+				.all(),
+	},
+});
+
+export const registry = setup({
+	use: { chat },
+});

--- a/examples/sqlite/src/server.ts
+++ b/examples/sqlite/src/server.ts
@@ -1,0 +1,3 @@
+import { registry } from "./registry";
+
+registry.runServer();

--- a/examples/sqlite/tsconfig.json
+++ b/examples/sqlite/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "esnext",
+    /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["esnext"],
+    /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",
+    "allowArbitraryExtensions": true,
+
+    /* Specify what module code is generated. */
+    "module": "esnext",
+    /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",
+    /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],
+    /* Enable importing .json files */
+    "resolveJsonModule": true,
+
+    /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    "allowJs": true,
+    /* Enable error reporting in type-checked JavaScript files. */
+    "checkJs": false,
+
+    /* Disable emitting files from a compilation. */
+    "noEmit": true,
+
+    /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,
+    /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,
+    /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true,
+
+    /* Enable all strict type-checking options. */
+    "strict": true,
+
+    /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/sqlite/turbo.json
+++ b/examples/sqlite/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,25 @@ importers:
         specifier: ^5.7.3
         version: 5.8.3
 
+  examples/sqlite:
+    dependencies:
+      '@rivetkit/actor':
+        specifier: workspace:*
+        version: link:../../packages/actor
+      '@rivetkit/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.9
+        version: 22.15.32
+      tsx:
+        specifier: ^3.12.7
+        version: 3.14.0
+      typescript:
+        specifier: ^5.5.2
+        version: 5.8.3
+
   examples/starter:
     dependencies:
       '@rivetkit/actor':


### PR DESCRIPTION
Closes FRONT-764

### TL;DR

Added a new SQLite integration example for RivetKit.

### What changed?

Created a new example project demonstrating SQLite integration with RivetKit. The example includes:

- A simple chat application with message storage in SQLite
- Implementation of basic database operations (inserting and retrieving messages)
- Integration with RivetKit's actor system
- Complete project structure with TypeScript configuration

The example shows how to:

- Define a SQLite schema using Drizzle ORM
- Set up database migrations
- Create actor actions for sending and retrieving messages
- Broadcast events to connected clients

### How to test?

1. Clone the repository:

```
git clone https://github.com/rivet-gg/rivetkit
```

1. Navigate to the example directory:

```
cd rivetkit/examples/sqlite
```

1. Install dependencies:

```
pnpm install
```

1. Start the development server:

```
pnpm run dev
```

1. Open your browser to <https://studio.rivet.gg/> to see the RivetKit server in action.

### Why make this change?

This example provides developers with a practical demonstration of how to integrate SQLite with RivetKit for persistent data storage. It serves as a reference implementation for projects that need simple, file-based database functionality without requiring external database services.