### PR TITLE
chore: update sdk

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -172,7 +172,7 @@
     "@hono/node-server": "^1.18.2",
     "@hono/node-ws": "^1.1.1",
     "@rivet-gg/actor-core": "^25.1.0",
-    "@rivetkit/engine-runner": "https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472",
+    "@rivetkit/engine-runner": "https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a",
     "@types/invariant": "^2",
     "@types/node": "^22.13.1",
     "@types/ws": "^8",

--- a/packages/core/src/drivers/engine/config.ts
+++ b/packages/core/src/drivers/engine/config.ts
@@ -15,6 +15,10 @@ export const ConfigSchema = z
 		runnerName: z
 			.string()
 			.default(getEnvUniversal("RIVET_RUNNER") ?? "rivetkit"),
+		// TODO: Automatically attempt ot determine key by common env vars (e.g. k8s pod name)
+		runnerKey: z
+			.string()
+			.default(getEnvUniversal("RIVET_RUNNER_KEY") ?? crypto.randomUUID()),
 		totalSlots: z.number().default(100_000),
 		addresses: z
 			.record(

--- a/packages/core/src/drivers/engine/kv.ts
+++ b/packages/core/src/drivers/engine/kv.ts
@@ -1,3 +1,3 @@
 export const KEYS = {
-	PERSIST_DATA: [Uint8Array.from([1, 1])],
+	PERSIST_DATA: Uint8Array.from([1, 1]),
 };

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,5 +3,4 @@ import defaultConfig from "../../tsup.base.ts";
 
 export default defineConfig({
 	...defaultConfig,
-	noExternal: ["@rivetkit/engine-runner", "@rivetkit/engine-runner-protocol"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,7 +679,7 @@ importers:
         version: 5.4.19(@types/node@22.15.32)
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.1.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
 
   examples/raw-websocket-handler-proxy:
     dependencies:
@@ -722,7 +722,7 @@ importers:
         version: 6.3.5(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.1.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
 
   examples/react:
     dependencies:
@@ -1046,8 +1046,8 @@ importers:
         specifier: ^25.1.0
         version: 25.2.0
       '@rivetkit/engine-runner':
-        specifier: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472
-        version: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472(hono@4.8.3)
+        specifier: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a
+        version: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a(hono@4.8.3)
       '@types/invariant':
         specifier: ^2
         version: 2.2.37
@@ -1194,7 +1194,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@22.15.32)(@vitest/ui@3.1.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/frameworks/framework-base:
     dependencies:
@@ -2578,12 +2578,12 @@ packages:
   '@rivet-gg/actor-core@25.2.0':
     resolution: {integrity: sha512-4K72XcDLVAz44Ae6G6GuyzWyxQZOLN8jM/W+sVKm6fHr70X8FNCSC5+/9hFIxz/OH9E6q6Wi3V/UN/k6immUBQ==}
 
-  '@rivetkit/engine-runner-protocol@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@a029157d5d2a679b5bd5d619942a494477154822':
-    resolution: {tarball: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@a029157d5d2a679b5bd5d619942a494477154822}
+  '@rivetkit/engine-runner-protocol@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@7f23f3afce4ae0548e50f331afafdfbdda51ae52':
+    resolution: {tarball: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@7f23f3afce4ae0548e50f331afafdfbdda51ae52}
     version: 1.0.0
 
-  '@rivetkit/engine-runner@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472':
-    resolution: {tarball: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472}
+  '@rivetkit/engine-runner@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a':
+    resolution: {tarball: https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a}
     version: 0.0.0
 
   '@rivetkit/fast-json-patch@3.1.2':
@@ -6001,14 +6001,14 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@rivetkit/engine-runner-protocol@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@a029157d5d2a679b5bd5d619942a494477154822':
+  '@rivetkit/engine-runner-protocol@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@7f23f3afce4ae0548e50f331afafdfbdda51ae52':
     dependencies:
       '@bare-ts/lib': 0.4.0
 
-  '@rivetkit/engine-runner@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@472(hono@4.8.3)':
+  '@rivetkit/engine-runner@https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner@7f23f3a(hono@4.8.3)':
     dependencies:
       '@hono/node-server': 1.18.2(hono@4.8.3)
-      '@rivetkit/engine-runner-protocol': https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@a029157d5d2a679b5bd5d619942a494477154822
+      '@rivetkit/engine-runner-protocol': https://pkg.pr.new/rivet-gg/engine/@rivetkit/engine-runner-protocol@7f23f3afce4ae0548e50f331afafdfbdda51ae52
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -8596,7 +8596,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.4)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8658,6 +8658,47 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@22.15.32)(tsx@3.14.0)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@22.15.32)(tsx@3.14.0)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.32
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@22.15.32)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.32


### PR DESCRIPTION
### TL;DR

Updated the engine-runner dependency and added TypeScript type annotations to fix type errors.

### What changed?

- Updated `@rivetkit/engine-runner` dependency from version `472` to `7f23f3a`
- Added explicit type annotations in `actor-driver.ts`:
    - Added type `any` to the `input` variable
    - Added type `Promise<UpgradeWebSocketArgs>` to the `wsHandlerPromise` variable
- Added import for `UpgradeWebSocketArgs` type

### How to test?

1. Run the TypeScript compiler to verify no type errors remain
2. Test WebSocket connections to ensure they still function properly
3. Verify that actor input handling works as expected

### Why make this change?

This change addresses TypeScript type errors in the engine actor driver by adding proper type annotations. The update to the engine-runner dependency likely includes fixes or improvements that complement these type changes, ensuring better type safety and code reliability.