### PR TITLE
fix(inspector): allow connection to inspector when using engine driver

### DIFF
--- a/packages/cloudflare-workers/src/actor-handler-do.ts
+++ b/packages/cloudflare-workers/src/actor-handler-do.ts
@@ -3,7 +3,7 @@ import type { ExecutionContext } from "hono";
 import invariant from "invariant";
 import type { ActorKey, ActorRouter, Registry, RunConfig } from "rivetkit";
 import { createActorRouter, createClientWithDriver } from "rivetkit";
-import type { ActorDriver } from "rivetkit/driver-helpers";
+import type { ActorDriver, ManagerDriver } from "rivetkit/driver-helpers";
 import { serializeEmptyPersistData } from "rivetkit/driver-helpers";
 import { promiseWithResolvers } from "rivetkit/utils";
 import {
@@ -121,6 +121,8 @@ export function createActorDurableObject(
 				runConfig,
 			);
 
+			configureInspectorAccessToken(registry.config, managerDriver);
+
 			// Create inline client
 			const inlineClient = createClientWithDriver(managerDriver);
 
@@ -186,4 +188,10 @@ export function createActorDurableObject(
 			await actor._onAlarm();
 		}
 	};
+}
+function configureInspectorAccessToken(
+	config: any,
+	managerDriver: ManagerDriver,
+) {
+	throw new Error("Function not implemented.");
 }

--- a/packages/rivetkit/src/actor/router.ts
+++ b/packages/rivetkit/src/actor/router.ts
@@ -34,7 +34,7 @@ import {
 	type ActorInspectorRouterEnv,
 	createActorInspectorRouter,
 } from "@/inspector/actor";
-import { secureInspector } from "@/inspector/utils";
+import { isInspectorEnabled, secureInspector } from "@/inspector/utils";
 import type { RunConfig } from "@/registry/run-config";
 import type { ActorDriver } from "./driver";
 import { InternalError } from "./errors";
@@ -206,7 +206,7 @@ export function createActorRouter(
 		}
 	});
 
-	if (runConfig.inspector.enabled) {
+	if (isInspectorEnabled(runConfig, "actor")) {
 		router.route(
 			"/inspect",
 			new Hono<ActorInspectorRouterEnv & { Bindings: ActorRouterBindings }>()

--- a/packages/rivetkit/src/driver-test-suite/mod.ts
+++ b/packages/rivetkit/src/driver-test-suite/mod.ts
@@ -4,6 +4,7 @@ import { bundleRequire } from "bundle-require";
 import invariant from "invariant";
 import { describe } from "vitest";
 import type { Transport } from "@/client/mod";
+import { configureInspectorAccessToken } from "@/inspector/utils";
 import { createManagerRouter } from "@/manager/router";
 import type { DriverConfig, Registry, RunConfig } from "@/mod";
 import { RunConfigSchema } from "@/registry/run-config";
@@ -193,6 +194,7 @@ export async function createTestRuntime(
 
 		// Create router
 		const managerDriver = driver.manager(registry.config, config);
+		configureInspectorAccessToken(config, managerDriver);
 		const { router } = createManagerRouter(
 			registry.config,
 			config,

--- a/packages/rivetkit/src/drivers/file-system/manager.ts
+++ b/packages/rivetkit/src/drivers/file-system/manager.ts
@@ -57,10 +57,6 @@ export class FileSystemManagerDriver implements ManagerDriver {
 		this.#driverConfig = driverConfig;
 
 		if (runConfig.inspector.enabled) {
-			if (!this.#runConfig.inspector.token()) {
-				this.#runConfig.inspector.token = () =>
-					this.#state.getOrCreateInspectorAccessToken();
-			}
 			const startedAt = new Date().toISOString();
 			function transformActor(actorState: schema.ActorState): Actor {
 				return {
@@ -316,5 +312,9 @@ export class FileSystemManagerDriver implements ManagerDriver {
 			instances: this.#state.actorCountOnStartup,
 			data: this.#state.storagePath,
 		};
+	}
+
+	getOrCreateInspectorAccessToken() {
+		return this.#state.getOrCreateInspectorAccessToken();
 	}
 }

--- a/packages/rivetkit/src/inspector/config.ts
+++ b/packages/rivetkit/src/inspector/config.ts
@@ -56,7 +56,16 @@ const defaultCors: CorsOptions = {
 
 export const InspectorConfigSchema = z
 	.object({
-		enabled: z.boolean().optional().default(defaultEnabled),
+		enabled: z
+			.boolean()
+			.or(
+				z.object({
+					actor: z.boolean().optional().default(true),
+					manager: z.boolean().optional().default(true),
+				}),
+			)
+			.optional()
+			.default(defaultEnabled),
 		/** CORS configuration for the router. Uses Hono's CORS middleware options. */
 		cors: z
 			.custom<CorsOptions>()

--- a/packages/rivetkit/src/inspector/mod.ts
+++ b/packages/rivetkit/src/inspector/mod.ts
@@ -1,2 +1,3 @@
 export * from "./protocol/common";
 export * from "./protocol/mod";
+export * from "./utils";

--- a/packages/rivetkit/src/manager/driver.ts
+++ b/packages/rivetkit/src/manager/driver.ts
@@ -45,6 +45,13 @@ export interface ManagerDriver {
 	 * @internal
 	 */
 	readonly inspector?: ManagerInspector;
+
+	/**
+	 * Get or create the inspector access token.
+	 * @internal
+	 * @returns creates or returns existing inspector access token
+	 */
+	getOrCreateInspectorAccessToken: () => string;
 }
 
 export interface ManagerDisplayInformation {

--- a/packages/rivetkit/src/manager/router.ts
+++ b/packages/rivetkit/src/manager/router.ts
@@ -27,7 +27,7 @@ import type {
 	TestInlineDriverCallResponse,
 } from "@/driver-test-suite/test-inline-client-driver";
 import { createManagerInspectorRouter } from "@/inspector/manager";
-import { secureInspector } from "@/inspector/utils";
+import { isInspectorEnabled, secureInspector } from "@/inspector/utils";
 import {
 	type ActorsCreateRequest,
 	ActorsCreateRequestSchema,
@@ -436,7 +436,7 @@ export function createManagerRouter(
 		router as unknown as Hono,
 	);
 
-	if (runConfig.inspector?.enabled) {
+	if (isInspectorEnabled(runConfig, "manager")) {
 		if (!managerDriver.inspector) {
 			throw new Unsupported("inspector");
 		}

--- a/packages/rivetkit/src/remote-manager-driver/mod.ts
+++ b/packages/rivetkit/src/remote-manager-driver/mod.ts
@@ -2,6 +2,7 @@ import * as cbor from "cbor-x";
 import type { Context as HonoContext } from "hono";
 import invariant from "invariant";
 import { deserializeActorKey, serializeActorKey } from "@/actor/keys";
+import { generateRandomString } from "@/actor/utils";
 import type { ClientConfig } from "@/client/client";
 import { noopNext } from "@/common/utils";
 import type {
@@ -251,5 +252,9 @@ export class RemoteManagerDriver implements ManagerDriver {
 
 	displayInformation(): ManagerDisplayInformation {
 		return { name: "Remote", properties: {} };
+	}
+
+	getOrCreateInspectorAccessToken() {
+		return generateRandomString();
 	}
 }

--- a/packages/rivetkit/src/test/mod.ts
+++ b/packages/rivetkit/src/test/mod.ts
@@ -5,7 +5,10 @@ import { type TestContext, vi } from "vitest";
 import { type Client, createClient } from "@/client/mod";
 import { chooseDefaultDriver } from "@/drivers/default";
 import { createFileSystemOrMemoryDriver } from "@/drivers/file-system/mod";
-import { getInspectorUrl } from "@/inspector/utils";
+import {
+	configureInspectorAccessToken,
+	getInspectorUrl,
+} from "@/inspector/utils";
 import { createManagerRouter } from "@/manager/router";
 import type { Registry } from "@/registry/mod";
 import { RunConfigSchema } from "@/registry/run-config";
@@ -27,6 +30,7 @@ function serve(registry: Registry<any>, inputConfig?: InputConfig): ServerType {
 	const runConfig = RunConfigSchema.parse(inputConfig);
 	const driver = inputConfig.driver ?? createFileSystemOrMemoryDriver(false);
 	const managerDriver = driver.manager(registry.config, config);
+	configureInspectorAccessToken(config, managerDriver);
 	const { router } = createManagerRouter(
 		registry.config,
 		runConfig,


### PR DESCRIPTION
### TL;DR

Added granular control over inspector enablement for actors and managers, and improved inspector access token configuration.

### What changed?

- Enhanced the inspector configuration to allow enabling/disabling the inspector separately for actors and managers
- Added a `configureInspectorAccessToken` utility function to centralize token management
- Modified the `isInspectorEnabled` function to check if the inspector is enabled for a specific context (actor or manager)
- Updated the `ManagerDriver` interface to include a `getOrCreateInspectorAccessToken` method
- Implemented the new method in various driver implementations
- Added skeleton implementation for `configureInspectorAccessToken` in Cloudflare Workers
- Updated router implementations to use the new context-specific inspector enablement checks
- Set default inspector configurations for engine and Cloudflare Workers drivers

### How to test?

1. Configure a registry with different inspector settings for actors and managers:
   ```typescript
   const registry = new Registry({
     inspector: {
       enabled: {
         actor: true,
         manager: false
       }
     }
   });
   ```

2. Verify that the inspector endpoints are accessible for actors but not for managers
3. Test that inspector access tokens are properly generated and configured

### Why make this change?

This change provides more flexibility in how the inspector is configured, allowing users to enable inspection capabilities selectively for actors or managers based on their needs. It also centralizes and standardizes the inspector access token management, making the codebase more maintainable and consistent across different driver implementations.