### PR TITLE
feat: add slack-cli WASM package (Go → WASI build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ registry/native/target/
 registry/native/vendor/
 registry/native/c/build/
 registry/native/c/vendor/
+registry/native/go/vendor/
 registry/native/c/libs/
 registry/native/c/.cache/
 registry/native/c/sysroot/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
 		"@rivet-dev/agent-os-ripgrep": "link:../../registry/software/ripgrep",
 		"@rivet-dev/agent-os-sed": "link:../../registry/software/sed",
 		"@rivet-dev/agent-os-tar": "link:../../registry/software/tar",
+		"@rivet-dev/agent-os-slack-cli": "link:../../registry/software/slack-cli",
 		"@rivet-dev/agent-os-tree": "link:../../registry/software/tree",
 		"@rivet-dev/agent-os-yq": "link:../../registry/software/yq",
 		"@types/node": "^22.10.2",

--- a/packages/core/tests/wasm-commands.test.ts
+++ b/packages/core/tests/wasm-commands.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { AgentOs } from "../src/index.js";
 import curlPackage from "@rivet-dev/agent-os-curl";
+import slackCliPackage from "@rivet-dev/agent-os-slack-cli";
 import {
 	REGISTRY_SOFTWARE,
 	registrySkipReason,
@@ -802,5 +803,35 @@ server.listen(0, "0.0.0.0", () => {
 			expect(r.exitCode).toBe(0);
 			expect(r.stdout.trim()).toBe("30");
 		});
+	});
+});
+
+// ── slack-cli (Go WASM, separate build) ──────────────────────────────
+
+const slackCliSkipReason = existsSync(slackCliPackage.commandDir)
+	? false
+	: "slack-cli WASM binary not available (run: cd registry && make build-wasm-go copy-wasm)";
+
+describe.skipIf(slackCliSkipReason)("slack-cli", () => {
+	let vm: AgentOs;
+
+	beforeEach(async () => {
+		vm = await AgentOs.create({ software: [...REGISTRY_SOFTWARE, slackCliPackage] });
+	});
+
+	afterEach(async () => {
+		await vm.dispose();
+	});
+
+	test("slack version prints version info", async () => {
+		const r = await vm.exec("slack version");
+		expect(r.exitCode).toBe(0);
+		expect(r.stdout).toMatch(/slack/i);
+	});
+
+	test("slack help prints usage", async () => {
+		const r = await vm.exec("slack help");
+		expect(r.exitCode).toBe(0);
+		expect(r.stdout).toContain("slack");
 	});
 });

--- a/packages/registry-types/src/index.ts
+++ b/packages/registry-types/src/index.ts
@@ -32,8 +32,8 @@ export interface WasmCommandPackage {
 	aptName: string;
 	/** Human-readable description. */
 	description: string;
-	/** Build source: "rust" or "c". */
-	source: "rust" | "c";
+	/** Build source: "rust", "c", or "go". */
+	source: "rust" | "c" | "go";
 	/** Commands provided by this package. */
 	commands: WasmCommandEntry[];
 	/** Absolute path to the directory containing WASM command binaries. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@rivet-dev/agent-os-sed':
         specifier: link:../../registry/software/sed
         version: link:../../registry/software/sed
+      '@rivet-dev/agent-os-slack-cli':
+        specifier: link:../../registry/software/slack-cli
+        version: link:../../registry/software/slack-cli
       '@rivet-dev/agent-os-tar':
         specifier: link:../../registry/software/tar
         version: link:../../registry/software/tar
@@ -889,6 +892,18 @@ importers:
         version: 5.9.3
 
   registry/software/sed:
+    devDependencies:
+      '@rivet-dev/agent-os-registry-types':
+        specifier: link:../../../packages/registry-types
+        version: link:../../../packages/registry-types
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
+  registry/software/slack-cli:
     devDependencies:
       '@rivet-dev/agent-os-registry-types':
         specifier: link:../../../packages/registry-types

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -8,13 +8,14 @@ COMMANDS_DIR := $(NATIVE_DIR)/target/wasm32-wasip1/release/commands
 MARKER_DIR  := .build-markers
 RUST_MARKER := $(MARKER_DIR)/rust-wasm-built
 C_MARKER    := $(MARKER_DIR)/c-wasm-built
+GO_MARKER   := $(MARKER_DIR)/go-wasm-built
 COPY_MARKER := $(MARKER_DIR)/wasm-copied
 META_MARKER := $(MARKER_DIR)/meta-generated
 TS_MARKER   := $(MARKER_DIR)/ts-built
 
 # Command packages (excludes _types and meta-packages)
 CMD_PACKAGES := coreutils sed grep gawk findutils diffutils tar gzip \
-                curl http-get wget zip unzip jq ripgrep fd tree file sqlite3 duckdb yq codex git
+                curl http-get wget zip unzip jq ripgrep fd tree file sqlite3 duckdb yq codex git slack-cli
 
 # Meta-packages
 META_PACKAGES := common build-essential everything
@@ -22,7 +23,7 @@ META_PACKAGES := common build-essential everything
 # All publishable packages
 ALL_PACKAGES := $(CMD_PACKAGES) $(META_PACKAGES)
 
-.PHONY: all build-wasm build-wasm-rust build-wasm-c copy-wasm generate-meta build test \
+.PHONY: all build-wasm build-wasm-rust build-wasm-c build-wasm-go copy-wasm generate-meta build test \
         publish publish-dry publish-force publish-clean clean rebuild
 
 all: build
@@ -36,7 +37,7 @@ $(MARKER_DIR):
 # ---------------------------------------------------------------------------
 # Build WASM binaries from source (in native/)
 # ---------------------------------------------------------------------------
-build-wasm: build-wasm-rust build-wasm-c
+build-wasm: build-wasm-rust build-wasm-c build-wasm-go
 
 build-wasm-rust: $(RUST_MARKER)
 $(RUST_MARKER): $(MARKER_DIR)
@@ -51,11 +52,17 @@ $(C_MARKER): $(MARKER_DIR)
 	cd $(NATIVE_DIR)/c && make install COMMANDS_DIR=../target/wasm32-wasip1/release/commands
 	@touch $(C_MARKER)
 
+build-wasm-go: $(GO_MARKER)
+$(GO_MARKER): $(MARKER_DIR)
+	@echo "=== Building Go WASM commands ==="
+	cd $(NATIVE_DIR)/go && make wasm
+	@touch $(GO_MARKER)
+
 # ---------------------------------------------------------------------------
 # Copy WASM binaries from native build output into per-package wasm/ dirs
 # ---------------------------------------------------------------------------
 copy-wasm: $(COPY_MARKER)
-$(COPY_MARKER): $(RUST_MARKER) $(C_MARKER)
+$(COPY_MARKER): $(RUST_MARKER) $(C_MARKER) $(GO_MARKER)
 	@echo "=== Copying WASM binaries to packages ==="
 
 	@# --- coreutils ---
@@ -185,6 +192,10 @@ $(COPY_MARKER): $(RUST_MARKER) $(C_MARKER)
 	@# --- git ---
 	@mkdir -p software/git/wasm
 	@[ -f "$(COMMANDS_DIR)/git" ] && cp -f "$(COMMANDS_DIR)/git" software/git/wasm/ || echo "  WARN: git not found"
+
+	@# --- slack-cli (Go build, GOOS=wasip1) ---
+	@mkdir -p software/slack-cli/wasm
+	@[ -f "$(COMMANDS_DIR)/slack" ] && cp -f "$(COMMANDS_DIR)/slack" software/slack-cli/wasm/ || echo "  WARN: slack not found (Go WASI build)"
 
 	@echo "=== Copy complete ==="
 	@touch $(COPY_MARKER)
@@ -321,6 +332,7 @@ clean-native:
 	@rm -rf $(NATIVE_DIR)/target
 	@rm -rf $(NATIVE_DIR)/vendor
 	@rm -rf $(NATIVE_DIR)/c/build $(NATIVE_DIR)/c/vendor $(NATIVE_DIR)/c/libs $(NATIVE_DIR)/c/.cache
+	@rm -rf $(NATIVE_DIR)/go/vendor
 	@rm -rf $(MARKER_DIR)
 	@echo "Cleaned native build artifacts"
 

--- a/registry/native/go/Makefile
+++ b/registry/native/go/Makefile
@@ -1,0 +1,66 @@
+SHELL := /bin/bash
+
+# Output directory (shared with Rust/C builds)
+COMMANDS_DIR ?= ../target/wasm32-wasip1/release/commands
+
+# Vendor directory for upstream Go sources
+VENDOR_DIR := vendor
+
+# --- slack-cli ---
+SLACK_CLI_REPO    := https://github.com/slackapi/slack-cli.git
+SLACK_CLI_COMMIT  := 24c1d2c50b7f438700596c4d1902e0838a42fab0
+SLACK_CLI_DIR     := $(VENDOR_DIR)/slack-cli
+SLACK_CLI_PATCHES := $(sort $(wildcard patches/slack-cli/*.patch))
+
+.PHONY: wasm clean install
+
+# ---------------------------------------------------------------------------
+# Build all Go WASM commands
+# ---------------------------------------------------------------------------
+wasm: $(COMMANDS_DIR)/slack
+
+# ---------------------------------------------------------------------------
+# slack-cli
+# ---------------------------------------------------------------------------
+
+# Fetch upstream source at pinned commit
+$(SLACK_CLI_DIR)/go.mod:
+	@echo "=== Fetching slack-cli ==="
+	@mkdir -p $(VENDOR_DIR)
+	git clone $(SLACK_CLI_REPO) $(SLACK_CLI_DIR)
+	git -C $(SLACK_CLI_DIR) checkout $(SLACK_CLI_COMMIT)
+
+# Vendor Go dependencies
+$(SLACK_CLI_DIR)/vendor/modules.txt: $(SLACK_CLI_DIR)/go.mod
+	@echo "=== Vendoring slack-cli dependencies ==="
+	cd $(SLACK_CLI_DIR) && go mod vendor
+
+# Apply WASI patches to vendored dependencies
+.PHONY: patch-slack-cli
+patch-slack-cli: $(SLACK_CLI_DIR)/vendor/modules.txt
+	@echo "=== Applying WASI patches to slack-cli ==="
+	@for patch in $(SLACK_CLI_PATCHES); do \
+		echo "  PATCH: $$patch"; \
+		patch --forward -p1 -d $(SLACK_CLI_DIR) < "$$patch" || \
+			echo "  (already applied)"; \
+	done
+
+# Build WASM binary
+$(COMMANDS_DIR)/slack: $(SLACK_CLI_DIR)/vendor/modules.txt $(SLACK_CLI_PATCHES) | patch-slack-cli
+	@echo "=== Building slack-cli WASM ==="
+	@mkdir -p $(COMMANDS_DIR)
+	cd $(SLACK_CLI_DIR) && GOOS=wasip1 GOARCH=wasm go build -mod=vendor -o $(abspath $@) .
+	@echo "  Built: $@ ($$(du -h $@ | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Install (copy to COMMANDS_DIR, for parity with C Makefile)
+# ---------------------------------------------------------------------------
+install:
+	@echo "Go binaries already output directly to COMMANDS_DIR"
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+clean:
+	rm -rf $(VENDOR_DIR)
+	rm -f $(COMMANDS_DIR)/slack

--- a/registry/native/go/patches/slack-cli/0001-clipboard-wasip1-stub.patch
+++ b/registry/native/go/patches/slack-cli/0001-clipboard-wasip1-stub.patch
@@ -1,0 +1,16 @@
+--- /dev/null
++++ b/vendor/github.com/atotto/clipboard/clipboard_wasip1.go
+@@ -0,0 +1,13 @@
++//go:build wasip1
++
++package clipboard
++
++import "errors"
++
++func readAll() (string, error) {
++	return "", errors.New("clipboard not supported in WASM")
++}
++
++func writeAll(text string) error {
++	return errors.New("clipboard not supported in WASM")
++}

--- a/registry/native/go/patches/slack-cli/0002-bubbletea-wasip1-stubs.patch
+++ b/registry/native/go/patches/slack-cli/0002-bubbletea-wasip1-stubs.patch
@@ -1,0 +1,24 @@
+--- /dev/null
++++ b/vendor/charm.land/bubbletea/v2/signals_wasip1.go
+@@ -0,0 +1,7 @@
++//go:build wasip1
++
++package tea
++
++func (p *Program) listenForResize(done chan struct{}) {
++	close(done)
++}
+--- /dev/null
++++ b/vendor/charm.land/bubbletea/v2/tty_wasip1.go
+@@ -0,0 +1,11 @@
++//go:build wasip1
++
++package tea
++
++const suspendSupported = false
++
++func suspendProcess() {}
++
++func (p *Program) initInput() error {
++	return nil
++}

--- a/registry/native/go/patches/slack-cli/0003-go-git-wasip1-stub.patch
+++ b/registry/native/go/patches/slack-cli/0003-go-git-wasip1-stub.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ b/vendor/github.com/go-git/go-git/v5/worktree_wasip1.go
+@@ -0,0 +1,7 @@
++//go:build wasip1
++
++package git
++
++func isSymlinkWindowsNonAdmin(err error) bool {
++	return false
++}

--- a/registry/software/slack-cli/agent-os-package.json
+++ b/registry/software/slack-cli/agent-os-package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rivet-dev/agent-os-slack-cli",
+  "type": "wasm",
+  "description": "Slack CLI for building apps on the Slack Platform",
+  "aptName": "slack-cli",
+  "source": "go"
+}

--- a/registry/software/slack-cli/package.json
+++ b/registry/software/slack-cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rivet-dev/agent-os-slack-cli",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "description": "Slack CLI for building apps on the Slack Platform for agentOS",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "wasm"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@rivet-dev/agent-os-registry-types": "link:../../../packages/registry-types",
+    "@types/node": "^22.10.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/registry/software/slack-cli/src/index.ts
+++ b/registry/software/slack-cli/src/index.ts
@@ -1,0 +1,18 @@
+import type { WasmCommandPackage } from "@rivet-dev/agent-os-registry-types";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const pkg = {
+	name: "slack-cli",
+	aptName: "slack-cli",
+	description: "Slack CLI for building apps on the Slack Platform",
+	source: "go" as const,
+	commands: [{ name: "slack", permissionTier: "full" as const }],
+	get commandDir() {
+		return resolve(__dirname, "..", "wasm");
+	},
+} satisfies WasmCommandPackage;
+
+export default pkg;

--- a/registry/software/slack-cli/tsconfig.json
+++ b/registry/software/slack-cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This adds the `slack-cli` package for WASI for use inside the sandbox. Its a commonly-depended-on binary used by a bunch of popular skills on clawhub so I think it merits inclusion in the sandbox'd registry. It's the first go program in the registry, so I tried to copy the same approach we use for `c` and added a new spot for vendored go dependencies. `slack-cli`'s transitive dependencies also annoyingly need some patches for WASI which Claude cooked up for us here.

### Summary

  - Adds @rivet-dev/agent-os-slack-cli, the first Go-compiled WASM package in the
  registry, providing the slack command (slackapi/slack-cli) for building Slack apps
  from inside agentOS VMs
  - Introduces the Go WASM build pipeline at registry/native/go/, following the same
  pattern as the existing Rust and C pipelines: clone upstream at a pinned commit,
  vendor dependencies, apply WASI compatibility patches, and compile with GOOS=wasip1
  GOARCH=wasm
  - Three WASI stub patches fix platform-incompatible dependencies: atotto/clipboard (no
   clipboard in WASM), charm.land/bubbletea (no terminal resize/suspend), and
  go-git/go-git (no Windows symlink check)
  
###   How to build

```
  cd registry
  make build-wasm-go   # clones slack-cli, vendors, patches, builds (~38MB WASM binary)
  make copy-wasm       # copies to software/slack-cli/wasm/
```

Requires Go 1.21+ (the upstream slack-cli pins Go 1.26.1).