### PR TITLE
docs: fix import path to `agent-os-core` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ You don't have to choose: agentOS works with sandboxes through the [sandbox exte
 ## Quick start
 
 ```bash
-npm install @rivet-dev/agent-os @rivet-dev/agent-os-common @rivet-dev/agent-os-pi
+npm install @rivet-dev/agent-os-core @rivet-dev/agent-os-common @rivet-dev/agent-os-pi
 ```
 
 ```ts
-import { AgentOs } from "@rivet-dev/agent-os";
+import { AgentOs } from "@rivet-dev/agent-os-core";
 import common from "@rivet-dev/agent-os-common";
 import pi from "@rivet-dev/agent-os-pi";
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @rivet-dev/agent-os
+# @rivet-dev/agent-os-core
 
 A high-level SDK for running coding agents in isolated VMs. agentOS manages the full lifecycle of virtual machines — from filesystem setup and process management to launching AI agents via the Agent Communication Protocol (ACP).
 
@@ -19,13 +19,13 @@ Agents run inside sandboxed VMs with their own filesystem, process table, and ne
 ## Quick Start
 
 ```bash
-npm install @rivet-dev/agent-os
+npm install @rivet-dev/agent-os-core
 # Install an agent adapter + its underlying agent
 npm install pi-acp @mariozechner/pi-coding-agent
 ```
 
 ```typescript
-import { AgentOs } from "@rivet-dev/agent-os";
+import { AgentOs } from "@rivet-dev/agent-os-core";
 
 // 1. Create a VM
 const vm = await AgentOs.create();

--- a/registry/file-system/google-drive/README.md
+++ b/registry/file-system/google-drive/README.md
@@ -10,7 +10,7 @@ plugin.
 ## Usage
 
 ```ts
-import { AgentOs } from "@rivet-dev/agent-os";
+import { AgentOs } from "@rivet-dev/agent-os-core";
 import { createGoogleDriveBackend } from "@rivet-dev/agent-os-google-drive";
 
 const vm = await AgentOs.create({


### PR DESCRIPTION
The core package is `@rivet-dev/agent-os-core` (as reflected in `packages/core/package.json`), but several documentation files referenced the name `@rivet-dev/agent-os`. This causes confusion for new users.

### Not changed

`CLAUDE_AGENT_SDK_CLIENT_APP: "@rivet-dev/agent-os"` in `packages/core/src/agents.ts` and `registry/agent/claude/src/index.ts` was left as-is. This is a client identifier string sent to the Claude SDK, not a package import path.
