### PR TITLE
test: regression guards for already-fixed VM behaviors

### DIFF
--- a/crates/agent-os-sidecar/tests/acp_request_timeout.rs
+++ b/crates/agent-os-sidecar/tests/acp_request_timeout.rs
@@ -1,0 +1,72 @@
+//! Regression test: the ACP request timeout must not be too short (was a flat 120s).
+//!
+//! The original bug was a flat 120s ACP request timeout on the JS AcpClient that
+//! long, multi-tool agent turns (`session/prompt`) routinely exceeded, causing the
+//! turn to be aborted mid-flight. The fix bumped the `session/prompt` timeout to
+//! 600s (600000ms). That timeout logic now lives in Rust, in the per-method
+//! selector `request_timeout(method)` in `src/acp_extension.rs`.
+//!
+//! `request_timeout` is a private helper, so this test textually inlines the real
+//! `acp_extension` source via `include!`. That makes the assertions below siblings of
+//! the actual shipped `request_timeout`, so they exercise the production value (not a
+//! copy). If a future refactor reverts `session/prompt` back to the old 120s default,
+//! this build fails.
+//!
+//! NOTE: a separate test file is used (rather than editing the inline `#[cfg(test)]`
+//! module or the existing `tests/acp_extension.rs`) to keep this regression guard
+//! standalone and to avoid touching shared test files or production source.
+
+// Pull the real production source in textually so we can call the private
+// `request_timeout` helper as a sibling. `dead_code`/`unused` are silenced because we
+// only exercise one helper out of the full module.
+#[allow(dead_code, unused_imports, unused_variables, clippy::all)]
+mod under_test {
+    include!("../src/acp_extension.rs");
+    // `Duration` is already imported by the included source above.
+
+    /// `session/prompt` must use the patched 600s (600000ms) timeout, not the old 120s
+    /// flat timeout that truncated long multi-tool agent turns.
+    #[test]
+    fn session_prompt_timeout_is_600s_not_120s() {
+        let prompt_timeout = request_timeout("session/prompt");
+
+        // Exactly the patched value.
+        assert_eq!(
+            prompt_timeout,
+            Duration::from_secs(600),
+            "session/prompt timeout must be 600s"
+        );
+        assert_eq!(
+            u64::try_from(prompt_timeout.as_millis()).unwrap(),
+            600_000,
+            "session/prompt timeout must be 600000ms"
+        );
+
+        // And specifically NOT the regressed 120s flat timeout.
+        assert_ne!(
+            prompt_timeout,
+            Duration::from_secs(120),
+            "session/prompt must not regress to the old flat 120s ACP request timeout"
+        );
+    }
+
+    /// The long-running `session/prompt` turn must get a strictly longer budget than the
+    /// short control-method default, so a future refactor that collapses prompt back
+    /// onto the default fails this assertion.
+    #[test]
+    fn session_prompt_exceeds_default_control_timeout() {
+        let prompt_timeout = request_timeout("session/prompt");
+        // An arbitrary non-overridden control method falls back to the default branch.
+        let default_timeout = request_timeout("session/foo");
+
+        assert_eq!(
+            default_timeout,
+            Duration::from_secs(120),
+            "default (non-prompt) control-method timeout is expected to be 120s"
+        );
+        assert!(
+            prompt_timeout > default_timeout,
+            "session/prompt ({prompt_timeout:?}) must exceed the default control timeout ({default_timeout:?})"
+        );
+    }
+}

--- a/packages/core/tests/custom-vfs-mount-hook.test.ts
+++ b/packages/core/tests/custom-vfs-mount-hook.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression guard: a supported hook must exist to inject custom VFS mounts on VM creation.
+ *
+ * Original bug: there was no supported hook to inject a custom VFS mount at VM
+ * creation, forcing callers to monkeypatch `ensureVm`/`createVm` to add a
+ * host-synced session VFS (e.g. `/home/user/.pi/agent/sessions`).
+ *
+ * Fix: `AgentOs.create({ mounts: [...] })` is a documented public option that
+ * accepts `MountConfig[]`. A host-synced directory is injected via the public
+ * `createHostDirBackend(...)` descriptor, mounted at an arbitrary path -- no
+ * patching of any internal VM-creation method required.
+ *
+ * This test reproduces the exact original use case end-to-end:
+ *   1. A host directory with a pre-existing marker file is mounted at the
+ *      Pi session path through the public `mounts` option.
+ *   2. The host content is visible from inside the VM (proves injection worked).
+ *   3. Writes round-trip back to the host directory when `readOnly: false`.
+ *   4. Writes are rejected (EROFS) when the mount is read-only.
+ *   5. The public API surface (`mounts` option + `createHostDirBackend` export)
+ *      exists, guarding against regression back to the patch-only state.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AgentOs, createHostDirBackend } from "../src/index.js";
+
+const SESSION_MOUNT_PATH = "/home/user/.pi/agent/sessions";
+
+describe("custom VFS mount injection hook on VM creation", () => {
+	let vm: AgentOs | undefined;
+	let hostDir: string;
+
+	beforeEach(() => {
+		hostDir = fs.mkdtempSync(path.join(os.tmpdir(), "custom-vfs-mount-"));
+		// Pre-seed a marker file on the host, mimicking an existing
+		// host-synced Pi sessions directory.
+		fs.writeFileSync(
+			path.join(hostDir, "marker.json"),
+			JSON.stringify({ origin: "host", id: "custom-vfs-mount" }),
+		);
+	});
+
+	afterEach(async () => {
+		if (vm) {
+			await vm.dispose();
+			vm = undefined;
+		}
+		fs.rmSync(hostDir, { recursive: true, force: true });
+	});
+
+	test("public API exposes the mount-injection hook", () => {
+		// The supported hook is the `mounts` create-option plus the exported
+		// host-dir descriptor helper. If either disappears, callers are forced
+		// back to monkeypatching ensureVm/createVm (the original bug).
+		expect(typeof createHostDirBackend).toBe("function");
+		const descriptor = createHostDirBackend({ hostPath: hostDir });
+		expect(descriptor.id).toBe("host_dir");
+		expect(descriptor.config.hostPath).toBe(hostDir);
+	});
+
+	test("host-synced mount injected at VM creation exposes existing host files", async () => {
+		vm = await AgentOs.create({
+			mounts: [
+				{
+					path: SESSION_MOUNT_PATH,
+					plugin: createHostDirBackend({ hostPath: hostDir }),
+				},
+			],
+		});
+
+		const raw = await vm.readFile(`${SESSION_MOUNT_PATH}/marker.json`);
+		const decoded = JSON.parse(new TextDecoder().decode(raw));
+		expect(decoded).toEqual({ origin: "host", id: "custom-vfs-mount" });
+	});
+
+	test("writes through a writable injected mount round-trip back to the host", async () => {
+		vm = await AgentOs.create({
+			mounts: [
+				{
+					path: SESSION_MOUNT_PATH,
+					plugin: createHostDirBackend({
+						hostPath: hostDir,
+						readOnly: false,
+					}),
+				},
+			],
+		});
+
+		await vm.writeFile(
+			`${SESSION_MOUNT_PATH}/session-123.json`,
+			JSON.stringify({ from: "vm" }),
+		);
+
+		// Host-sync write-through: the file must appear on the real host path.
+		const onHost = fs.readFileSync(
+			path.join(hostDir, "session-123.json"),
+			"utf-8",
+		);
+		expect(JSON.parse(onHost)).toEqual({ from: "vm" });
+	});
+
+	test("read-only injected mount rejects writes with EROFS", async () => {
+		vm = await AgentOs.create({
+			mounts: [
+				{
+					path: SESSION_MOUNT_PATH,
+					plugin: createHostDirBackend({
+						hostPath: hostDir,
+						readOnly: true,
+					}),
+				},
+			],
+		});
+
+		await expect(
+			vm.writeFile(`${SESSION_MOUNT_PATH}/should-fail.json`, "{}"),
+		).rejects.toThrow("EROFS");
+	});
+});

--- a/packages/core/tests/home-user-base-image.test.ts
+++ b/packages/core/tests/home-user-base-image.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression guard: a default /home/user mount must not hide base-image content.
+ *
+ * Original bug: `buildVmOptions` installed a default in-memory `/home/user`
+ * mount that shadowed base-image files. Anything the base image shipped under
+ * `/home/user` (and, more broadly, the base filesystem the Pi SDK adapter needs
+ * at startup) was hidden behind an empty, freshly-mounted volume, so reads at
+ * `/home/user` saw an empty directory instead of base content.
+ *
+ * Fix: `buildVmOptions` no longer exists. VM-mount construction flows through
+ * `collectSidecarMountPlan` (packages/core/src/agent-os.ts), which never injects
+ * any default mount (in-memory or otherwise) at `/home/user`. The base
+ * filesystem is the unshadowed root/lower snapshot; `/home/user` is created as a
+ * plain directory by shadow-root bootstrap (an idempotent mkdir), and the base
+ * snapshot's content is materialized into that same root afterwards -- so base
+ * content under `/home/user` survives and is never replaced by an empty mount.
+ *
+ * This test reproduces the original failure condition: a default VM with NO
+ * explicit mounts. If a default mount were shadowing `/home/user`, then:
+ *   - content written under `/home/user` would be isolated to the shadow mount
+ *     and would NOT survive into a fresh root snapshot of the base layer, and
+ *   - the base image's own files would be hidden.
+ * The assertions below all rely on `/home/user` being backed by the real,
+ * unshadowed base/root filesystem.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AgentOs } from "../src/agent-os.js";
+
+const HOME_DIR = "/home/user";
+const MARKER_PATH = `${HOME_DIR}/startup-marker.json`;
+const MARKER_CONTENT = JSON.stringify({ origin: "base-image", id: "home-user-base-image" });
+
+describe("default /home/user must not be shadowed by a default mount", () => {
+	let vm: AgentOs | undefined;
+	const textDecoder = new TextDecoder();
+
+	beforeEach(async () => {
+		// No explicit `mounts` -- this is the exact scenario the original
+		// `buildVmOptions` default-mount bug applied to.
+		vm = await AgentOs.create();
+	});
+
+	afterEach(async () => {
+		if (vm) {
+			await vm.dispose();
+			vm = undefined;
+		}
+	});
+
+	test("base-image files outside /home/user are visible (base image not hidden)", async () => {
+		// /etc/profile ships in the base filesystem snapshot. If a default mount
+		// regime shadowed the base image, sentinel base files could disappear.
+		const profile = textDecoder.decode(
+			await (vm as AgentOs).readFile("/etc/profile"),
+		);
+		expect(profile.length).toBeGreaterThan(0);
+	});
+
+	test("/home/user is a real directory from the base layer, not an empty shadow mount", async () => {
+		const stat = await (vm as AgentOs).stat(HOME_DIR);
+		expect(stat.isDirectory).toBe(true);
+	});
+
+	test("content under /home/user is readable through vm.readFile (no shadowing mount)", async () => {
+		await (vm as AgentOs).writeFile(MARKER_PATH, MARKER_CONTENT);
+
+		const raw = await (vm as AgentOs).readFile(MARKER_PATH);
+		expect(JSON.parse(textDecoder.decode(raw))).toEqual({
+			origin: "base-image",
+			id: "home-user-base-image",
+		});
+	});
+
+	test("/home/user content lives on the base/root filesystem, not an isolated mount", async () => {
+		// The original bug installed an *in-memory* mount over /home/user. A real
+		// in-memory mount would NOT be part of the root filesystem snapshot. By
+		// writing under /home/user and confirming the write is captured by a fresh
+		// root-filesystem snapshot, we prove /home/user is backed by the
+		// unshadowed root layer rather than a separate default mount.
+		await (vm as AgentOs).writeFile(MARKER_PATH, MARKER_CONTENT);
+
+		const snapshot = await (vm as AgentOs).snapshotRootFilesystem();
+
+		const restored = await AgentOs.create({
+			rootFilesystem: {
+				disableDefaultBaseLayer: true,
+				lowers: [snapshot],
+			},
+		});
+		try {
+			const raw = await restored.readFile(MARKER_PATH);
+			expect(JSON.parse(textDecoder.decode(raw))).toEqual({
+				origin: "base-image",
+				id: "home-user-base-image",
+			});
+		} finally {
+			await restored.dispose();
+		}
+	});
+});


### PR DESCRIPTION
Standalone regression tests that lock in three already-fixed behaviors:
- a default /home/user mount must not hide base-image content (home-user-base-image.test.ts)
- a supported hook must exist to inject custom VFS mounts at VM creation (custom-vfs-mount-hook.test.ts)
- the session/prompt ACP timeout must be 600s, not a flat 120s (acp_request_timeout.rs)

Exercises existing behavior via public APIs / included source; no runtime change.