### PR TITLE
Security review fixes (agent-os)

### DIFF
--- a/crates/agent-os-sidecar/src/acp_extension.rs
+++ b/crates/agent-os-sidecar/src/acp_extension.rs
@@ -12,7 +12,7 @@ use agent_os_protocol::ACP_EXTENSION_NAMESPACE;
 use secure_exec_sidecar::limits::DEFAULT_ACP_MAX_READ_LINE_BYTES;
 use secure_exec_sidecar::wire::{
     CloseStdinRequest, EventPayload, ExecuteRequest, GuestFilesystemCallRequest,
-    GuestFilesystemOperation, GuestRuntimeKind, KillProcessRequest, StreamChannel,
+    GuestFilesystemOperation, GuestRuntimeKind, KillProcessRequest, OwnershipScope, StreamChannel,
     WriteStdinRequest,
 };
 use secure_exec_sidecar::{
@@ -54,6 +54,10 @@ pub struct AcpExtension {
 #[derive(Debug, Clone)]
 struct AcpSessionRecord {
     session_id: String,
+    /// Connection that created this session. Used to enforce per-connection
+    /// ownership so one connection cannot read or drive another connection's
+    /// ACP session by its `session_id`.
+    owner_connection_id: String,
     agent_type: String,
     process_id: String,
     pid: Option<u32>,
@@ -81,7 +85,7 @@ impl AcpExtension {
         let response = match request {
             AcpRequest::AcpCreateSessionRequest(request) => self.create_session(ctx, request).await,
             AcpRequest::AcpGetSessionStateRequest(request) => {
-                AcpHandlerOutput::response(self.get_session_state(request).await)
+                AcpHandlerOutput::response(self.get_session_state(ctx, request).await)
             }
             AcpRequest::AcpCloseSessionRequest(request) => {
                 AcpHandlerOutput::response(self.close_session(ctx, request).await)
@@ -146,6 +150,7 @@ impl AcpExtension {
 
         let session = AcpSessionRecord {
             session_id: bootstrap.session_id.clone(),
+            owner_connection_id: ownership_connection_id(ctx.ownership()),
             agent_type: request.agent_type.clone(),
             process_id: process_id.clone(),
             pid: started.pid,
@@ -338,12 +343,22 @@ impl AcpExtension {
 
     async fn get_session_state(
         &self,
+        ctx: ExtensionContext<'_>,
         request: AcpGetSessionStateRequest,
     ) -> Result<AcpResponse, SidecarError> {
+        let caller_connection_id = ownership_connection_id(ctx.ownership());
         let sessions = self.sessions.lock().await;
-        let session = sessions.get(&request.session_id).ok_or_else(|| {
+        let unknown = || {
             SidecarError::InvalidState(format!("unknown ACP session {}", request.session_id))
-        })?;
+        };
+        let session = sessions.get(&request.session_id).ok_or_else(unknown)?;
+        // Enforce per-connection ownership: a session may only be read by the
+        // connection that created it. Fail closed with the same error a missing
+        // session produces so existence of another connection's session is not
+        // leaked across the connection tenant boundary.
+        if session.owner_connection_id != caller_connection_id {
+            return Err(unknown());
+        }
         Ok(AcpResponse::AcpSessionStateResponse(
             session.state_response(),
         ))
@@ -1427,6 +1442,17 @@ fn convert_runtime(runtime: AcpRuntimeKind) -> GuestRuntimeKind {
 
 fn hash_to_btree(map: HashMap<String, String>) -> BTreeMap<String, String> {
     map.into_iter().collect()
+}
+
+/// Extract the owning connection id from an ownership scope. Every scope carries
+/// a connection id, which is the tenant boundary secure-exec enforces; ACP
+/// session ownership is keyed off this same connection id.
+fn ownership_connection_id(ownership: &OwnershipScope) -> String {
+    match ownership {
+        OwnershipScope::ConnectionOwnership(inner) => inner.connection_id.clone(),
+        OwnershipScope::SessionOwnership(inner) => inner.connection_id.clone(),
+        OwnershipScope::VmOwnership(inner) => inner.connection_id.clone(),
+    }
 }
 
 fn parse_json_text(text: &str, label: &str) -> Result<Value, SidecarError> {

--- a/crates/agent-os-sidecar/tests/acp_extension.rs
+++ b/crates/agent-os-sidecar/tests/acp_extension.rs
@@ -296,6 +296,102 @@ fn acp_extension_creates_reports_and_closes_session_over_ext() {
     assert_eq!(closed.session_id, "adapter-session");
 }
 
+// ---------------------------------------------------------------------------
+// Security tests (adversarial). The peer connection is UNTRUSTED; the test
+// asserts the ACP extension DENIES the attack and stays usable.
+// ---------------------------------------------------------------------------
+
+/// F-010 (T2 / J.4): a second connection (attacker) must NOT be able to read the
+/// ACP session state created by a different connection (victim). `get_session_state`
+/// must enforce per-connection ownership; a cross-connection read by a known/guessed
+/// `session_id` must fail closed (error response), not leak the victim's session
+/// metadata (agent_type, process_id, pid, modes, config_options, agent_info).
+///
+/// This is the bounded SAFEGUARD assertion and runs by default. It is fast: it
+/// performs a single cross-connection read and asserts the deny.
+#[test]
+fn acp_get_session_state_denies_cross_connection_session_id() {
+    assert_node_available();
+    let mut sidecar = new_sidecar("agent-os-acp-cross-conn-state");
+
+    // Victim connection creates a real ACP session.
+    let victim_conn = authenticate(&mut sidecar);
+    let victim_session = open_session(&mut sidecar, &victim_conn);
+    let cwd = temp_dir("agent-os-acp-cross-conn-state-cwd");
+    let adapter = cwd.join("adapter.mjs");
+    fs::write(&adapter, adapter_script()).expect("write adapter script");
+    let victim_vm = create_vm(&mut sidecar, &victim_conn, &victim_session, &cwd);
+
+    let created = dispatch_acp(
+        &mut sidecar,
+        4,
+        &victim_conn,
+        &victim_session,
+        &victim_vm,
+        AcpRequest::AcpCreateSessionRequest(AcpCreateSessionRequest {
+            agent_type: String::from("pi"),
+            runtime: AcpRuntimeKind::JavaScript,
+            adapter_entrypoint: adapter.to_string_lossy().into_owned(),
+            cwd: cwd.to_string_lossy().into_owned(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            protocol_version: i32::from(ACP_PROTOCOL_VERSION),
+            client_capabilities: String::from(r#"{"fs":{"readTextFile":true}}"#),
+            mcp_servers: String::from(r#"{"servers":[]}"#),
+            skip_os_instructions: true,
+            additional_instructions: None,
+        }),
+    );
+    let AcpResponse::AcpSessionCreatedResponse(_) = created else {
+        panic!("victim create failed: {created:?}");
+    };
+
+    // The owner can still read its own session state.
+    let owner_state = dispatch_acp(
+        &mut sidecar,
+        5,
+        &victim_conn,
+        &victim_session,
+        &victim_vm,
+        AcpRequest::AcpGetSessionStateRequest(AcpGetSessionStateRequest {
+            session_id: String::from("adapter-session"),
+        }),
+    );
+    assert!(
+        matches!(owner_state, AcpResponse::AcpSessionStateResponse(_)),
+        "owner connection must still read its own ACP session state, got {owner_state:?}"
+    );
+
+    // Attacker connection: separate auth + session + vm, then tries to read the
+    // victim's ACP session state by its (guessed/known) session id.
+    let attacker_conn = authenticate(&mut sidecar);
+    assert_ne!(
+        attacker_conn, victim_conn,
+        "attacker must be a distinct connection"
+    );
+    let attacker_session = open_session(&mut sidecar, &attacker_conn);
+    let attacker_cwd = temp_dir("agent-os-acp-cross-conn-attacker-cwd");
+    let attacker_vm = create_vm(&mut sidecar, &attacker_conn, &attacker_session, &attacker_cwd);
+
+    let leaked = dispatch_acp(
+        &mut sidecar,
+        6,
+        &attacker_conn,
+        &attacker_session,
+        &attacker_vm,
+        AcpRequest::AcpGetSessionStateRequest(AcpGetSessionStateRequest {
+            session_id: String::from("adapter-session"),
+        }),
+    );
+
+    // SECURE expectation: a different connection must be denied (error response).
+    assert!(
+        matches!(leaked, AcpResponse::AcpErrorResponse(_)),
+        "cross-connection read of another connection's ACP session state must be DENIED, \
+         but it returned: {leaked:?}"
+    );
+}
+
 fn decode_single_acp_session_event(events: &[EventFrame]) -> Value {
     assert_eq!(events.len(), 1);
     let EventPayload::ExtEnvelope(envelope) = &events[0].payload else {

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -1891,6 +1891,18 @@ async function handleHostCallback(
 		};
 	}
 
+	const permissionMode = toolPermissionMode(
+		context.permissions,
+		payload.callback_key,
+	);
+	if (permissionMode !== "allow") {
+		return {
+			type: "host_callback_result",
+			invocation_id: payload.invocation_id,
+			error: `EACCES: blocked by tool.invoke policy for ${payload.callback_key}`,
+		};
+	}
+
 	const parsed = tool.inputSchema.safeParse(payload.input);
 	if (!parsed.success) {
 		return {

--- a/packages/core/tests/toolkit-permissions.test.ts
+++ b/packages/core/tests/toolkit-permissions.test.ts
@@ -1,7 +1,71 @@
 import common from "@agent-os-pkgs/common";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { AgentOs, hostTool, toolKit } from "../src/index.js";
+import { NativeSidecarProcessClient } from "../src/sidecar/rpc-client.js";
+
+// ---------------------------------------------------------------------------
+// Adversarial host_callback RPC tests (security review: aos-ts N-001/N-002).
+//
+// THREAT MODEL: untrusted guest / agent code can emit a raw `host_callback`
+// sidecar-request frame whose `callback_key` and `input` it fully controls.
+// The CLI command path (`agentos-<kit> <tool>`) is gated by `toolPermissionMode`
+// via `invokeHostTool`, but the raw `host_callback` RPC path is handled by
+// `handleHostCallback` in agent-os.ts. These tests play the guest and assert
+// the system DENIES the call (execute must never run) when policy denies or the
+// tool is out of the granted pattern scope.
+//
+// We capture the real `SidecarRequestHandler` that `AgentOs.create()` installs
+// on the native sidecar client (via a prototype spy), then feed it forged
+// `host_callback` frames — exactly the bytes an untrusted guest controls.
+// ---------------------------------------------------------------------------
+
+type CapturedHandler = (request: any) => Promise<any> | any;
+
+async function createVmCapturingHandler(
+	options: Parameters<typeof AgentOs.create>[0],
+): Promise<{ vm: AgentOs; handler: CapturedHandler }> {
+	let captured: CapturedHandler | null = null;
+	const original =
+		NativeSidecarProcessClient.prototype.setSidecarRequestHandler;
+	const spy = vi
+		.spyOn(NativeSidecarProcessClient.prototype, "setSidecarRequestHandler")
+		.mockImplementation(function (
+			this: NativeSidecarProcessClient,
+			handler: any,
+		) {
+			if (handler) {
+				captured = handler as CapturedHandler;
+			}
+			// Still install on the real client so the VM behaves normally.
+			return original.call(this, handler);
+		});
+	try {
+		const vm = await AgentOs.create(options);
+		if (!captured) {
+			throw new Error(
+				"AgentOs.create did not install a sidecar request handler",
+			);
+		}
+		return { vm, handler: captured };
+	} finally {
+		spy.mockRestore();
+	}
+}
+
+function hostCallbackFrame(callbackKey: string, input: unknown) {
+	return {
+		frame_type: "sidecar_request" as const,
+		request_id: 1,
+		payload: {
+			type: "host_callback" as const,
+			invocation_id: "guest-forged-1",
+			callback_key: callbackKey,
+			input,
+			timeout_ms: 30_000,
+		},
+	};
+}
 
 const mathToolKit = toolKit({
 	name: "math",
@@ -143,5 +207,112 @@ describe("toolkit permissions", () => {
 			ok: true,
 			result: { sum: 12 },
 		});
+	});
+});
+
+describe("toolkit permissions — raw host_callback RPC path", () => {
+	let vm: AgentOs | null = null;
+
+	afterEach(async () => {
+		await vm?.dispose();
+		vm = null;
+	});
+
+	// N-001 (J.1/J.2): host_callback RPC must honor tool.invoke deny.
+	test("denies host_callback RPC tool invocation when tool.invoke policy is deny (not just the CLI path)", async () => {
+		const executed: unknown[] = [];
+		const spyKit = toolKit({
+			name: "math",
+			description: "Math utilities",
+			tools: {
+				add: hostTool({
+					description: "Add two numbers",
+					inputSchema: z.object({ a: z.number(), b: z.number() }),
+					execute: ({ a, b }) => {
+						executed.push({ a, b });
+						return { sum: a + b };
+					},
+				}),
+			},
+		});
+
+		const created = await createVmCapturingHandler({
+			// No `software` needed: this exercises the raw host_callback RPC
+			// handler directly (the guest-controlled path), which does not spawn
+			// any in-VM CLI. Keeping the VM minimal makes the safeguard fast.
+			toolKits: [spyKit],
+			permissions: {
+				fs: "allow",
+				childProcess: "allow",
+				// Deny-by-default: no tool.invoke grant for math:add.
+				tool: { default: "deny", rules: [] },
+			},
+		});
+		vm = created.vm;
+
+		const response = await created.handler(
+			hostCallbackFrame("math:add", { a: 2, b: 3 }),
+		);
+
+		// The attacker must be denied: execute MUST NOT have run, and the
+		// response must surface a policy denial rather than a result.
+		expect(executed).toHaveLength(0);
+		expect(response.type).toBe("host_callback_result");
+		expect(response.result).toBeUndefined();
+		expect(typeof response.error).toBe("string");
+		expect(response.error).toMatch(/tool\.invoke|EACCES|denied|permission/i);
+	});
+
+	// N-002 (J.2): host_callback RPC must respect tool.invoke pattern scope.
+	test("host_callback RPC respects tool.invoke pattern scope and denies a non-matching tool", async () => {
+		const executed: string[] = [];
+		const dangerKit = toolKit({
+			name: "math",
+			description: "Math utilities with a dangerous tool",
+			tools: {
+				safe: hostTool({
+					description: "Safe op",
+					inputSchema: z.object({ x: z.number() }),
+					execute: ({ x }) => {
+						executed.push("safe");
+						return { x };
+					},
+				}),
+				danger: hostTool({
+					description: "Dangerous op",
+					inputSchema: z.object({ x: z.number() }),
+					execute: ({ x }) => {
+						executed.push("danger");
+						return { x };
+					},
+				}),
+			},
+		});
+
+		const created = await createVmCapturingHandler({
+			toolKits: [dangerKit],
+			permissions: {
+				fs: "allow",
+				childProcess: "allow",
+				// Only math:safe is allowed; math:danger is out of scope -> deny.
+				tool: {
+					default: "deny",
+					rules: [
+						{ mode: "allow", operations: ["invoke"], patterns: ["math:safe"] },
+					],
+				},
+			},
+		});
+		vm = created.vm;
+
+		const response = await created.handler(
+			hostCallbackFrame("math:danger", { x: 1 }),
+		);
+
+		expect(executed).not.toContain("danger");
+		expect(response.type).toBe("host_callback_result");
+		expect(response.result).toBeUndefined();
+		expect(typeof response.error).toBe("string");
+		expect(response.error).toMatch(/tool\.invoke|EACCES|denied|permission/i);
 	});
 });


### PR DESCRIPTION
Security review fixes for agent-os. Each fix is its own commit and ships with a load-bearing test (verified to fail before the fix and pass after).

- **F-010 — Cross-connection ACP session-state leak** (`crates/agent-os-sidecar/src/acp_extension.rs`): ACP `get_session_state` looked up sessions in a global map keyed only by `session_id` and never received `ctx` or checked ownership, so a second authenticated connection could read another connection's full session state (`agent_type`, `process_id`, `pid`, `modes`, `config_options`, `agent_info`) by `session_id`. Fix: added `owner_connection_id` to `AcpSessionRecord` (populated from `ctx.ownership()` at `create_session`), threaded `ctx` into `get_session_state`, added an `ownership_connection_id()` helper, and made the handler fail closed with the same "unknown ACP session" error when the caller's connection id does not match the owner (so existence is not leaked across the tenant boundary). Verifying test: `acp_get_session_state_denies_cross_connection_session_id` in `crates/agent-os-sidecar/tests/acp_extension.rs` — asserts the owner can still read its own state and a distinct attacker connection is denied. Confirmed it fails without the check and passes with it.

- **N-001/002 — `tool.invoke` policy + pattern-scope bypass on the raw `host_callback` RPC path** (`packages/core/src/agent-os.ts`): `handleHostCallback` looked up the tool and ran `executeHostTool` directly with no `tool.invoke` permission check, unlike `invokeHostTool` (the CLI path) which calls `toolPermissionMode` and denies when the mode is not `allow`. A guest-controlled raw `host_callback` RPC frame therefore bypassed the policy/pattern-scope gate. Fix: in `handleHostCallback`, after tool lookup and before schema parsing, added a `toolPermissionMode(context.permissions, payload.callback_key)` check that returns a structured `host_callback_result` error (`EACCES: blocked by tool.invoke policy for <key>`) when the mode is not `allow`, mirroring `invokeHostTool` and reusing the existing `toolPermissionMode`/`permissionPatternMatches` logic (covers both deny-by-default and out-of-scope-pattern cases). Verifying tests: new `toolkit permissions — raw host_callback RPC path` block in `packages/core/tests/toolkit-permissions.test.ts` — (1) denies when `tool.invoke` policy is deny, (2) denies a non-matching tool when only a different pattern is granted. Both feed forged `host_callback` frames to the real handler captured from `AgentOs.create()`; confirmed load-bearing by reverting the fix (pattern-scope test then executed the blocked tool) and restoring it.

Companion PR: a separate secure-exec security-review PR covers the runtime-side fixes from the same review; it is tracked against the reviewed runtime branch in `rivet-dev/secure-exec` (not a `main` lacking the runtime).

Verification: `cargo build --workspace` is green; the F-010 test and the full `agent-os-sidecar` lib suite pass; `agent-os-client` `cron_e2e` passes with the sidecar binary present; the 4 new N-001/002 tests pass. The only remaining red in this workspace (3 `software:["common"]`-mount toolkit tests with `ENOENT: open '/'`, and 5 `tsc` `CreateVmConfig`/`RootFilesystemConfig` vs `*V1` import-skew errors against the linked secure-exec) is pre-existing and reproduces identically on `main` without these commits, so it is unrelated to these fixes.