### PR TITLE
docs(CLAUDE): security model + testing conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ Agent OS is the agent-facing wrapper around secure-exec. It provides ACP session
 - Call OS instances VMs, never sandboxes.
 - The protocol has no backwards compatibility. Clients and the sidecar ship in same-version lockstep, so never add protocol or config versioning, runtime negotiation, fallbacks, or converters. Configs such as `CreateVmConfig` carry no `version` field; the single same-version wire handshake is the only version check. Change the protocol freely and update both sides together.
 
+## Security Model
+
+- Isolation is layered (defense in depth), like Cloudflare Workers. Untrusted guest code is isolated *within* the host process by V8/WASM virtualization today; host-level jailing (sandboxing the process itself) is a planned additional layer. Because the in-process layer is load-bearing: keep the embedded V8 patched to current security releases, and never let one isolate take down the shared process — a per-isolate failure (heap OOM, CPU runaway) must terminate that isolate, not abort the host process.
+- Match Cloudflare Workers wherever it makes sense. Use Workers' published behavior as the reference point for isolation semantics, resource limits, and egress defaults — e.g. ~128 MiB memory per isolate, bounded CPU time, default-deny network egress. Resource limits must be bounded by default (never `None`/0 for memory, heap, stack, or CPU time); operators may raise them.
+
 ## Agent Sessions
 
 - Every public method on `packages/core/src/agent-os.ts` must stay mirrored by RivetKit actor actions after the user confirms the Rivet repo path.


### PR DESCRIPTION
Adds two CLAUDE.md sections from the security review.

## Security Model (new, after Boundaries)
- Isolation is layered (defense in depth), like Cloudflare Workers: untrusted guest code is virtualized within the host process by V8/WASM today, with host-level jailing planned as an additional layer. Because the in-process layer is load-bearing, keep embedded V8 patched and never let one isolate abort the shared host process.
- Match Cloudflare Workers wherever it makes sense — use Workers' published isolation semantics, resource limits (~128 MiB/isolate, bounded CPU time), and default-deny egress as the reference. Limits must be bounded by default; operators may raise them.

## Testing
- Auto-skip expensive resource-saturation tests (infinite loops, heap/alloc bombs, fork bombs, process aborts) via `#[ignore = "expensive: <resource> saturation; run with --ignored"]` (or vitest `it.skip`/env gate) since they pin cores or crash the runner.
- Still keep the safeguard tests — a configured limit/watchdog/quota actually firing is fast and bounded, and is the regression guard that the protection works.
- Rule of thumb: ends when a watchdog whose absence you're documenting fires (slow) → `#[ignore]`; ends when a safeguard fires (fast) → keep running.