### PR TITLE
fix(ci): resolve pnpm/action-setup version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Problem

CI fails on **every commit, including `main`**. The `pnpm/action-setup@v4` step in `.github/workflows/ci.yml` passes a `version: latest` input while `package.json` also declares `"packageManager": "pnpm@10.13.1"`. v4 of the action refuses to accept both sources and errors out:

> Multiple versions of pnpm specified

This blocks the entire CI workflow repo-wide.

## Fix

Remove the `version:` input from the `pnpm/action-setup` step so the pnpm version is resolved solely from `package.json`'s `packageManager` field — the recommended configuration that resolves the conflict (and the related `ERR_PNPM_BAD_PM_VERSION`).

Minimal change: only two deleted lines in `ci.yml`. `publish.yaml` already invokes the action without a `version` input, so no change is needed there.