### PR TITLE
Security review fixes: browser egress (F-008/F-009)

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -55,7 +55,7 @@
     "check-types": "tsc --noEmit",
     "build": "tsc",
     "test:browser": "node ./scripts/run-browser-tests.mjs",
-    "test": "pnpm build && vitest run tests/runtime-driver/permission-validation.test.ts && pnpm run test:browser"
+    "test": "pnpm build && vitest run tests/runtime-driver && pnpm run test:browser"
   },
   "dependencies": {
     "sucrase": "^3.35.0"

--- a/packages/browser/src/driver.ts
+++ b/packages/browser/src/driver.ts
@@ -334,6 +334,9 @@ export function createBrowserNetworkAdapter(): NetworkAdapter {
 				method: options?.method || "GET",
 				headers: options?.headers,
 				body: options?.body as RequestInit["body"],
+				// Untrusted guest requests must never ride the embedding page's
+				// ambient cookies / HTTP-auth (F-008). Omit all credentials.
+				credentials: "omit",
 			});
 			const headers: Record<string, string> = {};
 			response.headers.forEach((v, k) => {
@@ -375,6 +378,9 @@ export function createBrowserNetworkAdapter(): NetworkAdapter {
 				method: options?.method || "GET",
 				headers: options?.headers,
 				body: options?.body as RequestInit["body"],
+				// Untrusted guest requests must never ride the embedding page's
+				// ambient cookies / HTTP-auth (F-008). Omit all credentials.
+				credentials: "omit",
 			});
 			const headers: Record<string, string> = {};
 			response.headers.forEach((v, k) => {

--- a/packages/browser/src/runtime.ts
+++ b/packages/browser/src/runtime.ts
@@ -405,6 +405,49 @@ export function wrapFileSystem(
 	};
 }
 
+/**
+ * Default port for a URL scheme, used when the URL omits an explicit port so
+ * host-keyed network policies can still reason about the effective port.
+ */
+function defaultPortForProtocol(protocol: string): number | undefined {
+	switch (protocol) {
+		case "http:":
+		case "ws:":
+			return 80;
+		case "https:":
+		case "wss:":
+			return 443;
+		case "ftp:":
+			return 21;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Parse a request URL into the `{ url, host, port }` shape the network
+ * permission callback expects, so host-keyed deny rules (e.g.
+ * `req.host === "169.254.169.254"`) can match. Falls back to `{ url }` only
+ * when the URL cannot be parsed.
+ */
+function buildNetworkPermissionRequest(url: string): {
+	url: string;
+	host?: string;
+	port?: number;
+} {
+	try {
+		const parsed = new URL(url);
+		// `hostname` strips brackets from IPv6 literals and excludes the port.
+		const host = parsed.hostname || undefined;
+		const port = parsed.port
+			? Number(parsed.port)
+			: defaultPortForProtocol(parsed.protocol);
+		return { url, host, port };
+	} catch {
+		return { url };
+	}
+}
+
 export function wrapNetworkAdapter(
 	adapter: NetworkAdapter,
 	permissions?: Permissions,
@@ -423,7 +466,7 @@ export function wrapNetworkAdapter(
 	};
 	return {
 		async fetch(url, options) {
-			check({ url });
+			check(buildNetworkPermissionRequest(url));
 			return adapter.fetch(url, options);
 		},
 		async dnsLookup(hostname) {
@@ -431,7 +474,7 @@ export function wrapNetworkAdapter(
 			return adapter.dnsLookup(hostname);
 		},
 		async httpRequest(url, options) {
-			check({ url });
+			check(buildNetworkPermissionRequest(url));
 			return adapter.httpRequest(url, options);
 		},
 	};

--- a/packages/browser/tests/runtime-driver/network-credentials.test.ts
+++ b/packages/browser/tests/runtime-driver/network-credentials.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBrowserNetworkAdapter } from "../../src/driver.js";
+
+// F-008 (sec-ts T1): the browser network adapter forwards guest requests to the
+// host `fetch`. Without an explicit credentials policy, the request defaults to
+// `same-origin` and rides the embedding page's ambient cookies / HTTP-auth,
+// enabling credential exfil / CSRF from untrusted guest code. The adapter must
+// set `credentials: 'omit'` on every host fetch. See:
+//   /home/nathan/.agent/notes/security-review/FAILURES.md#F-008
+
+function makeResponse(): Response {
+	return {
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		url: "https://example.com/",
+		redirected: false,
+		headers: {
+			get: () => "text/plain",
+			forEach: () => {},
+		},
+		text: async () => "body",
+		arrayBuffer: async () => new ArrayBuffer(0),
+	} as unknown as Response;
+}
+
+describe("browser fetch adapter omits ambient credentials and does not leak host-origin cookies", () => {
+	let fetchSpy: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn(async () => makeResponse());
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("fetch() forwards credentials: 'omit' to the host fetch", async () => {
+		const adapter = createBrowserNetworkAdapter();
+		await adapter.fetch("https://example.com/", { method: "GET" });
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const init = fetchSpy.mock.calls[0][1] as RequestInit;
+		expect(init.credentials).toBe("omit");
+	});
+
+	it("httpRequest() forwards credentials: 'omit' to the host fetch", async () => {
+		const adapter = createBrowserNetworkAdapter();
+		await adapter.httpRequest("https://example.com/", { method: "GET" });
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const init = fetchSpy.mock.calls[0][1] as RequestInit;
+		expect(init.credentials).toBe("omit");
+	});
+
+	it("credentials policy is omit regardless of guest-supplied headers", async () => {
+		const adapter = createBrowserNetworkAdapter();
+		await adapter.fetch("https://example.com/", {
+			method: "POST",
+			headers: { cookie: "session=guest-set" },
+			body: "x",
+		});
+
+		const init = fetchSpy.mock.calls[0][1] as RequestInit;
+		expect(init.credentials).toBe("omit");
+	});
+});

--- a/packages/browser/tests/runtime-driver/network-policy-host.test.ts
+++ b/packages/browser/tests/runtime-driver/network-policy-host.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+	type NetworkAdapter,
+	type Permissions,
+	wrapNetworkAdapter,
+} from "../../src/runtime.js";
+
+// F-009 (sec-ts T3): the network policy callback must receive the parsed host
+// and port, not just the url, so an operator's host-keyed SSRF deny rule
+// (`req.host === "169.254.169.254"`) actually matches and the cloud-metadata
+// host is unreachable. See:
+//   /home/nathan/.agent/notes/security-review/FAILURES.md#F-009
+
+const METADATA_HOST = "169.254.169.254";
+const SECRET_BODY = "SECRET-IAM-CREDENTIALS";
+
+function makeAdapter(): NetworkAdapter {
+	// Stub host adapter that would happily return metadata secrets if reached.
+	const response = {
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		headers: {},
+		body: SECRET_BODY,
+		url: "",
+		redirected: false,
+	};
+	return {
+		async fetch() {
+			return { ...response };
+		},
+		async dnsLookup() {
+			return { address: "127.0.0.1", family: 4 };
+		},
+		async httpRequest() {
+			const { redirected, ...rest } = response;
+			return { ...rest };
+		},
+	};
+}
+
+describe("network policy callback receives parsed host and port not just url", () => {
+	it("passes host and port from the URL to the policy callback", () => {
+		const seen: Array<{ url?: string; host?: string; port?: number }> = [];
+		const permissions: Permissions = {
+			network: (req) => {
+				seen.push(req);
+				return true;
+			},
+		};
+		const wrapped = wrapNetworkAdapter(makeAdapter(), permissions);
+
+		return wrapped
+			.fetch("https://example.com:8443/path")
+			.then(() => {
+				expect(seen).toHaveLength(1);
+				expect(seen[0].host).toBe("example.com");
+				expect(seen[0].port).toBe(8443);
+				expect(seen[0].url).toBe("https://example.com:8443/path");
+			});
+	});
+
+	it("derives the default port from the scheme when omitted", async () => {
+		const seen: Array<{ url?: string; host?: string; port?: number }> = [];
+		const permissions: Permissions = {
+			network: (req) => {
+				seen.push(req);
+				return true;
+			},
+		};
+		const wrapped = wrapNetworkAdapter(makeAdapter(), permissions);
+
+		await wrapped.fetch("http://example.com/path");
+		expect(seen[0].host).toBe("example.com");
+		expect(seen[0].port).toBe(80);
+
+		await wrapped.fetch("https://example.com/path");
+		expect(seen[1].host).toBe("example.com");
+		expect(seen[1].port).toBe(443);
+	});
+
+	it("denies a host-keyed deny rule against the cloud-metadata host (fetch)", async () => {
+		const permissions: Permissions = {
+			network: (req) => ({ allow: req.host !== METADATA_HOST }),
+		};
+		const wrapped = wrapNetworkAdapter(makeAdapter(), permissions);
+
+		await expect(
+			wrapped.fetch(`http://${METADATA_HOST}/latest/meta-data/iam/`),
+		).rejects.toThrow(/EACCES/);
+	});
+
+	it("denies a host-keyed deny rule against the cloud-metadata host (httpRequest)", async () => {
+		const permissions: Permissions = {
+			network: (req) => ({ allow: req.host !== METADATA_HOST }),
+		};
+		const wrapped = wrapNetworkAdapter(makeAdapter(), permissions);
+
+		await expect(
+			wrapped.httpRequest(`http://${METADATA_HOST}/latest/meta-data/iam/`),
+		).rejects.toThrow(/EACCES/);
+	});
+});


### PR DESCRIPTION
Security review fixes for the live browser package `@rivet-dev/agent-os-browser` (`packages/browser`, consumed by `packages/playground`). One commit per fix; diff is browser-only.

## F-008 — guest fetch rides the host's ambient credentials (High)

`createBrowserNetworkAdapter().fetch` / `.httpRequest` forwarded guest requests to the host `fetch(url, {method, headers, body})` with no `credentials` policy. The browser default is `same-origin`, so untrusted guest code (reachable via the exposed `_networkFetchRaw` global) rode the embedding page's ambient cookies / HTTP-auth → credential exfil / CSRF.

**Fix:** set `credentials: 'omit'` on both host fetch paths in `packages/browser/src/driver.ts`.

**Verifying test:** `packages/browser/tests/runtime-driver/network-credentials.test.ts` stubs the host `fetch` and asserts it is called with `credentials: 'omit'` from `fetch()` and `httpRequest()`, including when guest-supplied headers are present. Without the fix `init.credentials` is `undefined`.

## F-009 — network policy callback only receives `{url}`, host-keyed denies never match (High)

`wrapNetworkAdapter` forwarded only `{ url }` to the network permission callback, even though the `Permissions.network` type advertises `{ url, host, port }`. An operator's natural host-keyed SSRF deny rule (`req.host === "169.254.169.254"`) never matched, so the cloud-metadata host stayed reachable.

**Fix:** parse the request URL and pass `host` plus the explicit or scheme-default `port` to the callback in `packages/browser/src/runtime.ts`. Falls back to `{ url }` only when the URL is unparseable.

**Verifying test:** `packages/browser/tests/runtime-driver/network-policy-host.test.ts` asserts the callback receives the parsed host/port (explicit and scheme-default) and that a host-keyed deny rule blocks the metadata host via both `fetch` and `httpRequest`. Without the fix `req.host` is `undefined` and the deny rule never fires.

## Verification

- `pnpm -C packages/browser build` green.
- `pnpm exec vitest run tests/runtime-driver` → 37 passed (3 files).
- `jj diff --from main@origin` touches only `packages/browser/**`.

Companion PRs: #79 (secure-exec) / #1482 (agent-os).