### PR TITLE
ci: check out + build secure-exec sibling for @secure-exec/core link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Check out the secure-exec sibling repo that packages/core links to via
+      # `"@secure-exec/core": "link:../../../secure-exec/packages/core"`. That
+      # link resolves to `<agent-os-root>/../secure-exec/packages/core`, i.e.
+      # `$GITHUB_WORKSPACE/../secure-exec/packages/core`. actions/checkout can
+      # only write inside the workspace, so we check out into a subdir and then
+      # symlink it to the sibling path the link expects.
+      - uses: actions/checkout@v4
+        with:
+          repository: rivet-dev/secure-exec
+          ref: main
+          path: _secure-exec-sibling
+      - name: Place secure-exec at the sibling path the link expects
+        run: ln -s "$GITHUB_WORKSPACE/_secure-exec-sibling" "$GITHUB_WORKSPACE/../secure-exec"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -23,6 +36,16 @@ jobs:
         with:
           workspaces: |
             . -> target
+      # Build the link target so its dist/ exists. The `@secure-exec/core`
+      # subpath exports (./descriptors, ./vm-config, ./sidecar-client) resolve
+      # to dist/*.{js,d.ts}; without these the agent-os tsc build cannot find
+      # the module. The core build = protocol compile (Node) + a lightweight
+      # `cargo test -p secure-exec-vm-config` (pure serde/ts-rs crate, no V8
+      # bridge / native build) + tsc, so this stays cheap in CI.
+      - name: Install + build @secure-exec/core (link target)
+        run: |
+          pnpm -C "$GITHUB_WORKSPACE/_secure-exec-sibling" install --frozen-lockfile
+          pnpm -C "$GITHUB_WORKSPACE/_secure-exec-sibling" --filter @secure-exec/core build
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm --dir scripts/publish run check-types


### PR DESCRIPTION
## Root cause

`packages/core/package.json` pins:

```json
"@secure-exec/core": "link:../../../secure-exec/packages/core"
```

This is an intentional **local-dev** sibling link (per `CLAUDE.md`: "Local Agent OS development dependencies on secure-exec must point to `../secure-exec`"). In CI the secure-exec sibling isn't checked out, so the link can't resolve and `tsc` fails with `Cannot find module '@secure-exec/core/{descriptors,vm-config,sidecar-client}'` (plus cascading implicit-any errors).

## Fix (preserves the documented local-dev link)

Instead of changing the `link:`, CI now provides the sibling:

1. **Check out `rivet-dev/secure-exec` (`ref: main`)** into `_secure-exec-sibling` (a subdir, because `actions/checkout` can only write inside the workspace), then **symlink** it to `$GITHUB_WORKSPACE/../secure-exec`.
   - Path reasoning: the link `../../../secure-exec/packages/core` is relative to `packages/core`, so it resolves to `<agent-os-root>/../secure-exec/packages/core` = `$GITHUB_WORKSPACE/../secure-exec/packages/core`. The symlink makes that path point at the in-workspace checkout. Verified the relative-path resolution locally.
2. **Install + build `@secure-exec/core`** (the link target) so its `dist/` exists before `pnpm install`. The subpath exports resolve to `dist/*.{js,d.ts}`.
   - The core build = protocol compile (Node) + `cargo test -p secure-exec-vm-config` (a lightweight pure serde/ts-rs crate — **no V8 bridge / native build**, compiles in seconds) + `tsc`. CI-cheap. Both repos are public, so the default `GITHUB_TOKEN` can check out secure-exec without a PAT.

## ⚠️ Blocker: this is necessary but NOT sufficient

This PR makes the **link resolve**, but agent-os `main` does **not type-check against secure-exec `main`**. After building secure-exec `main` and running `pnpm --dir packages/core check-types` locally, there are **5 genuine type errors** from API drift between the two repos' `main`:

- `RootFilesystemConfig` now requires `bootstrapEntries` (secure-exec) vs. agent-os's local shape that lacks it
- `allowedNodeBuiltins` is no longer accepted by the configure-VM descriptor
- `RootLowerInput` / `RootFilesystemLowerDescriptor` shape mismatch in `rpc-client.ts`

The agent-os commit that re-introduced the link (`feat(client): migrate CreateVm to typed JSON config`) explicitly notes: *"the link:/path deps here must become a published version bump before merge"* — i.e. agent-os `main` depends on in-flight, not-yet-published secure-exec changes, developed in lockstep.

**Implication:** `ref: main` for secure-exec is a moving target and won't reliably make CI green. To truly unblock CI, one of:
- pin secure-exec to the exact commit/tag agent-os `main` was developed against (the subpath exports + `bootstrapEntries` were introduced in the same secure-exec commit, so there's no version with subpaths but the old types — the agent-os runtime code needs to catch up), **or**
- adopt the team's published-split strategy: consume the published `@secure-exec/core` (replace the `link:` with a pinned npm version) and bump agent-os runtime code to the published API.

Either path requires a coordinated agent-os runtime change to match secure-exec's current API — out of scope for "make the link resolve in CI". **Do not merge until that's decided.**