### PR TITLE
chore: repin agent-os to secure-exec 0.3.0-rc.1 (unblock build + CI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-bridge"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-client"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "futures",
  "parking_lot",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-execution"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-kernel"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-sidecar"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-sidecar-browser"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "secure-exec-bridge",
  "secure-exec-kernel",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-v8-runtime"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "ciborium",
  "crossbeam-channel",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "secure-exec-vm-config"
-version = "0.2.0-rc.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ repository = "https://github.com/rivet-dev/agent-os"
 # `cargo publish` can emit a registry-resolvable dependency). The release
 # tooling rewrites these versions together with `workspace.package.version`.
 [workspace.dependencies]
-agent-os-bridge = { package = "secure-exec-bridge", path = "../secure-exec/crates/bridge", version = "0.2.0-rc.3" }
+agent-os-bridge = { package = "secure-exec-bridge", path = "../secure-exec/crates/bridge", version = "0.3.0-rc.1" }
 agent-os-protocol = { path = "crates/agent-os-protocol", version = "0.2.0-rc.3" }
 agent-os-sidecar = { path = "crates/agent-os-sidecar", version = "0.2.0-rc.3" }
 agent-os-sidecar-browser = { path = "crates/agent-os-sidecar-browser", version = "0.2.0-rc.3" }
-agent-os-kernel = { package = "secure-exec-kernel", path = "../secure-exec/crates/kernel", version = "0.2.0-rc.3" }
-agent-os-execution = { package = "secure-exec-execution", path = "../secure-exec/crates/execution", version = "0.2.0-rc.3" }
-agent-os-v8-runtime = { package = "secure-exec-v8-runtime", path = "../secure-exec/crates/v8-runtime", version = "0.2.0-rc.3" }
-secure-exec-client = { path = "../secure-exec/crates/secure-exec-client", version = "0.2.0-rc.3" }
-secure-exec-bridge = { path = "../secure-exec/crates/bridge", version = "0.2.0-rc.3" }
-secure-exec-sidecar = { path = "../secure-exec/crates/sidecar", version = "0.2.0-rc.3" }
-secure-exec-sidecar-browser = { path = "../secure-exec/crates/sidecar-browser", version = "0.2.0-rc.3" }
-secure-exec-vm-config = { path = "../secure-exec/crates/vm-config", version = "0.2.0-rc.3" }
+agent-os-kernel = { package = "secure-exec-kernel", path = "../secure-exec/crates/kernel", version = "0.3.0-rc.1" }
+agent-os-execution = { package = "secure-exec-execution", path = "../secure-exec/crates/execution", version = "0.3.0-rc.1" }
+agent-os-v8-runtime = { package = "secure-exec-v8-runtime", path = "../secure-exec/crates/v8-runtime", version = "0.3.0-rc.1" }
+secure-exec-client = { path = "../secure-exec/crates/secure-exec-client", version = "0.3.0-rc.1" }
+secure-exec-bridge = { path = "../secure-exec/crates/bridge", version = "0.3.0-rc.1" }
+secure-exec-sidecar = { path = "../secure-exec/crates/sidecar", version = "0.3.0-rc.1" }
+secure-exec-sidecar-browser = { path = "../secure-exec/crates/sidecar-browser", version = "0.3.0-rc.1" }
+secure-exec-vm-config = { path = "../secure-exec/crates/vm-config", version = "0.3.0-rc.1" }
 vbare = "0.0.4"
 vbare-compiler = { package = "rivet-vbare-compiler", version = "0.0.5" }

--- a/crates/agent-os-sidecar/src/acp_extension.rs
+++ b/crates/agent-os-sidecar/src/acp_extension.rs
@@ -348,9 +348,8 @@ impl AcpExtension {
     ) -> Result<AcpResponse, SidecarError> {
         let caller_connection_id = ownership_connection_id(ctx.ownership());
         let sessions = self.sessions.lock().await;
-        let unknown = || {
-            SidecarError::InvalidState(format!("unknown ACP session {}", request.session_id))
-        };
+        let unknown =
+            || SidecarError::InvalidState(format!("unknown ACP session {}", request.session_id));
         let session = sessions.get(&request.session_id).ok_or_else(unknown)?;
         // Enforce per-connection ownership: a session may only be read by the
         // connection that created it. Fail closed with the same error a missing

--- a/crates/agent-os-sidecar/tests/acp_extension.rs
+++ b/crates/agent-os-sidecar/tests/acp_extension.rs
@@ -371,7 +371,12 @@ fn acp_get_session_state_denies_cross_connection_session_id() {
     );
     let attacker_session = open_session(&mut sidecar, &attacker_conn);
     let attacker_cwd = temp_dir("agent-os-acp-cross-conn-attacker-cwd");
-    let attacker_vm = create_vm(&mut sidecar, &attacker_conn, &attacker_session, &attacker_cwd);
+    let attacker_vm = create_vm(
+        &mut sidecar,
+        &attacker_conn,
+        &attacker_session,
+        &attacker_cwd,
+    );
 
     let leaked = dispatch_acp(
         &mut sidecar,

--- a/crates/client/src/agent_os.rs
+++ b/crates/client/src/agent_os.rs
@@ -341,7 +341,6 @@ impl AgentOs {
                     instructions: config.additional_instructions.clone().into_iter().collect(),
                     projected_modules: Vec::new(),
                     command_permissions: HashMap::new(),
-                    allowed_node_builtins: config.allowed_node_builtins.clone().unwrap_or_default(),
                     loopback_exempt_ports: config.loopback_exempt_ports.clone(),
                 }),
             )
@@ -798,6 +797,18 @@ fn serialize_create_vm_config_for_sidecar(
         native_root,
         listen: None,
         loopback_exempt_ports: config.loopback_exempt_ports.clone(),
+        // 0.3: the Node builtin allow-list moved from ConfigureVmRequest to
+        // VM creation. `None` => engine default allow-list; `Some([..])` =>
+        // exactly those (`Some([])` denies all). Platform/module-resolution
+        // keep their engine defaults (full Node emulation), matching prior
+        // behavior where Agent OS only ever constrained the builtin allow-list.
+        js_runtime: config.allowed_node_builtins.as_ref().map(|allowed| {
+            vm_config::JsRuntimeConfig {
+                platform: vm_config::JsRuntimePlatform::default(),
+                module_resolution: vm_config::JsModuleResolution::default(),
+                allowed_builtins: Some(allowed.clone()),
+            }
+        }),
     })
 }
 

--- a/crates/client/src/session.rs
+++ b/crates/client/src/session.rs
@@ -644,102 +644,6 @@ impl Drop for PendingSessionRequestGuard<'_> {
     }
 }
 
-// Private accumulator coverage stays inline because integration tests cannot construct the missed
-// broadcast plus hydrated-ring ordering without exposing client internals.
-#[cfg(test)]
-mod prompt_accumulation_tests {
-    use super::*;
-
-    fn notification(update: Value) -> JsonRpcNotification {
-        JsonRpcNotification {
-            jsonrpc: "2.0".to_string(),
-            method: "session/update".to_string(),
-            params: Some(json!({ "update": update })),
-        }
-    }
-
-    #[test]
-    fn non_chunk_events_do_not_affect_prompt_text() {
-        let chunk = notification(json!({
-            "sessionUpdate": "agent_message_chunk",
-            "content": { "text": "hello" },
-        }));
-        let non_chunk = notification(json!({
-            "sessionUpdate": "current_mode_update",
-            "currentModeId": "default",
-        }));
-
-        let mut delivered_chunks = 0;
-        let mut text = String::new();
-        accumulate_agent_message_chunk(&non_chunk, &mut delivered_chunks, &mut text)
-            .expect("non-chunk");
-        accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text).expect("chunk");
-
-        assert_eq!(text, "hello");
-    }
-
-    #[test]
-    fn prompt_text_capture_limit_rejects_overflowing_chunk() {
-        let chunk = notification(json!({
-            "sessionUpdate": "agent_message_chunk",
-            "content": { "text": "abcd" },
-        }));
-        let mut delivered_chunks = 0;
-        let mut text = "x".repeat(PROMPT_TEXT_CAPTURE_LIMIT_BYTES - 3);
-        let error = accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text)
-            .expect_err("chunk should exceed prompt text cap");
-        assert!(
-            error.to_string().contains("prompt text capture is"),
-            "unexpected error: {error}"
-        );
-        assert_eq!(text.len(), PROMPT_TEXT_CAPTURE_LIMIT_BYTES - 3);
-    }
-
-    #[test]
-    fn prompt_chunk_limit_rejects_more_tracked_chunks() {
-        let chunk = notification(json!({
-            "sessionUpdate": "agent_message_chunk",
-            "content": { "text": "x" },
-        }));
-        let mut delivered_chunks = PROMPT_DELIVERED_CHUNK_LIMIT;
-        let mut text = String::new();
-        let error = accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text)
-            .expect_err("chunk should exceed chunk tracking cap");
-        assert!(
-            error
-                .to_string()
-                .contains("prompt chunk tracking limit exceeded"),
-            "unexpected error: {error}"
-        );
-        assert!(text.is_empty());
-    }
-
-    #[test]
-    fn pending_session_request_count_tracks_registered_resolvers() {
-        let (event_tx, _) = tokio::sync::broadcast::channel(1);
-        let (permission_tx, _) = tokio::sync::broadcast::channel(1);
-        let entry = SessionEntry {
-            agent_type: "pi".to_string(),
-            modes: parking_lot::Mutex::new(None),
-            config_options: parking_lot::Mutex::new(Vec::new()),
-            capabilities: parking_lot::Mutex::new(None),
-            agent_info: parking_lot::Mutex::new(None),
-            config_overrides: parking_lot::Mutex::new(BTreeMap::new()),
-            event_tx,
-            permission_tx,
-            pending_permission_replies: scc::HashMap::new(),
-            pending_session_request_lock: parking_lot::Mutex::new(()),
-            pending_prompt_resolvers: scc::HashMap::new(),
-        };
-        let (first_tx, _first_rx) = tokio::sync::oneshot::channel();
-        let (second_tx, _second_rx) = tokio::sync::oneshot::channel();
-        let _ = entry.pending_prompt_resolvers.insert(1, first_tx);
-        let _ = entry.pending_prompt_resolvers.insert(2, second_tx);
-
-        assert_eq!(pending_session_request_count(&entry), 2);
-    }
-}
-
 /// Re-apply synthetic config overrides onto the cached config options. Mirrors
 /// `_applySyntheticConfigOverrides`.
 fn apply_synthetic_config_overrides(entry: &SessionEntry) {
@@ -2023,5 +1927,101 @@ impl AgentOs {
                 }
             }
         }
+    }
+}
+
+// Private accumulator coverage stays inline because integration tests cannot construct the missed
+// broadcast plus hydrated-ring ordering without exposing client internals.
+#[cfg(test)]
+mod prompt_accumulation_tests {
+    use super::*;
+
+    fn notification(update: Value) -> JsonRpcNotification {
+        JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "session/update".to_string(),
+            params: Some(json!({ "update": update })),
+        }
+    }
+
+    #[test]
+    fn non_chunk_events_do_not_affect_prompt_text() {
+        let chunk = notification(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "text": "hello" },
+        }));
+        let non_chunk = notification(json!({
+            "sessionUpdate": "current_mode_update",
+            "currentModeId": "default",
+        }));
+
+        let mut delivered_chunks = 0;
+        let mut text = String::new();
+        accumulate_agent_message_chunk(&non_chunk, &mut delivered_chunks, &mut text)
+            .expect("non-chunk");
+        accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text).expect("chunk");
+
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn prompt_text_capture_limit_rejects_overflowing_chunk() {
+        let chunk = notification(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "text": "abcd" },
+        }));
+        let mut delivered_chunks = 0;
+        let mut text = "x".repeat(PROMPT_TEXT_CAPTURE_LIMIT_BYTES - 3);
+        let error = accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text)
+            .expect_err("chunk should exceed prompt text cap");
+        assert!(
+            error.to_string().contains("prompt text capture is"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(text.len(), PROMPT_TEXT_CAPTURE_LIMIT_BYTES - 3);
+    }
+
+    #[test]
+    fn prompt_chunk_limit_rejects_more_tracked_chunks() {
+        let chunk = notification(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "text": "x" },
+        }));
+        let mut delivered_chunks = PROMPT_DELIVERED_CHUNK_LIMIT;
+        let mut text = String::new();
+        let error = accumulate_agent_message_chunk(&chunk, &mut delivered_chunks, &mut text)
+            .expect_err("chunk should exceed chunk tracking cap");
+        assert!(
+            error
+                .to_string()
+                .contains("prompt chunk tracking limit exceeded"),
+            "unexpected error: {error}"
+        );
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn pending_session_request_count_tracks_registered_resolvers() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(1);
+        let (permission_tx, _) = tokio::sync::broadcast::channel(1);
+        let entry = SessionEntry {
+            agent_type: "pi".to_string(),
+            modes: parking_lot::Mutex::new(None),
+            config_options: parking_lot::Mutex::new(Vec::new()),
+            capabilities: parking_lot::Mutex::new(None),
+            agent_info: parking_lot::Mutex::new(None),
+            config_overrides: parking_lot::Mutex::new(BTreeMap::new()),
+            event_tx,
+            permission_tx,
+            pending_permission_replies: scc::HashMap::new(),
+            pending_session_request_lock: parking_lot::Mutex::new(()),
+            pending_prompt_resolvers: scc::HashMap::new(),
+        };
+        let (first_tx, _first_rx) = tokio::sync::oneshot::channel();
+        let (second_tx, _second_rx) = tokio::sync::oneshot::channel();
+        let _ = entry.pending_prompt_resolvers.insert(1, first_tx);
+        let _ = entry.pending_prompt_resolvers.insert(2, second_tx);
+
+        assert_eq!(pending_session_request_count(&entry), 2);
     }
 }

--- a/crates/client/tests/os_instructions_e2e.rs
+++ b/crates/client/tests/os_instructions_e2e.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use agent_os_client::config::{
@@ -119,7 +119,7 @@ async fn launch_pi_session_with_tools_and_read_argv(
 }
 
 async fn run_session(
-    module_access_dir: &PathBuf,
+    module_access_dir: &Path,
     options: CreateSessionOptions,
     tool_kits: Vec<ToolKit>,
 ) -> Vec<String> {
@@ -156,7 +156,7 @@ async fn run_session(
     argv
 }
 
-fn injected_prompt<'a>(argv: &'a [String]) -> &'a str {
+fn injected_prompt(argv: &[String]) -> &str {
     let idx = argv
         .iter()
         .position(|arg| arg == "--append-system-prompt")

--- a/crates/client/tests/pi_session_e2e.rs
+++ b/crates/client/tests/pi_session_e2e.rs
@@ -58,6 +58,10 @@ struct LlmockServer {
 }
 
 impl LlmockServer {
+    // The spawned child is owned by `LlmockServer`, whose `Drop` kills and
+    // waits it; the only path that skips construction is an `assert!` that
+    // aborts the test process, so the zombie-process lint does not apply.
+    #[allow(clippy::zombie_processes)]
     fn start() -> Self {
         let root = repo_root();
         let mut child = Command::new("node")

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -2531,6 +2531,21 @@ export class AgentOs {
 					permissions: sidecarPermissions,
 					limits: options?.limits,
 					loopbackExemptPorts: options?.loopbackExemptPorts ?? [],
+					// 0.3: the Node builtin allow-list moved from configureVm to
+					// VM creation. `undefined` => engine default allow-list;
+					// `[]` => deny all; `[..]` => exactly those. Platform and
+					// module resolution keep their engine defaults (full Node
+					// emulation), matching the prior behavior where Agent OS only
+					// constrained the builtin allow-list.
+					...(options?.allowedNodeBuiltins !== undefined
+						? {
+								jsRuntime: {
+									platform: "node" as const,
+									moduleResolution: "node" as const,
+									allowedBuiltins: options.allowedNodeBuiltins,
+								},
+							}
+						: {}),
 				};
 				const nativeVm = await client.createVm(session, {
 					runtime: "java_script",
@@ -2546,7 +2561,6 @@ export class AgentOs {
 					mounts: sidecarMounts,
 					permissions: sidecarPermissions,
 					commandPermissions: processed.commandPermissions,
-					allowedNodeBuiltins: options?.allowedNodeBuiltins,
 					loopbackExemptPorts: options?.loopbackExemptPorts,
 				});
 				if (toolKits && toolKits.length > 0) {

--- a/packages/core/src/sidecar/rpc-client.ts
+++ b/packages/core/src/sidecar/rpc-client.ts
@@ -3,7 +3,7 @@ import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import { posix as posixPath } from "node:path";
 import type {
-	RootFilesystemConfig,
+	RootFilesystemConfig as VmConfigRootFilesystemConfig,
 	RootFilesystemEntry as VmConfigRootFilesystemEntry,
 	RootFilesystemLowerDescriptor as VmConfigRootFilesystemLowerDescriptor,
 } from "@secure-exec/core/vm-config";
@@ -2660,7 +2660,7 @@ export function serializeMountConfigForSidecar(
 	};
 }
 
-export type SidecarRootFilesystemDescriptor = RootFilesystemConfig;
+export type SidecarRootFilesystemDescriptor = VmConfigRootFilesystemConfig;
 export type SidecarRootFilesystemLowerDescriptor =
 	VmConfigRootFilesystemLowerDescriptor;
 export type SidecarRootFilesystemEntry = VmConfigRootFilesystemEntry;

--- a/packages/core/tests/generated-protocol.test.ts
+++ b/packages/core/tests/generated-protocol.test.ts
@@ -104,7 +104,6 @@ describe("generated sidecar protocol", () => {
 							{ packageName: "workspace", entrypoint: "/workspace/index.js" },
 						],
 						commandPermissions: new Map([["cat", WasmPermissionTier.ReadOnly]]),
-						allowedNodeBuiltins: ["fs"],
 						loopbackExemptPorts: new Uint16Array([3000]),
 					},
 				},
@@ -140,7 +139,6 @@ describe("generated sidecar protocol", () => {
 					{ package_name: "workspace", entrypoint: "/workspace/index.js" },
 				],
 				command_permissions: { cat: "read-only" },
-				allowed_node_builtins: ["fs"],
 				loopback_exempt_ports: [3000],
 			},
 		};
@@ -302,7 +300,6 @@ describe("generated sidecar protocol", () => {
 						instructions: [],
 						projectedModules: [],
 						commandPermissions: new Map(),
-						allowedNodeBuiltins: [],
 						loopbackExemptPorts: new Uint16Array(),
 					},
 				},

--- a/packages/core/tests/root-filesystem-descriptors.test.ts
+++ b/packages/core/tests/root-filesystem-descriptors.test.ts
@@ -77,7 +77,7 @@ describe("sidecar root filesystem descriptors", () => {
 				bootstrapLower,
 			),
 		).toEqual({
-			mode: "read_only",
+			mode: "read-only",
 			disableDefaultBaseLayer: true,
 			lowers: [
 				{
@@ -108,7 +108,7 @@ describe("sidecar root filesystem descriptors", () => {
 		expect(descriptor.bootstrapEntries).toEqual([]);
 		expect(descriptor.lowers).toHaveLength(1);
 		expect(descriptor.lowers[0]).toEqual({
-			kind: "bundled_base_filesystem",
+			kind: "bundledBaseFilesystem",
 		});
 	});
 });


### PR DESCRIPTION
## What

Repins agent-os from the stale `secure-exec` `0.2.0-rc.3` to the current `0.3.0-rc.1` and fixes the resulting API drift. This is the version skew that has been **reding `main` CI** and blocking every agent-os `cargo`/VM-booting test from even resolving dependencies.

## Changes

**Pins** — root `Cargo.toml`: the 9 `../secure-exec` path-dep version requirements `0.2.0-rc.3` → `0.3.0-rc.1`. agent-os's own version (line 11) and own crates (agent-os-protocol/sidecar/sidecar-browser) are unchanged.

**The 0.3 allowed-builtins model migration** (behavior-preserving): the Node builtin allow-list moved out of `ConfigureVmRequest` and into VM **creation** as `CreateVmConfig.js_runtime` → `JsRuntimeConfig.allowedBuiltins`.
- `crates/client/src/agent_os.rs`: drop `allowed_node_builtins` from `ConfigureVmRequest`; set `js_runtime` on the `CreateVmConfig` from `serialize_create_vm_config_for_sidecar`. That single config feeds **both** the native-sidecar path and the wire/transport path (it's `serde_json`-serialized into `CreateVmRequest.config`), so `AgentOsConfig.allowed_node_builtins` still reaches the guest. Tri-state preserved: `None` → engine default, `Some([])` → deny all, `Some([..])` → exactly those.
- `packages/core/src/agent-os.ts`: mirror — drop `allowedNodeBuiltins` from `configureVm`, set `jsRuntime.allowedBuiltins` on create (only when defined).
- `packages/core/src/sidecar/rpc-client.ts`: disambiguate the now-duplicate `RootFilesystemConfig` export (alias the vm-config one used by the serializer descriptor).

**Test fixtures** updated to 0.3 wire shapes (no behavior change): `generated-protocol.test.ts` (drop removed field), `root-filesystem-descriptors.test.ts` (`read_only`→`read-only`, `bundled_base_filesystem`→`bundledBaseFilesystem`).

**Incidental CI-gate cleanups** in files touched anyway: a clippy `items_after_test_module` relocation in `session.rs`, `&PathBuf`→`&Path` + lifetime elision + a `zombie_processes` allow in client e2e tests, and `cargo fmt` normalization. `Cargo.lock` refreshed.

## Verification (local, against secure-exec 0.3.0-rc.1)
- `cargo build --workspace`, `cargo test --workspace --no-run`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: **all clean**.
- `pnpm -C packages/core run check-types` + `build`: **pass**.
- `cargo test -p agent-os-client -p agent-os-sidecar -p agent-os-sidecar-browser`: **all pass** (client 35/35, sidecar 13/13, e2e green).
- `pnpm -C packages/core test`: the repin-affected tests pass; the remaining failures are pre-existing **missing build artifacts** (WASM registry commands + agent-adapter `dist/`), independent of this change.

## CI note
The deps are path deps to `../secure-exec`, so CI needs the sibling checkout from #1486 to resolve them (secure-exec `main` is `0.3.0-rc.1`). This PR + #1486 together green `main` CI without requiring a secure-exec publish.