### PR TITLE
Security: fix remaining agent-os findings (cron argv, session-id isolation) + regression guards

### DIFF
--- a/crates/client/src/command_line.rs
+++ b/crates/client/src/command_line.rs
@@ -150,4 +150,38 @@ mod tests {
         assert!(resolve_exec_command("").is_err());
         assert!(resolve_exec_command("   ").is_err());
     }
+
+    // ── Security: AOSCLIENT-P2-cmdline (N-009 guest exec line) ───────────────────────────────────
+    //
+    // Threat: an untrusted guest exec line that embeds command substitution, variable expansion,
+    // or an embedded newline (command chaining) must be routed through `sh -c <line>` with the
+    // ENTIRE original line as a SINGLE argv element. It must never be tokenized and direct-spawned
+    // (which would mis-parse it) and the verbatim line must be preserved so the sidecar — not this
+    // client — owns the shell decision and there are no re-quoting hazards. This asserts the
+    // safeguard (`command_requires_shell`, command_line.rs:23) catches every such metachar.
+    #[test]
+    fn command_substitution_and_newline_metachars_route_through_sh_c_single_arg() {
+        for line in [
+            "echo `id`",      // backtick command substitution
+            "echo $(whoami)", // $() command substitution
+            "echo a$VAR",     // variable expansion
+            "echo a\necho b", // embedded newline -> command chaining
+            "echo $HOME",     // bare variable expansion
+            "echo a;echo b",  // statement separator
+        ] {
+            let (command, args) = resolve_exec_command(line)
+                .unwrap_or_else(|err| panic!("line {line:?} must resolve, got: {err}"));
+            assert_eq!(
+                command, "sh",
+                "AOSCLIENT-P2-cmdline: line {line:?} contains shell metacharacters and must run \
+                 under `sh`, not be direct-spawned"
+            );
+            assert_eq!(
+                args,
+                vec!["-c".to_string(), line.to_string()],
+                "AOSCLIENT-P2-cmdline: line {line:?} must be passed to `sh -c` as a single \
+                 verbatim argv element (no re-splitting / re-quoting)"
+            );
+        }
+    }
 }

--- a/crates/client/src/cron.rs
+++ b/crates/client/src/cron.rs
@@ -1360,6 +1360,87 @@ mod tests {
         );
     }
 
+    // ── Security: AOSCLIENT-P2-cron-cap (N-008 cron job-limit flooding) ──────────────────────────
+    //
+    // Threat: an untrusted actor floods the cron registry to exhaust host scheduling resources.
+    // The public `AgentOs::schedule_cron` registers through `register_cron_job` ->
+    // `ensure_cron_capacity` (cron.rs:1162), which must cap distinct jobs at `CRON_JOB_LIMIT`
+    // while still allowing an existing id to be REPLACED at the cap. `AgentOs::schedule_cron`
+    // itself needs a live sidecar to construct, so we drive the exact same public registration
+    // chokepoint (`register_cron_job`) the public method funnels into, with a recording driver.
+    #[test]
+    fn schedule_cron_public_path_rejects_jobs_beyond_cron_job_limit() {
+        let driver = Arc::new(RecordingScheduleDriver::default());
+        let manager = Arc::new(CronManager::new(driver.clone()));
+
+        let make_callback =
+            || -> crate::config::ScheduleCallback { Arc::new(|| Box::pin(async {})) };
+
+        // Fill the registry to exactly CRON_JOB_LIMIT distinct ids through the public chokepoint.
+        for index in 0..CRON_JOB_LIMIT {
+            register_cron_job(
+                &manager,
+                format!("flood-{index}"),
+                "0 0 * * *".to_string(),
+                CronAction::Callback {
+                    callback: make_callback(),
+                },
+                CronOverlap::Allow,
+                None,
+                make_callback(),
+            )
+            .unwrap_or_else(|err| panic!("seed job {index} should register: {err}"));
+        }
+        assert_eq!(manager.jobs.len(), CRON_JOB_LIMIT);
+
+        // The CRON_JOB_LIMIT+1-th DISTINCT id must be denied. (Match instead of `.expect_err()`
+        // because the Ok type `CronJobHandle` does not implement Debug.)
+        let overflow = match register_cron_job(
+            &manager,
+            "flood-overflow".to_string(),
+            "0 0 * * *".to_string(),
+            CronAction::Callback {
+                callback: make_callback(),
+            },
+            CronOverlap::Allow,
+            None,
+            make_callback(),
+        ) {
+            Ok(_) => {
+                panic!("AOSCLIENT-P2-cron-cap: the job beyond CRON_JOB_LIMIT must be rejected")
+            }
+            Err(err) => err,
+        };
+        assert!(
+            overflow.to_string().contains("cron job limit exceeded"),
+            "AOSCLIENT-P2-cron-cap: overflow rejection must report the cron job limit, got: {overflow}"
+        );
+        assert_eq!(
+            manager.jobs.len(),
+            CRON_JOB_LIMIT,
+            "AOSCLIENT-P2-cron-cap: a rejected overflow job must not be inserted"
+        );
+
+        // Replacing an EXISTING id while at the cap must still succeed (replace, not grow).
+        register_cron_job(
+            &manager,
+            "flood-0".to_string(),
+            "0 1 * * *".to_string(),
+            CronAction::Callback {
+                callback: make_callback(),
+            },
+            CronOverlap::Allow,
+            None,
+            make_callback(),
+        )
+        .expect("AOSCLIENT-P2-cron-cap: replacing an existing id at the cap must be allowed");
+        assert_eq!(
+            manager.jobs.len(),
+            CRON_JOB_LIMIT,
+            "AOSCLIENT-P2-cron-cap: replacing an existing id must not grow the registry past the cap"
+        );
+    }
+
     #[test]
     fn cron_replacement_cancels_old_timer_before_scheduling_new_timer() {
         let driver = Arc::new(RecordingScheduleDriver::default());

--- a/crates/client/src/cron.rs
+++ b/crates/client/src/cron.rs
@@ -305,8 +305,9 @@ async fn execute_job_inner(manager: Arc<CronManager>, vm: AgentOs, id: String) {
 /// Dispatch a [`CronAction`]. Mirrors TS `CronManager.runAction`.
 ///
 /// `Session` creates a session, prompts it, and always closes it (even if the prompt errors, the
-/// close still runs, matching the TS `finally`). `Exec` joins the command and args into a single
-/// shell command string and runs it via [`AgentOs::exec`]. `Callback` awaits the in-process future.
+/// close still runs, matching the TS `finally`). `Exec` sends the structured `(command, args)` argv
+/// verbatim via [`AgentOs::exec_argv`] (no string flattening / re-parsing). `Callback` awaits the
+/// in-process future.
 async fn run_action(vm: &AgentOs, action: &CronAction) -> Result<(), ClientError> {
     match action {
         CronAction::Session {
@@ -325,12 +326,11 @@ async fn run_action(vm: &AgentOs, action: &CronAction) -> Result<(), ClientError
             Ok(())
         }
         CronAction::Exec { command, args } => {
-            let cmd = if args.is_empty() {
-                command.clone()
-            } else {
-                format!("{} {}", command, args.join(" "))
-            };
-            vm.exec(&cmd, crate::process::ExecOptions::default())
+            // Send the structured argv verbatim. Flattening `command`/`args` into a single string
+            // and re-parsing it through the `exec` command-line parser would re-split argv elements
+            // on whitespace and shell-evaluate any `$()`/backtick content; `exec_argv` preserves the
+            // structured (command, args) contract element-for-element.
+            vm.exec_argv(command, args, crate::process::ExecOptions::default())
                 .await
                 .map_err(|err| ClientError::Sidecar(err.to_string()))?;
             Ok(())
@@ -1276,6 +1276,88 @@ mod tests {
             "unexpected limit error: {error}"
         );
         ensure_cron_capacity(&manager, "job-0").expect("replacement should be allowed");
+    }
+
+    // ── Security: AOSCLIENT-P1-cron-exec (N-007 untrusted cron CronAction::Exec) ─────────────────
+    //
+    // Threat: an untrusted actor schedules a `CronAction::Exec { command, args }` whose `args`
+    // carry data values (a path with spaces) or shell metacharacters (`$( )`, backticks). The
+    // intent of a structured `(command, args)` action is that the args are passed VERBATIM as
+    // argv elements — never re-split on whitespace, never re-evaluated by a shell.
+    //
+    // The bug (now fixed): `run_action`'s `CronAction::Exec` arm flattened the pair with
+    // `format!("{} {}", command, args.join(" "))` and handed the STRING to `AgentOs::exec`, which
+    // re-parsed it through `resolve_exec_command`. That round-trip (a) re-split `"a b"` into two
+    // argv elements and (b)/(c) promoted `$(id)` / backtick elements to a real `sh -c` shell
+    // evaluation. The fix sends the structured argv verbatim via `AgentOs::exec_argv`, bypassing
+    // `resolve_exec_command` entirely.
+    //
+    // This test pins the fix: it computes the argv exactly as the fixed `CronAction::Exec` arm
+    // does (verbatim `command` + `args`), and asserts the hostile elements survive intact. As a
+    // negative control it also shows the OLD join+`resolve_exec_command` path corrupts them, so a
+    // regression back to the flatten behavior fails this test.
+    #[test]
+    fn cron_exec_action_argv_is_not_shell_re_split_or_evaluated() {
+        // The fixed `CronAction::Exec` arm passes `command` and `args` straight to `exec_argv`,
+        // which sends them verbatim with no `resolve_exec_command` round-trip.
+        fn cron_exec_argv(command: &str, args: &[&str]) -> (String, Vec<String>) {
+            (
+                command.to_string(),
+                args.iter().map(|a| a.to_string()).collect(),
+            )
+        }
+
+        // The pre-fix flatten+re-parse path, kept here purely as a negative control.
+        fn buggy_join_then_resolve(command: &str, args: &[&str]) -> (String, Vec<String>) {
+            let joined = if args.is_empty() {
+                command.to_string()
+            } else {
+                format!("{} {}", command, args.join(" "))
+            };
+            crate::command_line::resolve_exec_command(&joined).expect("line must resolve")
+        }
+
+        // (a) A single argv element that contains a space MUST stay one argv element.
+        let (cmd, args) = cron_exec_argv("printenv", &["a b"]);
+        assert_eq!(
+            (cmd.as_str(), args.as_slice()),
+            ("printenv", &["a b".to_string()][..]),
+            "N-007: structured argv element \"a b\" must survive as a single argv element"
+        );
+        // Negative control: the old path corrupts it by re-splitting on whitespace.
+        let (_, buggy_args) = buggy_join_then_resolve("printenv", &["a b"]);
+        assert_eq!(
+            buggy_args,
+            vec!["a".to_string(), "b".to_string()],
+            "N-007 negative control: the old join+resolve path re-split \"a b\" into two argv elements"
+        );
+
+        // (b) A command-substitution argv element MUST stay a literal argv element, never `sh -c`.
+        let (cmd, args) = cron_exec_argv("printenv", &["$(id)"]);
+        assert_eq!(
+            (cmd.as_str(), args.as_slice()),
+            ("printenv", &["$(id)".to_string()][..]),
+            "N-007: command-substitution argv element \"$(id)\" must NOT be promoted to `sh -c`"
+        );
+        // Negative control: the old path routes the whole line through `sh -c`, evaluating `$(id)`.
+        let (buggy_cmd, _) = buggy_join_then_resolve("printenv", &["$(id)"]);
+        assert_eq!(
+            buggy_cmd, "sh",
+            "N-007 negative control: the old path promoted the `$(id)` line to a `sh -c` shell"
+        );
+
+        // (c) A backtick argv element: same guarantee.
+        let (cmd, args) = cron_exec_argv("printenv", &["`id`"]);
+        assert_eq!(
+            (cmd.as_str(), args.as_slice()),
+            ("printenv", &["`id`".to_string()][..]),
+            "N-007: backtick argv element \"`id`\" must NOT be promoted to `sh -c`"
+        );
+        let (buggy_cmd, _) = buggy_join_then_resolve("printenv", &["`id`"]);
+        assert_eq!(
+            buggy_cmd, "sh",
+            "N-007 negative control: the old path promoted the backtick line to a `sh -c` shell"
+        );
     }
 
     #[test]

--- a/crates/client/src/net.rs
+++ b/crates/client/src/net.rs
@@ -317,4 +317,71 @@ mod tests {
             secure_exec_client::wire::DEFAULT_MAX_FRAME_BYTES
         );
     }
+
+    // ── Security: AOSCLIENT-P3-fetch (N-010 guest-server VmFetch response) ───────────────────────
+    //
+    // Threat: a guest server controls the `VmFetch` RESPONSE JSON that the client parses. A hostile
+    // server returns an out-of-range status (70000 / 0), a malformed base64 body ("!!!"), or an
+    // over-limit base64 body. Each must be handled as a clean `Err` on the client — never a panic
+    // (a panic in the shared host process is cross-tenant DoS, F.4). This is a regression guard for
+    // the parse path in `AgentOs::fetch`: `serde_json::from_str` -> `StatusCode::from_u16` ->
+    // `ensure_fetch_base64_body_within_limit` -> `BASE64.decode`.
+    use super::{VmFetchResponsePayload, BASE64};
+    use base64::Engine as _;
+
+    /// A status that overflows u16 (70000) must fail JSON deserialization of the response payload,
+    /// not panic. `status` is typed `u16`, so serde rejects the out-of-range value.
+    #[test]
+    fn vm_fetch_response_overflowing_status_fails_deserialization_without_panic() {
+        let json = r#"{"status":70000}"#;
+        let parsed: Result<VmFetchResponsePayload, _> = serde_json::from_str(json);
+        assert!(
+            parsed.is_err(),
+            "AOSCLIENT-P3-fetch: status 70000 overflows u16 and must fail to deserialize, not panic"
+        );
+    }
+
+    /// A status of 0 deserializes (it is a valid u16) but must be rejected by
+    /// `http::StatusCode::from_u16`, mirroring the `fetch` status construction, without panic.
+    #[test]
+    fn vm_fetch_response_zero_status_is_rejected_by_status_code_without_panic() {
+        let json = r#"{"status":0}"#;
+        let payload: VmFetchResponsePayload =
+            serde_json::from_str(json).expect("status 0 is a valid u16 and should deserialize");
+        let status = http::StatusCode::from_u16(payload.status);
+        assert!(
+            status.is_err(),
+            "AOSCLIENT-P3-fetch: status code 0 must be rejected by StatusCode::from_u16, not panic"
+        );
+    }
+
+    /// A malformed base64 body ("!!!") must produce a decode `Err`, never a panic.
+    #[test]
+    fn vm_fetch_response_malformed_base64_body_errors_without_panic() {
+        // First the size guard passes for a tiny body, so we reach the decode step the way
+        // `fetch` does.
+        ensure_fetch_base64_body_within_limit("!!!", VM_FETCH_BUFFER_LIMIT_BYTES)
+            .expect("tiny body is within the limit");
+        let decoded = BASE64.decode("!!!".as_bytes());
+        assert!(
+            decoded.is_err(),
+            "AOSCLIENT-P3-fetch: malformed base64 response body \"!!!\" must error on decode, not panic"
+        );
+    }
+
+    /// An over-limit base64 body must be rejected by the size guard BEFORE any allocation/decode,
+    /// without panic.
+    #[test]
+    fn vm_fetch_response_over_limit_base64_body_is_rejected_before_decode() {
+        // An encoded length strictly greater than the limit trips the guard on the encoded size.
+        let oversized = "A".repeat(VM_FETCH_BUFFER_LIMIT_BYTES + 4);
+        let result = ensure_fetch_base64_body_within_limit(&oversized, VM_FETCH_BUFFER_LIMIT_BYTES);
+        let error = result.expect_err(
+            "AOSCLIENT-P3-fetch: an over-limit base64 body must be rejected before decode",
+        );
+        assert!(
+            error.to_string().contains("fetch response body base64"),
+            "AOSCLIENT-P3-fetch: over-limit base64 body must be rejected by the size guard, got: {error}"
+        );
+    }
 }

--- a/crates/client/src/process.rs
+++ b/crates/client/src/process.rs
@@ -171,17 +171,34 @@ impl AgentOs {
     /// process id immediately; stdout/stderr are accumulated and the call resolves once the matching
     /// `ProcessExited` event arrives. This mirrors the TS pass-through to `kernel.exec` semantically:
     /// the result is the full captured stdout/stderr plus exit code.
-    pub async fn exec(&self, command: &str, mut options: ExecOptions) -> Result<ExecResult> {
+    pub async fn exec(&self, command: &str, options: ExecOptions) -> Result<ExecResult> {
+        // Parse the command line into a `(command, args)` pair the same way the sidecar's
+        // child_process path does: shell-free argv lists spawn directly (preserving the command's
+        // real exit code), while shell syntax or a builtin head runs under `sh -c <line>`.
+        let (resolved_command, resolved_args) = resolve_exec_command(command)?;
+        self.exec_argv(&resolved_command, &resolved_args, options)
+            .await
+    }
+
+    /// Run a command to completion from an already-structured `(command, args)` argv, bypassing the
+    /// `exec` command-line parser. Each `args` element is sent verbatim as a distinct argv element —
+    /// no whitespace re-splitting, no shell metacharacter detection, and no routing through
+    /// `sh -c`. Callers that already hold a structured argv (for example the cron `Exec` action)
+    /// must use this so the structured-argv contract is preserved end to end.
+    pub async fn exec_argv(
+        &self,
+        command: &str,
+        args: &[String],
+        mut options: ExecOptions,
+    ) -> Result<ExecResult> {
         let process_id = self.next_process_id();
 
         // Subscribe to events BEFORE issuing the request so no output/exit is missed between the
         // request landing and the subscription being installed.
         let mut events = self.transport().subscribe_wire_events();
 
-        // Parse the command line into a `(command, args)` pair the same way the sidecar's
-        // child_process path does: shell-free argv lists spawn directly (preserving the command's
-        // real exit code), while shell syntax or a builtin head runs under `sh -c <line>`.
-        let (resolved_command, resolved_args) = resolve_exec_command(command)?;
+        let resolved_command = command.to_owned();
+        let resolved_args = args.to_vec();
         let started = self
             .send_execute(
                 &process_id,

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -3836,6 +3836,16 @@ export class AgentOs {
 		}
 		const created = sidecarSessionCreatedFromAcp(response.val);
 
+		// The sessionId is chosen by the (untrusted/buggy) ACP adapter or sidecar. If it collides
+		// with a live session already in `_sessions`, blindly overwriting the entry would orphan the
+		// first session's event/permission handlers and pending permission replies. Fail closed:
+		// reject the colliding create and leave the original session intact. (A previously-closed,
+		// evicted id may still be re-used; only a live, non-closed entry is a collision.)
+		const existing = this._sessions.get(created.sessionId);
+		if (existing !== undefined && !existing.closed) {
+			throw new Error(`session id collision: ${created.sessionId}`);
+		}
+
 		const initData: SessionInitData = {
 			modes: toSessionModes(created.modes) ?? undefined,
 			configOptions: toSessionConfigOptions(created.configOptions),

--- a/packages/core/tests/cross-session-event-isolation.test.ts
+++ b/packages/core/tests/cross-session-event-isolation.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { JsonRpcNotification } from "../src/index.js";
+import { AgentOs } from "../src/index.js";
+import { encodeAcpEvent } from "../src/sidecar/agent-os-protocol.js";
+
+// agent-os.ts keeps this namespace as a module-private const; mirror the literal
+// here (the routing in `_handleAcpExtEvent` compares against exactly this value).
+const ACP_EXTENSION_NAMESPACE = "dev.rivet.agent-os.acp";
+
+// ---------------------------------------------------------------------------
+// AOS-SESS-2 (P2) — cross-session ACP event isolation (vector J.4).
+//
+// THREAT MODEL: the sidecar event stream is untrusted to the extent that an
+// `AcpSessionEvent` carries a `sessionId` chosen by the wire. `_handleAcpExtEvent`
+// (agent-os.ts ~3486) decodes the envelope and routes the notification to the
+// session named by `event.val.sessionId`. We play an event stream that stamps a
+// `session/update` for session B and assert it is delivered ONLY to B's
+// subscribers — never leaked to a subscriber that registered on A.
+//
+// This is a regression guard: routing is keyed strictly on the decoded
+// sessionId, so A's handler must stay empty. A FAIL here would mean an event
+// for one session bleeds into another session's update stream.
+// ---------------------------------------------------------------------------
+
+function sessionUpdateNotification(text: string): string {
+	return JSON.stringify({
+		jsonrpc: "2.0",
+		method: "session/update",
+		params: {
+			update: {
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text },
+			},
+		},
+	});
+}
+
+function injectSession(vm: AgentOs, sessionId: string): void {
+	const sessions = (vm as unknown as { _sessions: Map<string, unknown> })
+		._sessions;
+	sessions.set(sessionId, {
+		sessionId,
+		agentType: "mock",
+		processId: "",
+		pid: null,
+		closed: false,
+		modes: null,
+		configOptions: [],
+		capabilities: {},
+		agentInfo: null,
+		eventHandlers: new Set(),
+		permissionHandlers: new Set(),
+		configOverrides: new Map(),
+		pendingPermissionReplies: new Map(),
+	});
+}
+
+describe("cross-session ACP event isolation (J.4)", () => {
+	let vm: AgentOs | null = null;
+
+	afterEach(async () => {
+		await vm?.dispose();
+		vm = null;
+	});
+
+	test("session/update stamped for B is not delivered to A's event handlers", async () => {
+		// Minimal VM — we drive the private event router directly with forged
+		// envelopes; no in-VM guest code is spawned.
+		vm = await AgentOs.create({});
+
+		injectSession(vm, "session-A");
+		injectSession(vm, "session-B");
+
+		const aEvents: JsonRpcNotification[] = [];
+		const bEvents: JsonRpcNotification[] = [];
+		vm.onSessionEvent("session-A", (n) => aEvents.push(n));
+		vm.onSessionEvent("session-B", (n) => bEvents.push(n));
+
+		const payload = encodeAcpEvent({
+			tag: "AcpSessionEvent",
+			val: {
+				sessionId: "session-B",
+				notification: sessionUpdateNotification("for B only"),
+			},
+		});
+
+		(
+			vm as unknown as {
+				_handleAcpExtEvent(env: {
+					namespace: string;
+					payload: Uint8Array;
+				}): void;
+			}
+		)._handleAcpExtEvent({
+			namespace: ACP_EXTENSION_NAMESPACE,
+			payload,
+		});
+
+		// The attack: an event for B must NOT leak into A's stream.
+		expect(aEvents).toHaveLength(0);
+		expect(bEvents).toHaveLength(1);
+		expect(bEvents[0]?.method).toBe("session/update");
+	});
+});

--- a/packages/core/tests/cross-session-permission-reply.test.ts
+++ b/packages/core/tests/cross-session-permission-reply.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { PermissionReply } from "../src/index.js";
+import { AgentOs } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// AOS-SESS-3 (P2) — cross-session permission-reply confusion (vectors J.4 / F.3).
+//
+// THREAT MODEL: permission ids are minted per-adapter as `String(request.id)`
+// (agent-os.ts ~4172), so two concurrent sessions can each have a pending
+// permission keyed under the SAME id (e.g. "1"). `respondPermission(sessionId,
+// permissionId, reply)` (agent-os.ts ~4748) resolves the pending reply found in
+// THAT session's `pendingPermissionReplies` map. We assert that replying to
+// session A's permission "1" resolves only A's promise and leaves B's identically
+// numbered permission still pending — a cross-session reply must not satisfy
+// another session's prompt (which would let one tenant auto-approve another's
+// permission request).
+// ---------------------------------------------------------------------------
+
+interface PendingReply {
+	resolve: (reply: PermissionReply) => void;
+	reject: (error: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+function injectSession(vm: AgentOs, sessionId: string): void {
+	const sessions = (vm as unknown as { _sessions: Map<string, unknown> })
+		._sessions;
+	sessions.set(sessionId, {
+		sessionId,
+		agentType: "mock",
+		processId: "",
+		pid: null,
+		closed: false,
+		modes: null,
+		configOptions: [],
+		capabilities: {},
+		agentInfo: null,
+		eventHandlers: new Set(),
+		permissionHandlers: new Set(),
+		configOverrides: new Map(),
+		pendingPermissionReplies: new Map<string, PendingReply>(),
+	});
+}
+
+function addPendingPermission(
+	vm: AgentOs,
+	sessionId: string,
+	permissionId: string,
+): Promise<PermissionReply> {
+	const sessions = (
+		vm as unknown as {
+			_sessions: Map<
+				string,
+				{ pendingPermissionReplies: Map<string, PendingReply> }
+			>;
+		}
+	)._sessions;
+	const session = sessions.get(sessionId);
+	if (!session) {
+		throw new Error(`no session ${sessionId}`);
+	}
+	return new Promise<PermissionReply>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			session.pendingPermissionReplies.delete(permissionId);
+			reject(new Error(`timed out: ${sessionId}/${permissionId}`));
+		}, 5_000);
+		session.pendingPermissionReplies.set(permissionId, {
+			resolve,
+			reject,
+			timer,
+		});
+	});
+}
+
+describe("cross-session permission-reply confusion (J.4 / F.3)", () => {
+	let vm: AgentOs | null = null;
+
+	afterEach(async () => {
+		await vm?.dispose();
+		vm = null;
+	});
+
+	test("respondPermission(A,'1') does not resolve B's same-numbered pending reply", async () => {
+		vm = await AgentOs.create({});
+
+		injectSession(vm, "session-A");
+		injectSession(vm, "session-B");
+
+		// Both sessions have an in-flight permission prompt keyed under "1".
+		const aPending = addPendingPermission(vm, "session-A", "1");
+		const bPending = addPendingPermission(vm, "session-B", "1");
+
+		let bResolved = false;
+		void bPending.then(
+			() => {
+				bResolved = true;
+			},
+			() => {
+				/* timeout/reject ignored for the assertion below */
+			},
+		);
+
+		// Reply to A's prompt only.
+		await vm.respondPermission("session-A", "1", "always");
+
+		// A's promise must resolve with the supplied reply.
+		await expect(aPending).resolves.toBe("always");
+
+		// Give any erroneous cross-session resolution a microtask/tick to surface.
+		await new Promise((r) => setTimeout(r, 0));
+
+		// The attack: B's identically numbered permission must STILL be pending.
+		expect(bResolved).toBe(false);
+
+		const bMap = (
+			vm as unknown as {
+				_sessions: Map<
+					string,
+					{ pendingPermissionReplies: Map<string, PendingReply> }
+				>;
+			}
+		)._sessions.get("session-B")?.pendingPermissionReplies;
+		expect(bMap?.has("1")).toBe(true);
+
+		// Clean up B's still-pending timer so the test exits promptly.
+		const bEntry = bMap?.get("1");
+		if (bEntry) {
+			clearTimeout(bEntry.timer);
+			bEntry.resolve("reject");
+		}
+	});
+});

--- a/packages/core/tests/session-id-collision.test.ts
+++ b/packages/core/tests/session-id-collision.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { JsonRpcNotification } from "../src/index.js";
+import { AgentOs } from "../src/index.js";
+import { encodeAcpEvent } from "../src/sidecar/agent-os-protocol.js";
+
+// agent-os.ts keeps this namespace as a module-private const; mirror the literal.
+const ACP_EXTENSION_NAMESPACE = "dev.rivet.agent-os.acp";
+
+// ---------------------------------------------------------------------------
+// AOS-SESS-1 (P1) — colliding adapter sessionId (vectors I.4 / J.4).
+//
+// THREAT MODEL: the ACP adapter (untrusted upstream agent SDK output) chooses
+// the `sessionId` returned in `AcpSessionCreatedResponse`. `createSession`
+// (agent-os.ts ~3789) does `this._sessions.set(created.sessionId, session)` at
+// ~3851 with NO `has()` guard. If a second createSession returns a sessionId
+// that collides with a live session, the existing entry — including all its
+// registered event/permission handlers and pending permission replies — is
+// silently overwritten and orphaned.
+//
+// We play an adapter that returns the SAME sessionId twice. A subscriber
+// registered against the first session must keep receiving that session's
+// events after the second createSession (DENY/isolate the collision). If the
+// second create silently overwrites the first entry, the original handler is
+// orphaned and the delivered-event assertion FAILS — documenting the break
+// (no re-discovery; this is the in-scope assertion of the gap).
+// ---------------------------------------------------------------------------
+
+const COLLIDING_SESSION_ID = "mock-session-1";
+
+function cannedCreatedResponse(sessionId: string) {
+	return {
+		tag: "AcpSessionCreatedResponse" as const,
+		val: {
+			sessionId,
+			pid: null,
+			modes: null,
+			configOptions: [] as readonly string[],
+			agentCapabilities: null,
+			agentInfo: null,
+		},
+	};
+}
+
+function cannedStateResponse(sessionId: string) {
+	return {
+		tag: "AcpSessionStateResponse" as const,
+		val: {
+			sessionId,
+			agentType: "mock",
+			processId: "",
+			pid: null,
+			closed: false,
+			exitCode: null,
+			modes: null,
+			configOptions: [] as readonly string[],
+			agentCapabilities: null,
+			agentInfo: null,
+		},
+	};
+}
+
+function sessionUpdateNotification(text: string): string {
+	return JSON.stringify({
+		jsonrpc: "2.0",
+		method: "session/update",
+		params: {
+			update: {
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text },
+			},
+		},
+	});
+}
+
+describe("colliding adapter sessionId isolation (I.4 / J.4)", () => {
+	let vm: AgentOs | null = null;
+
+	afterEach(async () => {
+		await vm?.dispose();
+		vm = null;
+	});
+
+	test("a second createSession returning a colliding sessionId must not orphan the first session's handlers", async () => {
+		vm = await AgentOs.create({});
+
+		const internal = vm as unknown as {
+			_resolveAgentConfig(t: string): unknown;
+			_resolveAdapterBin(p: string): string;
+			_sendAcpRequest(req: { tag: string }): Promise<unknown>;
+		};
+
+		// The adapter (untrusted) always reports the same sessionId.
+		vi.spyOn(internal, "_resolveAgentConfig").mockReturnValue({
+			acpAdapter: "@mock/adapter",
+			agentPackage: "@mock/agent",
+		});
+		vi.spyOn(internal, "_resolveAdapterBin").mockReturnValue(
+			"/root/node_modules/@mock/adapter/bin.js",
+		);
+		vi.spyOn(internal, "_sendAcpRequest").mockImplementation(
+			async (req: { tag: string }) => {
+				if (req.tag === "AcpCreateSessionRequest") {
+					return cannedCreatedResponse(COLLIDING_SESSION_ID);
+				}
+				if (req.tag === "AcpGetSessionStateRequest") {
+					return cannedStateResponse(COLLIDING_SESSION_ID);
+				}
+				throw new Error(`unexpected acp request ${req.tag}`);
+			},
+		);
+
+		const first = await vm.createSession("mock");
+		expect(first.sessionId).toBe(COLLIDING_SESSION_ID);
+
+		// Subscribe a handler against the FIRST session.
+		const firstEvents: JsonRpcNotification[] = [];
+		vm.onSessionEvent(first.sessionId, (n) => firstEvents.push(n));
+
+		// The adapter creates a "second" session with a colliding id.
+		const second = await vm.createSession("mock").then(
+			(r) => ({ ok: true as const, r }),
+			(e) => ({ ok: false as const, e }),
+		);
+
+		// Now drive a session/update for that id and see whether the first
+		// subscriber still receives it.
+		const payload = encodeAcpEvent({
+			tag: "AcpSessionEvent",
+			val: {
+				sessionId: COLLIDING_SESSION_ID,
+				notification: sessionUpdateNotification("post-collision"),
+			},
+		});
+		(
+			vm as unknown as {
+				_handleAcpExtEvent(env: {
+					namespace: string;
+					payload: Uint8Array;
+				}): void;
+			}
+		)._handleAcpExtEvent({ namespace: ACP_EXTENSION_NAMESPACE, payload });
+
+		// DENY / isolate: either the colliding create was rejected (so the first
+		// session + its handler survive untouched), or — if it was accepted — the
+		// original handler must NOT have been orphaned. A silent overwrite that
+		// drops the first session's handler set is the vulnerability and fails here.
+		if (!second.ok) {
+			// Rejected collision is an acceptable defensive outcome.
+			expect(firstEvents).toHaveLength(1);
+		} else {
+			// Accepted: the original subscriber must still be wired up.
+			expect(firstEvents).toHaveLength(1);
+		}
+	});
+});

--- a/packages/core/tests/toolkit-permissions.test.ts
+++ b/packages/core/tests/toolkit-permissions.test.ts
@@ -67,6 +67,32 @@ function hostCallbackFrame(callbackKey: string, input: unknown) {
 	};
 }
 
+// A forged *command-shaped* host_callback. `handleHostCallback` dispatches any
+// input that parses as `{type:'command',command,args,cwd}` through the SECOND
+// branch (`handleHostCommandCallback` -> `handleAgentOsToolkitCommand` ->
+// `invokeHostTool`), bypassing the `callback_key`/Zod path entirely. We forge a
+// CLI-style command frame to confirm THAT branch also enforces tool.invoke.
+function commandHostCallbackFrame(command: string, args: string[]) {
+	return {
+		frame_type: "sidecar_request" as const,
+		request_id: 1,
+		payload: {
+			type: "host_callback" as const,
+			invocation_id: "guest-forged-cmd-1",
+			// callback_key is irrelevant on the command branch; set it to a tool
+			// that DOES exist to prove the command branch is what runs.
+			callback_key: "math:add",
+			input: {
+				type: "command",
+				command,
+				args,
+				cwd: "/home/user",
+			},
+			timeout_ms: 30_000,
+		},
+	};
+}
+
 const mathToolKit = toolKit({
 	name: "math",
 	description: "Math utilities",
@@ -310,6 +336,177 @@ describe("toolkit permissions — raw host_callback RPC path", () => {
 		);
 
 		expect(executed).not.toContain("danger");
+		expect(response.type).toBe("host_callback_result");
+		expect(response.result).toBeUndefined();
+		expect(typeof response.error).toBe("string");
+		expect(response.error).toMatch(/tool\.invoke|EACCES|denied|permission/i);
+	});
+
+	// AOSFS-1 (P1, J.1/J.2): the raw host_callback RPC path is fully
+	// guest-controlled, including the `input` object. The guest can stuff extra
+	// keys, a `__proto__` payload, and a `constructor` key into `input` to try to
+	// (a) leak raw unvalidated fields into the host-side `execute`, or (b) pollute
+	// Object.prototype on the host. The handler runs `tool.inputSchema.safeParse`
+	// and passes ONLY `parsed.data` to execute; a strict/stripping Zod object must
+	// hand `execute` exactly the declared keys and nothing else, and no prototype
+	// pollution may occur. Asserts the system strips the hostile/extra keys.
+	test("host_callback strips hostile/extra input keys; execute receives only validated Zod data and no prototype pollution", async () => {
+		const seen: unknown[] = [];
+		const kit = toolKit({
+			name: "math",
+			description: "Math utilities",
+			tools: {
+				add: hostTool({
+					description: "Add two numbers",
+					inputSchema: z.object({ a: z.number(), b: z.number() }),
+					execute: (input) => {
+						// Capture exactly what execute is handed.
+						seen.push(input);
+						const { a, b } = input;
+						return { sum: a + b };
+					},
+				}),
+			},
+		});
+
+		const created = await createVmCapturingHandler({
+			toolKits: [kit],
+			permissions: {
+				fs: "allow",
+				childProcess: "allow",
+				tool: {
+					default: "deny",
+					rules: [
+						{ mode: "allow", operations: ["invoke"], patterns: ["math:add"] },
+					],
+				},
+			},
+		});
+		vm = created.vm;
+
+		// Hostile input: declared keys + extra fields + a prototype-pollution
+		// payload. Build via JSON so __proto__ is a real own enumerable key (the
+		// exact shape an untrusted guest sends over the wire).
+		const hostileInput = JSON.parse(
+			'{"a":2,"b":3,"evilField":"leak-me","secret":"do-not-pass","__proto__":{"polluted":"yes"},"constructor":{"prototype":{"polluted2":"yes"}}}',
+		);
+
+		const response = await created.handler(
+			hostCallbackFrame("math:add", hostileInput),
+		);
+
+		// The tool ran (policy allows math:add) and produced the correct result.
+		expect(response.type).toBe("host_callback_result");
+		expect(response.error).toBeUndefined();
+		expect(response.result).toEqual({ sum: 5 });
+
+		// execute saw EXACTLY the declared keys — no leaked hostile/extra fields.
+		expect(seen).toHaveLength(1);
+		const handed = seen[0] as Record<string, unknown>;
+		expect(Object.keys(handed).sort()).toEqual(["a", "b"]);
+		expect(handed.a).toBe(2);
+		expect(handed.b).toBe(3);
+		expect(handed).not.toHaveProperty("evilField");
+		expect(handed).not.toHaveProperty("secret");
+
+		// No prototype pollution of Object.prototype on the host.
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(({} as Record<string, unknown>).polluted2).toBeUndefined();
+		expect(
+			Object.prototype.hasOwnProperty.call(Object.prototype, "polluted"),
+		).toBe(false);
+	});
+
+	// AOSFS-2 (P2): a guest can send schema-failing input on the raw host_callback
+	// RPC path (which does NOT go through the CLI argv parser / sidecar-tool
+	// dispatch validation at sidecar-tool-dispatch:108). The handler must
+	// safeParse and return a validation error WITHOUT invoking execute.
+	test("host_callback rejects schema-failing input without invoking execute", async () => {
+		const executed: unknown[] = [];
+		const kit = toolKit({
+			name: "math",
+			description: "Math utilities",
+			tools: {
+				add: hostTool({
+					description: "Add two numbers",
+					inputSchema: z.object({ a: z.number(), b: z.number() }),
+					execute: ({ a, b }) => {
+						executed.push({ a, b });
+						return { sum: a + b };
+					},
+				}),
+			},
+		});
+
+		const created = await createVmCapturingHandler({
+			toolKits: [kit],
+			permissions: {
+				fs: "allow",
+				childProcess: "allow",
+				tool: {
+					default: "deny",
+					rules: [
+						{ mode: "allow", operations: ["invoke"], patterns: ["math:add"] },
+					],
+				},
+			},
+		});
+		vm = created.vm;
+
+		// `a` is the wrong type; `b` is missing entirely.
+		const response = await created.handler(
+			hostCallbackFrame("math:add", { a: "not-a-number" }),
+		);
+
+		expect(executed).toHaveLength(0);
+		expect(response.type).toBe("host_callback_result");
+		expect(response.result).toBeUndefined();
+		expect(typeof response.error).toBe("string");
+		// Zod validation message (number expected / required), not a thrown crash.
+		expect(response.error).toMatch(/number|expected|required|invalid|nan/i);
+	});
+
+	// AOS-SESS-4 (N-014, P2, J.1/J.2): the *command-shaped* host_callback dispatch
+	// branch (handleHostCommandCallback -> invokeHostTool) must ALSO honor
+	// tool.invoke deny — defense-in-depth on the second dispatch path that the
+	// callback_key/Zod branch does not cover. (Hold-as-regression; not a
+	// re-discovery — assert the gate holds on this branch.)
+	test("forged {type:'command'} host_callback is denied by tool.invoke on the command dispatch branch", async () => {
+		const executed: unknown[] = [];
+		const spyKit = toolKit({
+			name: "math",
+			description: "Math utilities",
+			tools: {
+				add: hostTool({
+					description: "Add two numbers",
+					inputSchema: z.object({ a: z.number(), b: z.number() }),
+					execute: ({ a, b }) => {
+						executed.push({ a, b });
+						return { sum: a + b };
+					},
+				}),
+			},
+		});
+
+		const created = await createVmCapturingHandler({
+			toolKits: [spyKit],
+			permissions: {
+				fs: "allow",
+				childProcess: "allow",
+				// Deny-by-default: no tool.invoke grant for math:add.
+				tool: { default: "deny", rules: [] },
+			},
+		});
+		vm = created.vm;
+
+		// Forge `agentos-math add --a 2 --b 3` as a command host_callback.
+		const response = await created.handler(
+			commandHostCallbackFrame("agentos-math", ["add", "--a", "2", "--b", "3"]),
+		);
+
+		// The attacker must be denied on the command branch too: execute MUST NOT
+		// have run and the response must surface a policy denial, not a result.
+		expect(executed).toHaveLength(0);
 		expect(response.type).toBe("host_callback_result");
 		expect(response.result).toBeUndefined();
 		expect(typeof response.error).toBe("string");


### PR DESCRIPTION
## Summary

Fixes the remaining open agent-os security findings and locks the already-passing safeguards as regression tests. Each logical change is its own commit on top of the secure-exec 0.3 repin.

**Stacking:** This PR stacks on **#1488** (`security/repin-secure-exec-0.3`, the secure-exec 0.3.0 repin that unblocks build/CI) — it is the base of this branch, so review/merge #1488 first. It complements **#1487** (per-connection ownership on ACP `close_session` + `session_request`, F-010 follow-up), which lives on a sibling branch.

## Real fixes

### N-007 — cron exec argv integrity injection
- **Severity:** High. **Reachable by:** anyone able to create a cron job (`CronAction::Exec`).
- The Exec action flattened `(command, args)` into a single string and routed it back through the exec command-line parser, which re-split argv elements on whitespace and shell-evaluated `$(...)` / backtick content — so a literal arg like `a b`, `$(id)`, or `` `id` `` was corrupted/executed.
- **Fix:** added `AgentOs::exec_argv(command, &args, opts)` in `crates/client/src/process.rs` that sends the structured argv verbatim, bypassing `resolve_exec_command`; the cron Exec arm now calls it.
- **Status:** REAL FIX + GREEN. Regression test `cron::tests::cron_exec_action_argv_is_not_shell_re_split_or_evaluated` asserts `"a b"` / `$(id)` / `` `id` `` survive as literal argv elements, with negative controls proving the old join+resolve path corrupted them.

### N-011 — sessionId collision orphaning handlers
- **Severity:** High. **Reachable by:** an adapter/sidecar returning a colliding (or attacker-influenced) `sessionId`.
- `createSession` in `packages/core/src/agent-os.ts` trusted the adapter/sidecar-chosen `sessionId` and unconditionally overwrote any existing `_sessions` entry, orphaning the first session's event/permission handlers and pending permission replies.
- **Fix:** fail closed — if a live (non-closed) `_sessions` entry already holds that id, throw `session id collision: <id>` before mutating state. Previously-closed/evicted ids may still be re-used.
- **Status:** REAL FIX + GREEN.

## Locked guards (already-passing safeguards captured as regression tests)

These were already behaving correctly; the commit adds tests so the behavior can't silently regress:
- **N-008** — cron job-limit cap enforced (Rust, `cron.rs`).
- **N-009** — shell-metachar exec lines route through `sh -c` as a single arg (Rust, `command_line.rs`).
- **N-010** — hostile `VmFetch` response parse never panics, 4 sub-cases (Rust, `net.rs`).
- **N-012** — cross-session ACP event isolation (TS).
- **N-013** — cross-session permission-reply isolation (TS).
- **N-014** — forged command-shaped `host_callback` denied on the command dispatch branch (TS).
- **N-015** — `host_callback` strips hostile keys / no prototype pollution (TS).
- **N-016** — `host_callback` rejects schema-failing input without invoking `execute` (TS).

## Build-verified-only tests

Any test that requires runtime WASM/adapter artifacts not present in this environment is build-verified-only (compiles/type-checks, not executed) due to missing WASM/adapter artifacts. The N-007 and N-011 fixes and their pure Rust/TS regression tests above run green.

## fmt / clippy / check-types

- `fmt`: clean.
- `clippy`: clean.
- `check-types`: clean.