### PR TITLE
fix(shell): resolve registry WASM from secure-exec sibling in local mode

### DIFF
--- a/packages/shell/src/main.ts
+++ b/packages/shell/src/main.ts
@@ -17,29 +17,31 @@ import yq from "@agentos-software/yq";
 import zip from "@agentos-software/zip";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const fallbackCommandDir = resolve(
-	__dirname,
-	"../../..",
-	"registry/native/target/wasm32-wasip1/release/commands",
-);
-
+const COMMAND_SUBPATH = "registry/native/target/wasm32-wasip1/release/commands";
 // Published packages ship package-local wasm/ dirs. Workspace packages use the
-// native build output when those package-local dirs have not been materialized.
+// native build output: agent-os's own registry when present, or the sibling
+// secure-exec checkout under `just secure-exec-local` (where the WASM is built).
+const fallbackCommandDir = [
+	resolve(__dirname, "../../..", COMMAND_SUBPATH),
+	resolve(__dirname, "../../../../secure-exec", COMMAND_SUBPATH),
+].find((dir) => existsSync(dir));
+
 function withLocalCommandFallback(software: SoftwareInput): SoftwareInput {
 	if (Array.isArray(software)) {
 		return software.map(withLocalCommandFallback) as SoftwareInput;
 	}
 
 	if (
+		fallbackCommandDir !== undefined &&
 		"commandDir" in software &&
 		typeof software.commandDir === "string" &&
-		!existsSync(software.commandDir) &&
-		existsSync(fallbackCommandDir)
+		!existsSync(software.commandDir)
 	) {
+		const dir = fallbackCommandDir;
 		return {
 			...software,
 			get commandDir() {
-				return fallbackCommandDir;
+				return dir;
 			},
 		};
 	}


### PR DESCRIPTION
## Problem

`@rivet-dev/agent-os-shell` (`packages/shell`) fails to boot a VM under `just secure-exec-local`, aborting at `AgentOs.create()` with:

```
plugin_error: ENOENT: open '/': No such file or directory (os error 2)
```

The shell's `withLocalCommandFallback` only checked agent-os's own `registry/native/target/.../commands` for WASM tools — a directory that doesn't exist in this repo. In local mode the registry WASM is built in the sibling **secure-exec** checkout, so every registry tool's `commandDir` resolved to a missing path and the software mount failed.

## Fix

Try both candidate dirs (agent-os's own native build, then the `../secure-exec` sibling) and use the first that exists.

**No effect in published/pinned mode** — the `@agentos-software/*` packages ship bundled `wasm/` dirs there, so the fallback is never consulted.

## Verification (against a local secure-exec build)

- `agent-os-shell -- node -e ...` → runs in VM, exits with guest status ✓
- `agent-os-shell -- jq -n "1+2"` → `3` ✓
- `agent-os-shell -- bash -c "echo 'hello world' | rg hello"` → `1:hello world` ✓
- `pnpm check-types` clean; `pnpm test` (cli.test.ts) 2/2 ✓