### PR TITLE
[codex] publish Darwin sidecar and plugin artifacts

### DIFF
--- a/crates/client/src/agent_os.rs
+++ b/crates/client/src/agent_os.rs
@@ -1120,7 +1120,7 @@ fn permissions_policy_config(config: &AgentOsConfig) -> vm_config::PermissionsPo
 }
 
 /// Default permission policy when the client supplies no `permissions`:
-/// allow-all for fs/childProcess/process/env/tool (the VM is itself the
+/// allow-all for fs/childProcess/process/env/binding (the VM is itself the
 /// isolation boundary), with network egress restricted to the default LLM
 /// allowlist (see [`default_network_egress_scope_config`]).
 fn default_permissions_policy_config() -> vm_config::PermissionsPolicy {
@@ -3572,7 +3572,7 @@ fn permissions_policy(config: &AgentOsConfig) -> wire::PermissionsPolicy {
 }
 
 /// Default permission policy (wire form) when the client supplies no
-/// `permissions`: allow-all for fs/childProcess/process/env/tool, with network
+/// `permissions`: allow-all for fs/childProcess/process/env/binding, with network
 /// egress restricted to the default LLM allowlist
 /// (see [`default_network_egress_scope`]).
 fn default_permissions_policy() -> wire::PermissionsPolicy {

--- a/packages/agentos-plugin/npm/README.md
+++ b/packages/agentos-plugin/npm/README.md
@@ -14,3 +14,5 @@ The binary is built in CI (`.github/workflows/publish.yaml`, `build-plugin`
 job: `cargo build -p agentos-actor-plugin`) and copied into the matching
 platform directory before publish. The committed directories contain only the
 `package.json` describing the platform.
+
+Supported platforms: `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-arm64`, `darwin-x64`.

--- a/packages/sidecar-binary/README.md
+++ b/packages/sidecar-binary/README.md
@@ -13,7 +13,7 @@ const { getSidecarPath } = require("@rivet-dev/agentos-sidecar");
 const binaryPath = getSidecarPath();
 ```
 
-Set `AGENT_OS_SIDECAR_BIN` to an absolute path to override resolution (useful
+Set `AGENTOS_SIDECAR_BIN` to an absolute path to override resolution (useful
 for development or custom builds).
 
-Supported platforms: `linux-x64-gnu`, `linux-arm64-gnu`.
+Supported platforms: `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-arm64`, `darwin-x64`.

--- a/packages/sidecar-binary/npm/README.md
+++ b/packages/sidecar-binary/npm/README.md
@@ -8,3 +8,5 @@ are not built by Turborepo.
 
 The meta package `@rivet-dev/agentos-sidecar` (one directory up) resolves the
 correct platform package at runtime via npm `os`/`cpu`/`libc` selection.
+
+Supported platforms: `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-arm64`, `darwin-x64`.


### PR DESCRIPTION
## What changed

Adds Darwin publish support for the native AgentOS stack on top of the dylib integration branch:

- builds `agentos-sidecar` on `darwin-arm64` and `darwin-x64`
- builds `agentos-actor-plugin` on Darwin and ships `libagentos_actor_plugin.dylib`
- adds Darwin npm platform packages for both sidecar and actor plugin
- updates sidecar/plugin runtime resolvers and publish package discovery tests
- pins AgentOS to secure-exec `0.3.1-rc.2` so the macOS build uses the Darwin-capable secure-exec preview

## Why

macOS installs need both pieces: the AgentOS sidecar binary and the RivetKit-loadable actor plugin dylib. Shipping only the sidecar leaves `@rivet-dev/agentos` unable to load the native plugin on Darwin.

## Validation

Local:

- `pnpm --dir scripts/publish test`
- `pnpm --dir scripts/publish run check-types`
- `cargo build -p agentos-sidecar -p agentos-actor-plugin`
- `pnpm --filter @rivet-dev/agentos-core build && pnpm --filter @rivet-dev/agentos run check-types`
- `cargo test -p agentos-sidecar --test acp_adapter_stderr --test acp_extension --no-run`
- `cargo test -p agentos-client --test os_instructions_e2e --no-run`

Preview publish:

- https://github.com/rivet-dev/agentos/actions/runs/28033945159 succeeded
- published preview version `0.0.0-codex-darwin-ci-publish.61a7af3`
- confirmed npm optional deps include Darwin sidecar/plugin packages
- publish log placed plugin cdylibs for `linux-x64-gnu`, `darwin-arm64`, and `darwin-x64`

## Notes

`cargo fmt --check` still reports unrelated pre-existing formatting churn in `crates/client/tests/fs_e2e.rs` and older formatting in touched Rust files; I left that out of scope to keep this diff focused.
