### PR TITLE
feat(sidecar): configurable logfmt logging + ext stall-watchdog tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-appender",
+ "tracing-logfmt",
  "tracing-subscriber",
 ]
 
@@ -2178,6 +2180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,6 +3701,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,15 +3746,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-logfmt"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
+dependencies = [
+ "nu-ansi-term",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/crates/agentos-sidecar/Cargo.toml
+++ b/crates/agentos-sidecar/Cargo.toml
@@ -18,9 +18,11 @@ agentos-protocol = { workspace = true }
 serde_json = "1.0"
 serde_bare = "0.5"
 secure-exec-sidecar = { workspace = true }
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["sync", "time", "macros"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tracing-logfmt = { version = "0.3", features = ["ansi_logs"] }
+tracing-appender = "0.2"
 
 [dev-dependencies]
 agentos-bridge = { workspace = true }

--- a/crates/agentos-sidecar/src/acp_extension.rs
+++ b/crates/agentos-sidecar/src/acp_extension.rs
@@ -109,20 +109,72 @@ impl AcpExtension {
         ctx: ExtensionContext<'_>,
         payload: &[u8],
     ) -> Result<ExtensionResponse, SidecarError> {
+        use tracing::Instrument as _;
         let request = decode_request(payload)?;
-        let response = match request {
-            AcpRequest::AcpCreateSessionRequest(request) => self.create_session(ctx, request).await,
-            AcpRequest::AcpGetSessionStateRequest(request) => {
-                AcpHandlerOutput::response(self.get_session_state(ctx, request).await)
+        let kind = Self::acp_request_kind(&request);
+        let start = std::time::Instant::now();
+        tracing::info!(target: "agentos_sidecar::acp_extension", kind, "ext request received");
+
+        let work = async move {
+            match request {
+                AcpRequest::AcpCreateSessionRequest(request) => {
+                    self.create_session(ctx, request).await
+                }
+                AcpRequest::AcpGetSessionStateRequest(request) => {
+                    AcpHandlerOutput::response(self.get_session_state(ctx, request).await)
+                }
+                AcpRequest::AcpCloseSessionRequest(request) => {
+                    AcpHandlerOutput::response(self.close_session(ctx, request).await)
+                }
+                AcpRequest::AcpSessionRequest(request) => self.session_request(ctx, request).await,
+                AcpRequest::AcpResumeSessionRequest(request) => {
+                    self.resume_session(ctx, request).await
+                }
             }
-            AcpRequest::AcpCloseSessionRequest(request) => {
-                AcpHandlerOutput::response(self.close_session(ctx, request).await)
+        }
+        .instrument(tracing::info_span!(
+            target: "agentos_sidecar::acp_extension",
+            "ext.request",
+            kind
+        ));
+
+        // Stall watchdog: while the request is in flight, warn periodically so a
+        // hang surfaces as a breadcrumb long before the host's 120s frame
+        // timeout. This never interrupts the work itself.
+        tokio::pin!(work);
+        let response = loop {
+            tokio::select! {
+                result = &mut work => break result,
+                _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                    tracing::warn!(
+                        target: "agentos_sidecar::acp_extension",
+                        kind,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        "ext request still pending — possible stall before response frame",
+                    );
+                }
             }
-            AcpRequest::AcpSessionRequest(request) => self.session_request(ctx, request).await,
-            AcpRequest::AcpResumeSessionRequest(request) => self.resume_session(ctx, request).await,
         };
+
+        tracing::info!(
+            target: "agentos_sidecar::acp_extension",
+            kind,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "ext request handled",
+        );
         let payload = encode_response(response.response.unwrap_or_else(error_response))?;
         ExtensionResponse::with_wire_events(payload, response.events)
+    }
+
+    /// Stable label for an ACP request kind, used as a tracing field.
+    fn acp_request_kind(request: &AcpRequest) -> &'static str {
+        match request {
+            AcpRequest::AcpCreateSessionRequest(_) => "create_session",
+            AcpRequest::AcpGetSessionStateRequest(_) => "get_session_state",
+            AcpRequest::AcpCloseSessionRequest(_) => "close_session",
+            AcpRequest::AcpSessionRequest(_) => "session_request",
+            AcpRequest::AcpResumeSessionRequest(_) => "resume_session",
+        }
     }
 
     async fn create_session(

--- a/crates/agentos-sidecar/src/main.rs
+++ b/crates/agentos-sidecar/src/main.rs
@@ -1,17 +1,90 @@
+use tracing_subscriber::fmt::writer::BoxMakeWriter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
 fn main() {
-    // The sidecar speaks its binary protocol over stdout (see
-    // `secure_exec_sidecar::stdio`), so tracing output MUST go to stderr —
-    // otherwise log lines are interleaved into the frame stream and the client
-    // misreads them as (garbage-length) frames. See crates/CLAUDE.md:
-    // "Control channels must be out-of-band."
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_max_level(tracing::Level::ERROR)
-        .init();
+    init_tracing();
     if let Err(error) =
         secure_exec_sidecar::stdio::run_with_extensions(agentos_sidecar_wrapper::extensions())
     {
         tracing::error!(?error, "agentos-sidecar startup failed");
         std::process::exit(1);
+    }
+}
+
+/// `1` => true, anything else => false. Mirrors rivet's `env_flag`.
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).map_or(false, |v| v == "1")
+}
+
+/// Initialize tracing for the sidecar.
+///
+/// Mirrors the rivet logging setup (`rivetkit-napi::init_tracing`): an
+/// `EnvFilter`-gated subscriber with a logfmt formatter, so log level and
+/// verbosity are runtime-configurable instead of hardcoded.
+///
+/// Configuration (all optional):
+/// - level: `AGENTOS_LOG_LEVEL` > `LOG_LEVEL` > `RUST_LOG` > `"info"`.
+/// - format: `RUST_LOG_FORMAT=logfmt` (default) or `text`.
+/// - sink: `AGENTOS_LOG_FILE` (append to that file) else stderr.
+/// - field toggles: `RUST_LOG_{SPAN_NAME,SPAN_PATH,TARGET,LOCATION,MODULE_PATH,ANSI_COLOR}`.
+///
+/// The sink MUST be stderr or a file — NEVER stdout, which carries the
+/// sidecar's binary frame protocol (see crates/CLAUDE.md: "Control channels
+/// must be out-of-band").
+fn init_tracing() {
+    // Level priority: AGENTOS_LOG_LEVEL > LOG_LEVEL > RUST_LOG > "info".
+    let directive = std::env::var("AGENTOS_LOG_LEVEL")
+        .ok()
+        .or_else(|| std::env::var("LOG_LEVEL").ok())
+        .or_else(|| std::env::var("RUST_LOG").ok())
+        .unwrap_or_else(|| "info".to_string());
+    let env_filter = EnvFilter::try_new(&directive).unwrap_or_else(|_| EnvFilter::new("info"));
+
+    // Sink: a file if AGENTOS_LOG_FILE is set, else stderr. Never stdout.
+    let writer: BoxMakeWriter = match std::env::var("AGENTOS_LOG_FILE") {
+        Ok(path) if !path.is_empty() => {
+            let path = std::path::PathBuf::from(path);
+            let dir = path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+            let name = path
+                .file_name()
+                .map(std::ffi::OsString::from)
+                .unwrap_or_else(|| std::ffi::OsString::from("agentos-sidecar.log"));
+            BoxMakeWriter::new(tracing_appender::rolling::never(dir, name))
+        }
+        _ => BoxMakeWriter::new(std::io::stderr),
+    };
+
+    let registry = tracing_subscriber::registry().with(env_filter);
+
+    let text_format = std::env::var("RUST_LOG_FORMAT")
+        .map(|v| v.eq_ignore_ascii_case("text"))
+        .unwrap_or(false);
+
+    if text_format {
+        registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(writer),
+            )
+            .init();
+    } else {
+        registry
+            .with(
+                tracing_logfmt::builder()
+                    .with_span_name(env_flag("RUST_LOG_SPAN_NAME"))
+                    .with_span_path(env_flag("RUST_LOG_SPAN_PATH"))
+                    .with_target(env_flag("RUST_LOG_TARGET"))
+                    .with_location(env_flag("RUST_LOG_LOCATION"))
+                    .with_module_path(env_flag("RUST_LOG_MODULE_PATH"))
+                    .with_ansi_color(env_flag("RUST_LOG_ANSI_COLOR"))
+                    .layer()
+                    .with_writer(writer),
+            )
+            .init();
     }
 }


### PR DESCRIPTION
## What

Make the `agentos-sidecar` logging **configurable** (matching the `~/rivet` setup) and add the tracing needed to see where an `ext` request — especially a tool-call turn — spends its time or hangs.

### 1. Logging setup (mirrors rivet's `init_tracing`)
`crates/agentos-sidecar/src/main.rs` previously hardcoded `Level::ERROR` with no `EnvFilter`, so `RUST_LOG` was silently ignored and the sidecar was effectively unobservable. Now:
- **Level**: `AGENTOS_LOG_LEVEL` > `LOG_LEVEL` > `RUST_LOG` > `info`.
- **Format**: logfmt by default (`tracing-logfmt`), `RUST_LOG_FORMAT=text` to opt out.
- **Sink**: `AGENTOS_LOG_FILE` writes to a file; otherwise stderr. Never stdout (that carries the binary frame protocol).
- Field toggles: `RUST_LOG_{SPAN_NAME,SPAN_PATH,TARGET,LOCATION,MODULE_PATH,ANSI_COLOR}`.

### 2. ext-request tracing + stall watchdog
`crates/agentos-sidecar/src/acp_extension.rs`: wrap `handle_payload` in an `ext.request` span with `kind` + `elapsed_ms`, emit received/handled events, and — the key bit — a **stall watchdog** that `warn!`s every 10s while a request is still in flight. A hung tool turn now leaves a breadcrumb long before the host's 120s frame timeout instead of timing out silently.

## Why

Debugging a Zid tool-call hang (`timed out waiting for sidecar protocol frame for ext`), we found the sidecar emitted nothing: ERROR-only, `RUST_LOG`-deaf, and no per-request timing. This restores parity with rivet logging and makes the hang (and session-creation latency) diagnosable.

## Notes
- Default level is `info`; prod behavior is unchanged unless a level is set.
- Pairs with a secure-exec PR adding `binding.invoke` tracing on the tool-resolution path (separate PR; independent to compile).
- `cargo check -p agentos-sidecar` passes.