### PR TITLE
[codex] test Agent OS mountFs layers

### DIFF
--- a/examples/docs/filesystem/server.ts
+++ b/examples/docs/filesystem/server.ts
@@ -1,11 +1,13 @@
 import { agentOS, setup } from "@rivet-dev/agentos";
-import { createInMemoryFileSystem } from "@rivet-dev/agent-os-core";
 import pi from "./software/pi";
 
 const vm = agentOS({
   software: [pi],
   mounts: [
-    { path: "/home/agentos/scratch", driver: createInMemoryFileSystem() },
+    {
+      path: "/home/agentos/scratch",
+      plugin: { id: "memory", config: {} },
+    },
   ],
 });
 

--- a/packages/agentos/tests/actor.test.ts
+++ b/packages/agentos/tests/actor.test.ts
@@ -402,10 +402,49 @@ describe("@rivet-dev/agentos native plugin package bridge", () => {
 		expect(() =>
 			agentOs({
 				options: {
+					mounts: [
+						{
+							path: "/data",
+							driver: {
+								readFile: async () => new Uint8Array(),
+							},
+						},
+					],
+				} as never,
+			}),
+		).toThrow(/driver/);
+
+		expect(() =>
+			agentOs({
+				options: {
 					sidecar: { kind: "explicit", handle: {} },
 				} as never,
 			}),
 		).toThrow(/sidecar/);
+	});
+
+	test("serializes native memory mounts across the Rivet native plugin boundary", () => {
+		const config = JSON.parse(
+			buildConfigJson({
+				options: {
+					defaultSoftware: false,
+					software: [],
+					mounts: [
+						{
+							path: "/data",
+							plugin: { id: "memory", config: {} },
+						},
+					],
+				},
+			} as never),
+		);
+
+		expect(config.mounts).toEqual([
+			{
+				path: "/data",
+				plugin: { id: "memory", config: {} },
+			},
+		]);
 	});
 
 	test("buildConfigJson rejects unknown options instead of dropping them", () => {
@@ -488,8 +527,8 @@ describe("@rivet-dev/agentos native plugin package bridge", () => {
 			(s: { package: string }) => s.package,
 		);
 		expect(pkgs).toContain("/x/wasm");
-		// common (sh + coreutils + tools) is injected from @agentos-software/*.
-		expect(pkgs.some((p: string) => p.includes("@agentos-software"))).toBe(
+		// common (sh + coreutils + tools) is injected from the software registry.
+		expect(pkgs.some((p: string) => p.includes("coreutils"))).toBe(
 			true,
 		);
 		expect(withDefault.software.length).toBeGreaterThan(1);

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -2677,6 +2677,7 @@ export class AgentOs {
 	private _hostMounts: HostMountInfo[];
 	private _env: Record<string, string>;
 	private _rootFilesystem: VirtualFileSystem;
+	private readonly _additionalInstructions: string | undefined;
 	private _sidecarLease: AgentOsSidecarVmLease<AgentOsVmAdmin> | null = null;
 	private readonly _sidecarClient: SidecarProcess;
 	private readonly _sidecarSession: AuthenticatedSession;
@@ -2695,6 +2696,7 @@ export class AgentOs {
 		sidecarClient: SidecarProcess,
 		sidecarSession: AuthenticatedSession,
 		sidecarVm: CreatedVm,
+		additionalInstructions?: string,
 		agentStderrHandler?: AgentStderrHandler,
 	) {
 		this.#kernel = kernel;
@@ -2707,6 +2709,7 @@ export class AgentOs {
 		this._sidecarClient = sidecarClient;
 		this._sidecarSession = sidecarSession;
 		this._sidecarVm = sidecarVm;
+		this._additionalInstructions = additionalInstructions;
 		this._agentStderrHandler = agentStderrHandler;
 		this._disposeSidecarEventListener = this._sidecarClient.onEvent((event) => {
 			this._handleSidecarEvent(event);
@@ -2957,19 +2960,20 @@ export class AgentOs {
 			});
 			const vmAdmin = sidecarLease.admin;
 
-			const vm = new AgentOs(
-				vmAdmin.kernel,
-				sidecar,
-				processed.softwareRoots,
+				const vm = new AgentOs(
+					vmAdmin.kernel,
+					sidecar,
+					processed.softwareRoots,
 				processed.agentConfigs,
 				vmAdmin.hostMounts,
 				vmAdmin.env,
 				vmAdmin.rootView,
-				vmAdmin.sidecarClient,
-				vmAdmin.sidecarSession,
-				vmAdmin.sidecarVm,
-				options?.onAgentStderr ?? defaultAgentStderrHandler,
-			);
+					vmAdmin.sidecarClient,
+					vmAdmin.sidecarSession,
+					vmAdmin.sidecarVm,
+					options?.additionalInstructions,
+					options?.onAgentStderr ?? defaultAgentStderrHandler,
+				);
 			vm._sidecarLease = sidecarLease;
 			vm._toolKits = vmAdmin.toolKits;
 			vm._toolReference = vmAdmin.toolReference;
@@ -3356,7 +3360,7 @@ export class AgentOs {
 
 	async delete(path: string, options?: { recursive?: boolean }): Promise<void> {
 		this._assertSafeAbsolutePath(path);
-		const s = await this.#kernel.stat(path);
+		const s = await this._vfs().lstat(path);
 		if (s.isDirectory) {
 			if (options?.recursive) {
 				const entries = await this.#kernel.readdir(path);
@@ -4189,17 +4193,20 @@ export class AgentOs {
 				adapterEntrypoint,
 				args: launchArgs,
 				env: new Map(Object.entries(launchEnv)),
-				cwd: sessionCwd,
-				mcpServers: JSON.stringify(options?.mcpServers ?? []),
-				protocolVersion: ACP_PROTOCOL_VERSION,
-				clientCapabilities: JSON.stringify(defaultAcpClientCapabilities()),
-				additionalInstructions: combineInstructions(
-					options?.additionalInstructions,
-					this._toolReference,
-				),
-				skipOsInstructions: options?.skipOsInstructions ?? false,
-			},
-		});
+					cwd: sessionCwd,
+					mcpServers: JSON.stringify(options?.mcpServers ?? []),
+					protocolVersion: ACP_PROTOCOL_VERSION,
+					clientCapabilities: JSON.stringify(defaultAcpClientCapabilities()),
+					additionalInstructions: combineInstructions(
+						[this._additionalInstructions, options?.additionalInstructions]
+							.map((part) => part?.trim())
+							.filter((part): part is string => Boolean(part))
+							.join("\n\n") || undefined,
+						this._toolReference,
+					),
+					skipOsInstructions: options?.skipOsInstructions ?? false,
+				},
+			});
 		if (response.tag !== "AcpSessionCreatedResponse") {
 			throw new Error(`unexpected create_session response: ${response.tag}`);
 		}
@@ -4300,6 +4307,11 @@ export class AgentOs {
 		const { sessionId: liveSessionId, mode } = response.val;
 
 		// Register + hydrate the live session so subsequent prompts route to it.
+		const existing = this._sessions.get(liveSessionId);
+		if (existing !== undefined && !existing.closed) {
+			throw new Error(`session id collision: ${liveSessionId}`);
+		}
+
 		const session = sessionEntryFromInit(liveSessionId, String(agentType), {});
 		this._closedSessionIds.delete(liveSessionId);
 		this._sessions.set(liveSessionId, session);

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -242,12 +242,15 @@ import {
 	NativeSidecarKernelProxy,
 	SidecarProcess,
 	type RootFilesystemEntry,
+	type SidecarMountDescriptor,
+	type SidecarPermissionsPolicy,
 	type SidecarRegisteredHostCallbackDefinition,
 	type SidecarRequestFrame,
 	type SidecarResponsePayload,
 	type SidecarSessionState,
 	serializeRootFilesystemForSidecar,
 } from "./sidecar/rpc-client.js";
+import type { PermissionTier } from "./runtime.js";
 
 export interface AgentOsSharedSidecarOptions {
 	pool?: string;
@@ -292,6 +295,10 @@ interface AgentOsVmAdmin extends InProcessSidecarVmAdmin {
 	hostMounts: HostMountInfo[];
 	env: Record<string, string>;
 	permissions: Permissions;
+	sidecarMounts: SidecarMountDescriptor[];
+	sidecarPermissions: SidecarPermissionsPolicy | undefined;
+	commandPermissions: Record<string, PermissionTier>;
+	loopbackExemptPorts: number[] | undefined;
 	sidecarClient: SidecarProcess;
 	sidecarSession: AuthenticatedSession;
 	sidecarVm: CreatedVm;
@@ -1673,6 +1680,16 @@ function collectSidecarMountPlan(options: {
 
 	for (const mount of options.mounts ?? []) {
 		if (!isNativeMountConfig(mount)) {
+			sidecarMounts.push({
+				guestPath: mount.path,
+				readOnly: isOverlayMountConfig(mount)
+					? (mount.filesystem.mode ?? "ephemeral") === "read-only"
+					: (mount.readOnly ?? false),
+				plugin: {
+					id: "js_bridge",
+					config: {},
+				},
+			});
 			continue;
 		}
 		pushMount(mount);
@@ -2035,6 +2052,177 @@ interface HostCallbackContext {
 	toolMap: ReadonlyMap<string, HostTool>;
 	permissions: Permissions;
 	readFile(path: string): Promise<Uint8Array>;
+}
+
+interface JsBridgeContext {
+	filesystem: VirtualFileSystem;
+}
+
+function bridgeErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function toBridgeArgs(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("js_bridge args must be an object");
+	}
+	return value as Record<string, unknown>;
+}
+
+function bridgePath(mountId: string, value: unknown): string {
+	if (!mountId.startsWith("/")) {
+		throw new Error(`Unsupported js_bridge mount id: ${mountId}`);
+	}
+	if (typeof value !== "string") {
+		throw new Error("js_bridge path argument must be a string");
+	}
+	return posixPath.normalize(posixPath.join(mountId, value));
+}
+
+function requireBridgeNumber(value: unknown, field: string): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`js_bridge args.${field} must be a number`);
+	}
+	return value;
+}
+
+function decodeBridgeBytes(value: unknown, field: string): Uint8Array {
+	if (typeof value === "string") {
+		return new Uint8Array(Buffer.from(value, "base64"));
+	}
+	if (
+		Array.isArray(value) &&
+		value.every((entry) => Number.isInteger(entry) && entry >= 0 && entry <= 255)
+	) {
+		return new Uint8Array(value);
+	}
+	throw new Error(`js_bridge args.${field} must be base64 bytes`);
+}
+
+async function handleJsBridgeCall(
+	request: Extract<
+		SidecarRequestFrame["payload"],
+		{ type: "js_bridge_call" }
+	>,
+	context: JsBridgeContext,
+): Promise<SidecarResponsePayload> {
+	try {
+		const args = toBridgeArgs(request.args);
+		const fs = context.filesystem;
+		const path = () => bridgePath(request.mount_id, args.path);
+		let result: unknown;
+
+		switch (request.operation) {
+			case "readFile":
+				result = Buffer.from(await fs.readFile(path())).toString("base64");
+				break;
+			case "readDir":
+				result = await fs.readDir(path());
+				break;
+			case "readDirWithTypes":
+				result = await fs.readDirWithTypes(path());
+				break;
+			case "writeFile":
+				await fs.writeFile(path(), decodeBridgeBytes(args.content, "content"));
+				break;
+			case "createDir":
+				await fs.createDir(path());
+				break;
+			case "mkdir":
+				await fs.mkdir(path(), { recursive: args.recursive !== false });
+				break;
+			case "exists":
+				result = await fs.exists(path());
+				break;
+			case "stat":
+				result = await fs.stat(path());
+				break;
+			case "removeFile":
+				await fs.removeFile(path());
+				break;
+			case "removeDir":
+				await fs.removeDir(path());
+				break;
+			case "rename":
+				await fs.rename(
+					bridgePath(request.mount_id, args.oldPath),
+					bridgePath(request.mount_id, args.newPath),
+				);
+				break;
+			case "realpath":
+				result = await fs.realpath(path());
+				break;
+			case "symlink": {
+				if (typeof args.target !== "string") {
+					throw new Error("js_bridge args.target must be a string");
+				}
+				await fs.symlink(args.target, bridgePath(request.mount_id, args.linkPath));
+				break;
+			}
+			case "readlink":
+				result = await fs.readlink(path());
+				break;
+			case "lstat":
+				result = await fs.lstat(path());
+				break;
+			case "link":
+				await fs.link(
+					bridgePath(request.mount_id, args.oldPath),
+					bridgePath(request.mount_id, args.newPath),
+				);
+				break;
+			case "chmod":
+				await fs.chmod(path(), requireBridgeNumber(args.mode, "mode"));
+				break;
+			case "chown":
+				await fs.chown(
+					path(),
+					requireBridgeNumber(args.uid, "uid"),
+					requireBridgeNumber(args.gid, "gid"),
+				);
+				break;
+			case "utimes":
+				await fs.utimes(
+					path(),
+					requireBridgeNumber(args.atimeMs, "atimeMs"),
+					requireBridgeNumber(args.mtimeMs, "mtimeMs"),
+				);
+				break;
+			case "truncate":
+				await fs.truncate(path(), requireBridgeNumber(args.length, "length"));
+				break;
+			case "pread":
+				result = Buffer.from(
+					await fs.pread(
+						path(),
+						requireBridgeNumber(args.offset, "offset"),
+						requireBridgeNumber(args.length, "length"),
+					),
+				).toString("base64");
+				break;
+			case "pwrite":
+				await fs.pwrite(
+					path(),
+					requireBridgeNumber(args.offset, "offset"),
+					decodeBridgeBytes(args.content, "content"),
+				);
+				break;
+			default:
+				throw new Error(`Unsupported js_bridge operation: ${request.operation}`);
+		}
+
+		return {
+			type: "js_bridge_result",
+			call_id: request.call_id,
+			...(result === undefined ? {} : { result }),
+		};
+	} catch (error) {
+		return {
+			type: "js_bridge_result",
+			call_id: request.call_id,
+			error: bridgeErrorMessage(error),
+		};
+	}
 }
 
 function parseHostCommandCallbackInput(
@@ -2693,6 +2881,10 @@ export class AgentOs {
 					env,
 					cwd: "/workspace",
 					localMounts,
+					sidecarMounts,
+					permissions: sidecarPermissions,
+					commandPermissions: processed.commandPermissions,
+					loopbackExemptPorts: options?.loopbackExemptPorts,
 					commandGuestPaths,
 					onDispose: cleanup,
 				});
@@ -2711,6 +2903,10 @@ export class AgentOs {
 					hostMounts,
 					kernel,
 					rootView: rootBridge.createRootView(),
+					sidecarMounts,
+					sidecarPermissions,
+					commandPermissions: processed.commandPermissions,
+					loopbackExemptPorts: options?.loopbackExemptPorts,
 					sidecarClient: client,
 					sidecarSession: session,
 					sidecarVm: nativeVm,
@@ -4198,11 +4394,7 @@ export class AgentOs {
 				case "host_callback":
 					return handleHostCallback(request, context);
 				case "js_bridge_call":
-					return Promise.resolve({
-						type: "js_bridge_result",
-						call_id: request.payload.call_id,
-						error: `unsupported sidecar request type: ${request.payload.type}`,
-					});
+					return handleJsBridgeCall(request.payload, { filesystem: this.#kernel.vfs });
 				case "ext":
 					return this._handleAcpExtSidecarRequest(request.payload.envelope);
 			}

--- a/packages/core/src/host-tools.ts
+++ b/packages/core/src/host-tools.ts
@@ -51,18 +51,31 @@ export function toolKit(def: ToolKit): ToolKit {
 	return def;
 }
 
+const TOOLKIT_COMMAND_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function validateToolCommandName(kind: "Toolkit" | "Tool", name: string): void {
+	if (TOOLKIT_COMMAND_NAME_RE.test(name)) {
+		return;
+	}
+	throw new Error(
+		`${kind} name "${name}" must be lowercase alphanumeric with optional single hyphen separators`,
+	);
+}
+
 /**
  * Validate all description lengths in the given toolkits.
  * Throws if any toolkit or tool description exceeds MAX_TOOL_DESCRIPTION_LENGTH.
  */
 export function validateToolkits(toolKits: ToolKit[]): void {
 	for (const tk of toolKits) {
+		validateToolCommandName("Toolkit", tk.name);
 		if (tk.description.length > MAX_TOOL_DESCRIPTION_LENGTH) {
 			throw new Error(
 				`Toolkit "${tk.name}" description is ${tk.description.length} characters, max is ${MAX_TOOL_DESCRIPTION_LENGTH}`,
 			);
 		}
 		for (const [toolName, tool] of Object.entries(tk.tools)) {
+			validateToolCommandName("Tool", toolName);
 			if (tool.description.length > MAX_TOOL_DESCRIPTION_LENGTH) {
 				throw new Error(
 					`Tool "${tk.name}/${toolName}" description is ${tool.description.length} characters, max is ${MAX_TOOL_DESCRIPTION_LENGTH}`,

--- a/packages/core/src/runtime-compat.ts
+++ b/packages/core/src/runtime-compat.ts
@@ -20,6 +20,7 @@ import {
 	NativeSidecarKernelProxy,
 	SidecarProcess,
 	type RootFilesystemEntry,
+	type SidecarMountDescriptor,
 	serializeMountConfigForSidecar,
 } from "./sidecar/rpc-client.js";
 
@@ -2417,6 +2418,45 @@ function bindLiveFilesystem(
 	};
 }
 
+function serializeLocalCompatMountForSidecar(
+	mount: LocalCompatMount,
+): SidecarMountDescriptor {
+	return (
+		mount.sidecarMount ??
+		(mount.fs instanceof NodeFileSystem
+			? serializeMountConfigForSidecar({
+					path: mount.path,
+					readOnly: mount.readOnly,
+					plugin: {
+						id: "host_dir",
+						config: {
+							hostPath: mount.fs.rootPath,
+							readOnly: mount.readOnly,
+						},
+					},
+				})
+			: serializeMountConfigForSidecar({
+					path: mount.path,
+					driver: mount.fs,
+					readOnly: mount.readOnly,
+				}))
+	);
+}
+
+function makeLocalCompatMount(options: {
+	path: string;
+	fs: VirtualFileSystem;
+	readOnly?: boolean;
+}): LocalCompatMount {
+	const localMount: LocalCompatMount = {
+		path: normalizePath(options.path),
+		fs: options.fs,
+		readOnly: options.readOnly ?? false,
+	};
+	localMount.sidecarMount = serializeLocalCompatMountForSidecar(localMount);
+	return localMount;
+}
+
 class NativeKernel implements Kernel {
 	readonly env: Record<string, string>;
 	readonly cwd: string;
@@ -2480,11 +2520,13 @@ class NativeKernel implements Kernel {
 		};
 		this.loopbackExemptPorts = [...(options.loopbackExemptPorts ?? [])];
 		for (const mount of options.mounts ?? []) {
-			this.pendingLocalMounts.push({
-				path: normalizePath(mount.path),
-				fs: mount.fs,
-				readOnly: mount.readOnly ?? false,
-			});
+			this.pendingLocalMounts.push(
+				makeLocalCompatMount({
+					path: mount.path,
+					fs: mount.fs,
+					readOnly: mount.readOnly,
+				}),
+			);
 		}
 		this.vfs = new DeferredFileSystem(() => this.rootFilesystem);
 		this.liveFilesystemBinding = bindLiveFilesystem(
@@ -2541,23 +2583,7 @@ class NativeKernel implements Kernel {
 			}),
 		);
 		const localMounts = this.pendingLocalMounts.map((mount) =>
-			mount.fs instanceof NodeFileSystem
-				? serializeMountConfigForSidecar({
-						path: mount.path,
-						readOnly: mount.readOnly,
-						plugin: {
-							id: "host_dir",
-							config: {
-								hostPath: mount.fs.rootPath,
-								readOnly: mount.readOnly,
-							},
-						},
-					})
-				: serializeMountConfigForSidecar({
-						path: mount.path,
-						driver: mount.fs,
-						readOnly: mount.readOnly,
-					}),
+			serializeLocalCompatMountForSidecar(mount),
 		);
 		await this.client.configureVm(this.session, this.vm, {
 			mounts: [...localMounts, ...sidecarMounts],
@@ -2685,14 +2711,24 @@ class NativeKernel implements Kernel {
 		options?: { readOnly?: boolean },
 	): void {
 		if (!this.proxy) {
-			this.pendingLocalMounts.push({
-				path: normalizePath(mountPath),
-				fs: filesystem,
-				readOnly: options?.readOnly ?? false,
-			});
+			this.pendingLocalMounts.push(
+				makeLocalCompatMount({
+					path: mountPath,
+					fs: filesystem,
+					readOnly: options?.readOnly,
+				}),
+			);
 			return;
 		}
-		this.proxy.mountFs(mountPath, filesystem, options);
+		const localMount = makeLocalCompatMount({
+			path: mountPath,
+			fs: filesystem,
+			readOnly: options?.readOnly,
+		});
+		this.proxy.mountFs(mountPath, filesystem, {
+			readOnly: localMount.readOnly,
+			sidecarMount: localMount.sidecarMount,
+		});
 	}
 
 	unmountFs(mountPath: string): void {
@@ -2864,37 +2900,33 @@ class NativeKernel implements Kernel {
 			);
 		}
 		if (rootPassthroughPlan.mounts.length > 0) {
-			this.pendingLocalMounts.push(...rootPassthroughPlan.mounts);
+			this.pendingLocalMounts.push(
+				...rootPassthroughPlan.mounts.map((mount) =>
+					makeLocalCompatMount({
+						path: mount.path,
+						fs: mount.fs,
+						readOnly: mount.readOnly,
+					}),
+				),
+			);
 		}
 		if (
 			this.pendingLocalMounts.length > 0 ||
 			this.loopbackExemptPorts.length > 0 ||
 			requestedPermissions
 		) {
+			const sidecarMounts = this.pendingLocalMounts.map((mount) =>
+				serializeLocalCompatMountForSidecar(mount),
+			);
 			await client.configureVm(session, vm, {
-				mounts: this.pendingLocalMounts.map((mount) =>
-					mount.fs instanceof NodeFileSystem
-						? serializeMountConfigForSidecar({
-								path: mount.path,
-								readOnly: mount.readOnly,
-								plugin: {
-									id: "host_dir",
-									config: {
-										hostPath: mount.fs.rootPath,
-										readOnly: mount.readOnly,
-									},
-								},
-							})
-						: serializeMountConfigForSidecar({
-								path: mount.path,
-								driver: mount.fs,
-								readOnly: mount.readOnly,
-							}),
-				),
+				mounts: sidecarMounts,
 				permissions: requestedPermissions,
 				loopbackExemptPorts: this.loopbackExemptPorts,
 			});
 		}
+		const configuredSidecarMounts = this.pendingLocalMounts.map((mount) =>
+			serializeLocalCompatMountForSidecar(mount),
+		);
 
 		const proxy = new NativeSidecarKernelProxy({
 			client,
@@ -2904,6 +2936,9 @@ class NativeKernel implements Kernel {
 			cwd: this.cwd,
 			defaultExecCwd: this.options.cwd === undefined ? "/workspace" : this.cwd,
 			localMounts: this.pendingLocalMounts,
+			sidecarMounts: configuredSidecarMounts,
+			permissions: requestedPermissions,
+			loopbackExemptPorts: this.loopbackExemptPorts,
 			commandGuestPaths: new Map<string, string>(),
 			onWasmCommandResolved: (command) => {
 				this.recordModuleExecution(command);

--- a/packages/core/src/runtime-compat.ts
+++ b/packages/core/src/runtime-compat.ts
@@ -583,7 +583,7 @@ export class InMemoryFileSystem implements VirtualFileSystem {
 			throw errnoError("ENOENT", `open '${targetPath}'`);
 		}
 		entry.atimeMs = Date.now();
-		return entry.data;
+		return new Uint8Array(entry.data);
 	}
 
 	async readTextFile(targetPath: string): Promise<string> {
@@ -619,10 +619,12 @@ export class InMemoryFileSystem implements VirtualFileSystem {
 		targetPath: string,
 		content: string | Uint8Array,
 	): Promise<void> {
-		const normalized = normalizePath(targetPath);
-		await this.mkdir(dirnameVirtual(normalized), { recursive: true });
-		const data =
-			typeof content === "string" ? new TextEncoder().encode(content) : content;
+			const normalized = normalizePath(targetPath);
+			await this.mkdir(dirnameVirtual(normalized), { recursive: true });
+			const data =
+				typeof content === "string"
+					? new TextEncoder().encode(content)
+					: new Uint8Array(content);
 		const existing = this.entries.get(normalized);
 		if (existing?.type === "file") {
 			existing.data = data;
@@ -687,11 +689,11 @@ export class InMemoryFileSystem implements VirtualFileSystem {
 		return this.toStat(entry);
 	}
 
-	async removeFile(targetPath: string): Promise<void> {
-		const resolved = this.resolvePath(targetPath);
-		const entry = this.entries.get(resolved);
-		if (!entry || entry.type === "dir") {
-			throw errnoError("ENOENT", `unlink '${targetPath}'`);
+		async removeFile(targetPath: string): Promise<void> {
+			const resolved = normalizePath(targetPath);
+			const entry = this.entries.get(resolved);
+			if (!entry || entry.type === "dir") {
+				throw errnoError("ENOENT", `unlink '${targetPath}'`);
 		}
 		this.entries.delete(resolved);
 	}
@@ -870,9 +872,9 @@ export class InMemoryFileSystem implements VirtualFileSystem {
 			throw errnoError("ENOENT", `open '${targetPath}'`);
 		}
 		const nextSize = Math.max(entry.data.length, offset + data.length);
-		const updated = new Uint8Array(nextSize);
-		updated.set(entry.data);
-		updated.set(data, offset);
+			const updated = new Uint8Array(nextSize);
+			updated.set(entry.data);
+			updated.set(new Uint8Array(data), offset);
 		entry.data = updated;
 		entry.mtimeMs = Date.now();
 		entry.ctimeMs = Date.now();
@@ -2710,21 +2712,18 @@ class NativeKernel implements Kernel {
 		filesystem: VirtualFileSystem,
 		options?: { readOnly?: boolean },
 	): void {
-		if (!this.proxy) {
-			this.pendingLocalMounts.push(
-				makeLocalCompatMount({
-					path: mountPath,
-					fs: filesystem,
-					readOnly: options?.readOnly,
-				}),
-			);
-			return;
-		}
 		const localMount = makeLocalCompatMount({
 			path: mountPath,
 			fs: filesystem,
 			readOnly: options?.readOnly,
 		});
+		this.pendingLocalMounts.unshift(localMount);
+		this.pendingLocalMounts.sort(
+			(left, right) => right.path.length - left.path.length,
+		);
+		if (!this.proxy) {
+			return;
+		}
 		this.proxy.mountFs(mountPath, filesystem, {
 			readOnly: localMount.readOnly,
 			sidecarMount: localMount.sidecarMount,
@@ -2732,6 +2731,13 @@ class NativeKernel implements Kernel {
 	}
 
 	unmountFs(mountPath: string): void {
+		const normalized = normalizePath(mountPath);
+		const pendingIndex = this.pendingLocalMounts.findIndex(
+			(mount) => mount.path === normalized,
+		);
+		if (pendingIndex >= 0) {
+			this.pendingLocalMounts.splice(pendingIndex, 1);
+		}
 		this.proxy?.unmountFs(mountPath);
 	}
 

--- a/packages/core/src/sidecar/rpc-client.ts
+++ b/packages/core/src/sidecar/rpc-client.ts
@@ -34,6 +34,7 @@ import type {
 	GuestFilesystemStat,
 	SidecarProcess,
 	SidecarProcessSnapshotEntry,
+	SidecarPermissionsPolicy,
 	SidecarSignalHandlerRegistration,
 	SidecarSocketStateEntry,
 } from "./native-process-client.js";
@@ -229,6 +230,7 @@ export interface LocalCompatMount {
 	path: string;
 	fs: VirtualFileSystem;
 	readOnly: boolean;
+	sidecarMount?: SidecarMountDescriptor;
 }
 
 interface KernelSocketSnapshot {
@@ -290,6 +292,10 @@ interface NativeSidecarKernelProxyOptions {
 	cwd: string;
 	defaultExecCwd?: string;
 	localMounts: LocalCompatMount[];
+	sidecarMounts: SidecarMountDescriptor[];
+	permissions?: SidecarPermissionsPolicy;
+	commandPermissions?: Parameters<SidecarProcess["configureVm"]>[2]["commandPermissions"];
+	loopbackExemptPorts?: number[];
 	commandGuestPaths: ReadonlyMap<string, string>;
 	onWasmCommandResolved?: (command: string) => void;
 	onDispose?: () => Promise<void>;
@@ -307,6 +313,12 @@ export class NativeSidecarKernelProxy {
 	private readonly session: AuthenticatedSession;
 	private readonly vm: CreatedVm;
 	private readonly localMounts: LocalCompatMount[];
+	private readonly baseSidecarMounts: SidecarMountDescriptor[];
+	private readonly permissions: SidecarPermissionsPolicy | undefined;
+	private readonly commandPermissions:
+		| Parameters<SidecarProcess["configureVm"]>[2]["commandPermissions"]
+		| undefined;
+	private readonly loopbackExemptPorts: number[] | undefined;
 	private readonly commandDrivers: Map<string, string>;
 	private readonly onWasmCommandResolved:
 		| ((command: string) => void)
@@ -329,6 +341,7 @@ export class NativeSidecarKernelProxy {
 	private zombieTimerCountRefresh: Promise<void> | null = null;
 	private disposed = false;
 	private pumpError: Error | null = null;
+	private mountReconfigurePromise: Promise<void> | null = null;
 	private nextSyntheticPid = SYNTHETIC_PID_BASE;
 	private readonly eventPumpAbortController = new AbortController();
 	private readonly eventPump: Promise<void>;
@@ -343,6 +356,15 @@ export class NativeSidecarKernelProxy {
 		this.localMounts = [...options.localMounts].sort(
 			(left, right) => right.path.length - left.path.length,
 		);
+		const localMountPaths = new Set(this.localMounts.map((mount) => mount.path));
+		this.baseSidecarMounts = options.sidecarMounts.filter(
+			(mount) =>
+				mount.plugin.id !== "js_bridge" ||
+				!localMountPaths.has(posixPath.normalize(mount.guestPath)),
+		);
+		this.permissions = options.permissions;
+		this.commandPermissions = options.commandPermissions;
+		this.loopbackExemptPorts = options.loopbackExemptPorts;
 		this.commandDrivers = buildCommandMap(options.commandGuestPaths);
 		this.onWasmCommandResolved = options.onWasmCommandResolved;
 		this.onDispose = options.onDispose;
@@ -378,6 +400,7 @@ export class NativeSidecarKernelProxy {
 		}
 		this.disposed = true;
 		this.eventPumpAbortController.abort();
+		await this.mountReconfigurePromise?.catch(() => {});
 
 		const liveProcesses = [...this.trackedProcesses.values()].filter(
 			(entry) => entry.exitCode === null,
@@ -1298,16 +1321,18 @@ export class NativeSidecarKernelProxy {
 	mountFs(
 		path: string,
 		driver: VirtualFileSystem,
-		options?: { readOnly?: boolean },
+		options?: { readOnly?: boolean; sidecarMount?: SidecarMountDescriptor },
 	): void {
 		this.localMounts.unshift({
 			path: posixPath.normalize(path),
 			fs: driver,
 			readOnly: options?.readOnly ?? false,
+			sidecarMount: options?.sidecarMount,
 		});
 		this.localMounts.sort(
 			(left, right) => right.path.length - left.path.length,
 		);
+		void this.reconfigureSidecarMounts().catch(() => {});
 	}
 
 	unmountFs(path: string): void {
@@ -1317,6 +1342,53 @@ export class NativeSidecarKernelProxy {
 		);
 		if (index >= 0) {
 			this.localMounts.splice(index, 1);
+			void this.reconfigureSidecarMounts().catch(() => {});
+		}
+	}
+
+	private desiredSidecarMounts(): SidecarMountDescriptor[] {
+		return [
+			...this.baseSidecarMounts,
+			...this.localMounts.map(
+				(mount) =>
+					mount.sidecarMount ?? {
+						guestPath: mount.path,
+						readOnly: mount.readOnly,
+						plugin: {
+							id: "js_bridge",
+							config: {},
+						},
+					},
+			),
+		];
+	}
+
+	private reconfigureSidecarMounts(): Promise<void> {
+		const run = async () => {
+			if (this.disposed) {
+				return;
+			}
+			await this.client.configureVm(this.session, this.vm, {
+				mounts: this.desiredSidecarMounts(),
+				permissions: this.permissions,
+				commandPermissions: this.commandPermissions,
+				loopbackExemptPorts: this.loopbackExemptPorts,
+			});
+		};
+		const previous = this.mountReconfigurePromise ?? Promise.resolve();
+		const next = previous.then(run, run);
+		const tracked = next.finally(() => {
+			if (this.mountReconfigurePromise === tracked) {
+				this.mountReconfigurePromise = null;
+			}
+		});
+		this.mountReconfigurePromise = tracked;
+		return tracked;
+	}
+
+	private async waitForMountReconfigure(): Promise<void> {
+		if (this.mountReconfigurePromise) {
+			await this.mountReconfigurePromise;
 		}
 	}
 
@@ -1471,6 +1543,7 @@ export class NativeSidecarKernelProxy {
 	}
 
 	private async startTrackedProcess(entry: TrackedProcessEntry): Promise<void> {
+		await this.waitForMountReconfigure();
 		const started = await this.client.execute(this.session, this.vm, {
 			processId: entry.processId,
 			command: entry.command,
@@ -2071,7 +2144,8 @@ export class NativeSidecarKernelProxy {
 		return this.dispatchNativeRead(path) as Promise<T>;
 	}
 
-	private dispatchNativeRead(path: string): Promise<Uint8Array> {
+	private async dispatchNativeRead(path: string): Promise<Uint8Array> {
+		await this.waitForMountReconfigure();
 		return this.client.readFile(this.session, this.vm, path);
 	}
 
@@ -2088,6 +2162,7 @@ export class NativeSidecarKernelProxy {
 			await handler(local.mount, local.relativePath);
 			return;
 		}
+		await this.waitForMountReconfigure();
 		await nativeHandler();
 	}
 

--- a/packages/core/tests/allowed-node-builtins.test.ts
+++ b/packages/core/tests/allowed-node-builtins.test.ts
@@ -66,6 +66,7 @@ describe("NativeSidecarKernelProxy execute payloads", () => {
 			env: { HOME: "/workspace" },
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map(),
 		});
 
@@ -108,6 +109,7 @@ describe("NativeSidecarKernelProxy execute payloads", () => {
 			env: { HOME: "/workspace" },
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map([["sh", "/__secure_exec/commands/000/sh"]]),
 		});
 
@@ -138,6 +140,7 @@ describe("NativeSidecarKernelProxy execute payloads", () => {
 			env: { HOME: "/workspace" },
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map(),
 		});
 

--- a/packages/core/tests/facade-forwarding.test.ts
+++ b/packages/core/tests/facade-forwarding.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, vi } from "vitest";
+import { AgentOs } from "../src/index.js";
+
+describe("AgentOs facade forwarding", () => {
+	test("rawSessionSend forwards method and params to the session request path", async () => {
+		const sendSessionRequest = vi.fn(async () => ({
+			jsonrpc: "2.0" as const,
+			id: 1,
+			result: { ok: true },
+		}));
+		const vm = Object.create(AgentOs.prototype) as AgentOs & {
+			_sendSessionRequest: typeof sendSessionRequest;
+		};
+		vm._sendSessionRequest = sendSessionRequest;
+
+		await expect(
+			vm.rawSessionSend("session-1", "custom/method", { value: 42 }),
+		).resolves.toMatchObject({
+			result: { ok: true },
+		});
+
+		expect(sendSessionRequest).toHaveBeenCalledWith("session-1", "custom/method", {
+			value: 42,
+		});
+	});
+
+	test("resizeShell forwards dimensions to the tracked shell handle", () => {
+		const resize = vi.fn();
+		const vm = Object.create(AgentOs.prototype) as AgentOs & {
+			_shells: Map<string, { handle: { resize(cols: number, rows: number): void } }>;
+		};
+		vm._shells = new Map([
+			[
+				"shell-1",
+				{
+					handle: {
+						resize,
+					},
+				},
+			],
+		]);
+
+		vm.resizeShell("shell-1", 120, 40);
+
+		expect(resize).toHaveBeenCalledWith(120, 40);
+	});
+
+	test("resizeShell rejects unknown shell ids", () => {
+		const vm = Object.create(AgentOs.prototype) as AgentOs & {
+			_shells: Map<string, unknown>;
+		};
+		vm._shells = new Map();
+
+		expect(() => vm.resizeShell("missing", 80, 24)).toThrow(
+			"Shell not found: missing",
+		);
+	});
+});

--- a/packages/core/tests/filesystem-symlink-delete.test.ts
+++ b/packages/core/tests/filesystem-symlink-delete.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AgentOs } from "../src/index.js";
+
+describe("filesystem symlink deletion", () => {
+	let vm: AgentOs;
+
+	beforeEach(async () => {
+		vm = await AgentOs.create({ defaultSoftware: false });
+	});
+
+	afterEach(async () => {
+		await vm.dispose();
+	});
+
+	test("delete symlink to directory removes the link, not the target", async () => {
+		const vfs = (
+			vm as unknown as {
+				_vfs(): {
+					symlink(target: string, linkPath: string): Promise<void>;
+					lstat(path: string): Promise<{ isSymbolicLink: boolean }>;
+				};
+			}
+		)._vfs();
+
+		await vm.mkdir("/tmp/real-dir");
+		await vm.writeFile("/tmp/real-dir/child.txt", "keep me");
+		await vfs.symlink("/tmp/real-dir", "/tmp/dir-link");
+		expect((await vfs.lstat("/tmp/dir-link")).isSymbolicLink).toBe(true);
+
+		await vm.delete("/tmp/dir-link", { recursive: true });
+
+		await expect(vfs.lstat("/tmp/dir-link")).rejects.toThrow("ENOENT");
+		expect(new TextDecoder().decode(await vm.readFile("/tmp/real-dir/child.txt"))).toBe(
+			"keep me",
+		);
+	});
+});

--- a/packages/core/tests/host-tools.test.ts
+++ b/packages/core/tests/host-tools.test.ts
@@ -72,6 +72,46 @@ describe("host tool description limits", () => {
 		);
 	});
 
+	test("rejects toolkit names that cannot become stable command names", () => {
+		expect(() =>
+			validateToolkits([
+				toolKit({
+					name: "Browser_Tools",
+					description: "Browser automation",
+					tools: {
+						screenshot: hostTool({
+							description: "Take a screenshot",
+							inputSchema: z.object({ url: z.string() }),
+							execute: () => ({ ok: true }),
+						}),
+					},
+				}),
+			]),
+		).toThrow(
+			'Toolkit name "Browser_Tools" must be lowercase alphanumeric with optional single hyphen separators',
+		);
+	});
+
+	test("rejects tool names that cannot become stable subcommands", () => {
+		expect(() =>
+			validateToolkits([
+				toolKit({
+					name: "browser-tools",
+					description: "Browser automation",
+					tools: {
+						"screenshot_now": hostTool({
+							description: "Take a screenshot",
+							inputSchema: z.object({ url: z.string() }),
+							execute: () => ({ ok: true }),
+						}),
+					},
+				}),
+			]),
+		).toThrow(
+			'Tool name "screenshot_now" must be lowercase alphanumeric with optional single hyphen separators',
+		);
+	});
+
 	test("fails loudly when a host tool input schema uses an unsupported discriminated union", () => {
 		const tool = hostTool({
 			description: "Inspect a variant payload",

--- a/packages/core/tests/in-memory-filesystem.test.ts
+++ b/packages/core/tests/in-memory-filesystem.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { createInMemoryFileSystem } from "../src/index.js";
+
+const decoder = new TextDecoder();
+
+describe("InMemoryFileSystem", () => {
+	test("copies caller-provided write buffers and returned read buffers", async () => {
+		const fs = createInMemoryFileSystem();
+		const input = new Uint8Array([97, 98, 99]);
+
+		await fs.writeFile("/data.txt", input);
+		input[0] = 120;
+
+		const firstRead = await fs.readFile("/data.txt");
+		expect(decoder.decode(firstRead)).toBe("abc");
+
+		firstRead[1] = 121;
+		expect(decoder.decode(await fs.readFile("/data.txt"))).toBe("abc");
+	});
+
+	test("removeFile on a symlink removes the link without deleting the target", async () => {
+		const fs = createInMemoryFileSystem();
+
+		await fs.writeFile("/target.txt", "target content");
+		await fs.symlink("/target.txt", "/link.txt");
+
+		await fs.removeFile("/link.txt");
+
+		expect(await fs.exists("/link.txt")).toBe(false);
+		expect(decoder.decode(await fs.readFile("/target.txt"))).toBe(
+			"target content",
+		);
+	});
+});

--- a/packages/core/tests/limits.test.ts
+++ b/packages/core/tests/limits.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { AgentOs } from "../src/index.js";
+
+describe("AgentOs limits", () => {
+	let vm: AgentOs | undefined;
+
+	afterEach(async () => {
+		await vm?.dispose();
+		vm = undefined;
+	});
+
+	test("maxProcessArgvBytes is forwarded to the VM process runtime", async () => {
+		vm = await AgentOs.create({
+			defaultSoftware: false,
+			limits: {
+				resources: {
+					maxProcessArgvBytes: 16,
+				},
+			},
+		});
+
+		const result = await vm.execArgv("node", [
+			"-e",
+			"console.log('should not run')",
+			"this-argument-is-too-long",
+		]).then(
+			(value) => ({ type: "result" as const, value }),
+			(error) => ({ type: "error" as const, error }),
+		);
+
+		if (result.type === "result") {
+			expect(result.value.exitCode).not.toBe(0);
+			expect(`${result.value.stderr}\n${result.value.stdout}`).toMatch(
+				/argv|argument|limit|too large/i,
+			);
+		} else {
+			expect(result.error).toBeInstanceOf(Error);
+			expect(String(result.error.message)).toMatch(/argv|argument|limit|too large/i);
+		}
+	});
+});

--- a/packages/core/tests/mount.test.ts
+++ b/packages/core/tests/mount.test.ts
@@ -4,24 +4,81 @@ import {
 	createInMemoryFileSystem,
 	createInMemoryLayerStore,
 	createSnapshotExport,
+	type VirtualFileSystem,
 } from "../src/index.js";
 
+const VFS_METHODS = [
+	"readFile",
+	"readTextFile",
+	"readDir",
+	"readDirWithTypes",
+	"writeFile",
+	"createDir",
+	"mkdir",
+	"exists",
+	"stat",
+	"removeFile",
+	"removeDir",
+	"rename",
+	"realpath",
+	"symlink",
+	"readlink",
+	"lstat",
+	"link",
+	"chmod",
+	"chown",
+	"utimes",
+	"truncate",
+	"pread",
+	"pwrite",
+] as const;
+
+function createRecordingFilesystem(): {
+	fs: VirtualFileSystem;
+	calls: string[];
+} {
+	const base = createInMemoryFileSystem();
+	const calls: string[] = [];
+	const delegates = base as unknown as Record<
+		(typeof VFS_METHODS)[number],
+		(...args: unknown[]) => unknown
+	>;
+	const fs = Object.fromEntries(
+		VFS_METHODS.map((method) => [
+			method,
+			(...args: unknown[]) => {
+				calls.push(`${method}:${String(args[0])}`);
+				return delegates[method].apply(base, args);
+			},
+		]),
+	) as unknown as VirtualFileSystem;
+
+	return { fs, calls };
+}
+
+function createMountVm(
+	options: NonNullable<Parameters<typeof AgentOs.create>[0]> = {},
+): Promise<AgentOs> {
+	return AgentOs.create({ defaultSoftware: false, ...options });
+}
+
 describe("mount integration", () => {
-	let vm: AgentOs;
+	let vm: AgentOs | undefined;
 
 	afterEach(async () => {
-		await vm.dispose();
+		await vm?.dispose();
+		vm = undefined;
 	});
 
 	test("create with memory mount", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],
 		});
 		expect(await vm.exists("/data")).toBe(true);
 	});
 
 	test("writeFile and readFile round-trip through mounted backend", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],
 		});
 		await vm.writeFile("/data/foo.txt", "hello mount");
@@ -30,7 +87,7 @@ describe("mount integration", () => {
 	});
 
 	test("create with declarative native memory mount config", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [
 				{
 					path: "/native",
@@ -47,7 +104,7 @@ describe("mount integration", () => {
 	});
 
 	test("root FS and mount are separate", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],
 		});
 		await vm.writeFile("/home/agentos/foo.txt", "root content");
@@ -60,7 +117,7 @@ describe("mount integration", () => {
 	});
 
 	test("runtime mountFs and unmountFs work", async () => {
-		vm = await AgentOs.create();
+		vm = await createMountVm();
 
 		vm.mountFs("/mnt/dynamic", createInMemoryFileSystem());
 		await vm.writeFile("/mnt/dynamic/test.txt", "dynamic");
@@ -71,8 +128,25 @@ describe("mount integration", () => {
 		await expect(vm.readFile("/mnt/dynamic/test.txt")).rejects.toThrow();
 	});
 
+	test("runtime mountFs routes through a plain JS VFS driver", async () => {
+		const mounted = createRecordingFilesystem();
+		vm = await createMountVm();
+
+		vm.mountFs("/mnt/custom", mounted.fs);
+		await vm.writeFile("/mnt/custom/note.txt", "from custom vfs");
+
+		expect(
+			new TextDecoder().decode(await vm.readFile("/mnt/custom/note.txt")),
+		).toBe("from custom vfs");
+		expect(mounted.calls).toContain("writeFile:/note.txt");
+		expect(mounted.calls).toContain("readFile:/note.txt");
+
+		vm.unmountFs("/mnt/custom");
+		await expect(vm.readFile("/mnt/custom/note.txt")).rejects.toThrow();
+	});
+
 	test("readdir('/') includes 'data' alongside standard POSIX dirs", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],
 		});
 		const entries = await vm.readdir("/");
@@ -83,7 +157,7 @@ describe("mount integration", () => {
 	});
 
 	test("rename across mounts throws EXDEV", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],
 		});
 		await vm.writeFile("/data/cross.txt", "cross-mount");
@@ -93,7 +167,7 @@ describe("mount integration", () => {
 	});
 
 	test("readOnly mount blocks writeFile with EROFS", async () => {
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [
 				{ path: "/ro", driver: createInMemoryFileSystem(), readOnly: true },
 			],
@@ -127,7 +201,7 @@ describe("mount integration", () => {
 			]).source,
 		});
 
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [
 				{
 					path: "/data",
@@ -164,7 +238,7 @@ describe("mount integration", () => {
 			]).source,
 		});
 
-		vm = await AgentOs.create({
+		vm = await createMountVm({
 			mounts: [
 				{
 					path: "/data",

--- a/packages/core/tests/mount.test.ts
+++ b/packages/core/tests/mount.test.ts
@@ -126,7 +126,9 @@ describe("mount integration", () => {
 
 		vm.unmountFs("/mnt/dynamic");
 		await expect(vm.readFile("/mnt/dynamic/test.txt")).rejects.toThrow();
-	});
+		// Runtime mount + unmount each trigger a full sidecar reconfigure, so this
+		// integration test needs more than the 30s default (see PR #1521 CI).
+	}, 120_000);
 
 	test("runtime mountFs routes through a plain JS VFS driver", async () => {
 		const mounted = createRecordingFilesystem();
@@ -143,7 +145,9 @@ describe("mount integration", () => {
 
 		vm.unmountFs("/mnt/custom");
 		await expect(vm.readFile("/mnt/custom/note.txt")).rejects.toThrow();
-	});
+		// Runtime mount + unmount each trigger a full sidecar reconfigure, so this
+		// integration test needs more than the 30s default (see PR #1521 CI).
+	}, 120_000);
 
 	test("guest processes can read and write a create-time plain JS VFS mount", async () => {
 		const mounted = createRecordingFilesystem();

--- a/packages/core/tests/mount.test.ts
+++ b/packages/core/tests/mount.test.ts
@@ -145,6 +145,53 @@ describe("mount integration", () => {
 		await expect(vm.readFile("/mnt/custom/note.txt")).rejects.toThrow();
 	});
 
+	test("guest processes can read and write a create-time plain JS VFS mount", async () => {
+		const mounted = createRecordingFilesystem();
+		vm = await createMountVm({
+			mounts: [{ path: "/mnt/custom", driver: mounted.fs }],
+		});
+
+		await vm.writeFile("/mnt/custom/host.txt", "from host api");
+		const result = await vm.execArgv("node", [
+			"-e",
+			[
+				'const { readFileSync, writeFileSync } = require("node:fs");',
+				'console.log(readFileSync("/mnt/custom/host.txt", "utf8"));',
+				'writeFileSync("/mnt/custom/guest.txt", "from guest process");',
+			].join("\n"),
+		]);
+		expect(result.exitCode, result.stderr).toBe(0);
+		expect(result.stdout.trim()).toBe("from host api");
+		expect(mounted.calls).toContain("readFile:/host.txt");
+		expect(mounted.calls).toContain("writeFile:/guest.txt");
+		expect(
+			new TextDecoder().decode(await vm.readFile("/mnt/custom/guest.txt")),
+		).toBe("from guest process");
+	});
+
+	test("guest processes can read and write a runtime-mounted plain JS VFS", async () => {
+		const mounted = createRecordingFilesystem();
+		vm = await createMountVm();
+
+		vm.mountFs("/mnt/custom", mounted.fs);
+		await vm.writeFile("/mnt/custom/host.txt", "from host api");
+		const result = await vm.execArgv("node", [
+			"-e",
+			[
+				'const { readFileSync, writeFileSync } = require("node:fs");',
+				'console.log(readFileSync("/mnt/custom/host.txt", "utf8"));',
+				'writeFileSync("/mnt/custom/guest.txt", "from guest process");',
+			].join("\n"),
+		]);
+		expect(result.exitCode, result.stderr).toBe(0);
+		expect(result.stdout.trim()).toBe("from host api");
+		expect(mounted.calls).toContain("readFile:/host.txt");
+		expect(mounted.calls).toContain("writeFile:/guest.txt");
+		expect(
+			new TextDecoder().decode(await vm.readFile("/mnt/custom/guest.txt")),
+		).toBe("from guest process");
+	});
+
 	test("readdir('/') includes 'data' alongside standard POSIX dirs", async () => {
 		vm = await createMountVm({
 			mounts: [{ path: "/data", driver: createInMemoryFileSystem() }],

--- a/packages/core/tests/native-sidecar-process.test.ts
+++ b/packages/core/tests/native-sidecar-process.test.ts
@@ -385,6 +385,7 @@ describe("native sidecar process client", () => {
 			env: {},
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map(),
 		});
 

--- a/packages/core/tests/os-instructions.test.ts
+++ b/packages/core/tests/os-instructions.test.ts
@@ -1,15 +1,8 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
-import { moduleAccessMounts } from "./helpers/node-modules-mount.js";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { AgentOs } from "../src/agent-os.js";
-import { createHostDirBackend } from "../src/host-dir-mount.js";
 
-/**
- * Workspace root has shamefully-hoisted node_modules with pi-acp available.
- */
-const MODULE_ACCESS_CWD = resolve(import.meta.dirname, "..");
 const OS_INSTRUCTIONS_FIXTURE = resolve(
 	import.meta.dirname,
 	"../fixtures/AGENTOS_SYSTEM_PROMPT.md",
@@ -91,29 +84,15 @@ process.stdin.on('data', (chunk) => {
 
 describe("createSession OS instructions integration", () => {
 	let vm: AgentOs;
-	let hostWorkspaceDir: string;
 
 	beforeEach(async () => {
-		hostWorkspaceDir = fs.mkdtempSync(
-			os.tmpdir() + "/agentos-os-instructions-",
-		);
 		vm = await AgentOs.create({
-			mounts: [
-				...moduleAccessMounts(MODULE_ACCESS_CWD),
-				{
-					path: "/home/agentos",
-					plugin: createHostDirBackend({
-						hostPath: hostWorkspaceDir,
-						readOnly: false,
-					}),
-				},
-			],
+			defaultSoftware: false,
 		});
 	});
 
 	afterEach(async () => {
 		await vm.dispose();
-		fs.rmSync(hostWorkspaceDir, { recursive: true, force: true });
 	});
 
 	/**
@@ -121,17 +100,20 @@ describe("createSession OS instructions integration", () => {
 	 * resolving the real adapter from node_modules.
 	 */
 	function useMockAdapterBin(scriptPath: string): () => void {
-		const origResolve = (
+		const privateVm = vm as unknown as {
+			_resolveAdapterBin: (pkg: string) => string;
+			_resolvePackageBin: (pkg: string, bin?: string) => string;
+		};
+		const origResolveAdapter = (
 			vm as unknown as { _resolveAdapterBin: (pkg: string) => string }
 		)._resolveAdapterBin;
-		(
-			vm as unknown as { _resolveAdapterBin: (pkg: string) => string }
-		)._resolveAdapterBin = (_pkg: string) => scriptPath;
+		const origResolvePackageBin = privateVm._resolvePackageBin;
+		privateVm._resolveAdapterBin = (_pkg: string) => scriptPath;
+		privateVm._resolvePackageBin = (_pkg: string, _bin?: string) => "/tmp/mock-bin";
 
 		return () => {
-			(
-				vm as unknown as { _resolveAdapterBin: (pkg: string) => string }
-			)._resolveAdapterBin = origResolve;
+			privateVm._resolveAdapterBin = origResolveAdapter;
+			privateVm._resolvePackageBin = origResolvePackageBin;
 		};
 	}
 
@@ -290,6 +272,37 @@ describe("createSession OS instructions integration", () => {
 			expect(argIdx).toBeGreaterThan(-1);
 			const instructionsArg = argv[argIdx + 1];
 			expect(instructionsArg).toContain(additionalText);
+
+			vm.closeSession(sessionId);
+		} finally {
+			restore();
+		}
+	});
+
+	test("AgentOs.create additionalInstructions are included in created sessions", async () => {
+		await vm.dispose();
+		const vmLevelInstructions =
+			"CUSTOM_MARKER: VM-level instruction applies to every session.";
+		vm = await AgentOs.create({
+			defaultSoftware: false,
+			additionalInstructions: vmLevelInstructions,
+		});
+
+		const scriptPath = "/tmp/mock-adapter.mjs";
+		await vm.writeFile(scriptPath, MOCK_ACP_ADAPTER);
+		const restore = useMockAdapterBin(scriptPath);
+
+		try {
+			const { sessionId } = await vm.createSession("pi");
+			const agentInfo = vm.getSessionAgentInfo(sessionId) as {
+				argv?: string[];
+			};
+			const argv = agentInfo.argv ?? [];
+
+			const argIdx = argv.indexOf("--append-system-prompt");
+			expect(argIdx).toBeGreaterThan(-1);
+			const instructionsArg = argv[argIdx + 1];
+			expect(instructionsArg).toContain(vmLevelInstructions);
 
 			vm.closeSession(sessionId);
 		} finally {

--- a/packages/core/tests/public-api-exports.test.ts
+++ b/packages/core/tests/public-api-exports.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, test } from "vitest";
 import {
+	AGENT_CONFIGS,
+	AgentOs,
+	AgentOsSidecar,
+	CronManager,
+	KernelError,
+	MAX_TOOL_DESCRIPTION_LENGTH,
 	InvalidScheduleError,
 	PastScheduleError,
+	TimerScheduleDriver,
+	agentOsLimitsSchema,
+	agentOsOptionsSchema,
+	createHostDirBackend,
+	createInMemoryFileSystem,
+	createInMemoryLayerStore,
+	createSnapshotExport,
+	defineSoftware,
+	hostTool,
+	hostToolSchema,
 	isAcpTimeoutErrorData,
 	isUnknownSessionErrorData,
+	mountConfigSchema,
 	nodeModulesMount,
+	parseAgentOsOptions,
+	rootFilesystemConfigSchema,
+	toolKit,
+	toolKitSchema,
+	validateToolkits,
 	type AcpTimeoutErrorData,
 	type AgentOsLimits,
 	type ExecOptions,
@@ -26,6 +48,36 @@ import {
 } from "../src/index.js";
 
 describe("root public API exports", () => {
+	test("re-exports the main public value surface from the root entrypoint", () => {
+		expect(AgentOs).toBeTypeOf("function");
+		expect(AgentOsSidecar).toBeTypeOf("function");
+		expect(AGENT_CONFIGS).toBeTypeOf("object");
+		expect(CronManager).toBeTypeOf("function");
+		expect(TimerScheduleDriver).toBeTypeOf("function");
+		expect(createHostDirBackend).toBeTypeOf("function");
+		expect(hostTool).toBeTypeOf("function");
+		expect(toolKit).toBeTypeOf("function");
+		expect(validateToolkits).toBeTypeOf("function");
+		expect(MAX_TOOL_DESCRIPTION_LENGTH).toBeGreaterThan(0);
+		expect(agentOsLimitsSchema.safeParse({}).success).toBe(true);
+		expect(agentOsOptionsSchema.safeParse({ defaultSoftware: false }).success).toBe(
+			true,
+		);
+		expect(hostToolSchema).toBeTypeOf("object");
+		expect(toolKitSchema).toBeTypeOf("object");
+		expect(mountConfigSchema).toBeTypeOf("object");
+		expect(rootFilesystemConfigSchema).toBeTypeOf("object");
+		expect(parseAgentOsOptions({ defaultSoftware: false })).toEqual({
+			defaultSoftware: false,
+		});
+		expect(createInMemoryFileSystem).toBeTypeOf("function");
+		expect(KernelError).toBeTypeOf("function");
+		expect(createInMemoryLayerStore).toBeTypeOf("function");
+		expect(createSnapshotExport).toBeTypeOf("function");
+		expect(defineSoftware({ name: "x", type: "wasm-commands", commandDir: "/tmp" }))
+			.toMatchObject({ name: "x" });
+	});
+
 	test("re-exports current public SDK types from the root entrypoint", () => {
 		void (null as AcpTimeoutErrorData | null);
 		void (null as AgentOsLimits | null);

--- a/packages/core/tests/runtime-compat-mount.test.ts
+++ b/packages/core/tests/runtime-compat-mount.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	createInMemoryFileSystem,
+	createKernel,
+	type Kernel,
+} from "../src/runtime-compat.js";
+
+describe("runtime-compat mountFs bookkeeping", () => {
+	let kernel: Kernel | undefined;
+
+	afterEach(async () => {
+		await kernel?.dispose();
+		kernel = undefined;
+	});
+
+	test("unmountFs cancels a queued mount before kernel initialization", async () => {
+		const mounted = createInMemoryFileSystem();
+		await mounted.writeFile("/file.txt", "should not be visible");
+
+		kernel = createKernel({
+			filesystem: createInMemoryFileSystem(),
+		});
+		kernel.mountFs("/queued", mounted);
+		kernel.unmountFs("/queued");
+
+		await expect(kernel.readFile("/queued/file.txt")).rejects.toThrow();
+	});
+});

--- a/packages/core/tests/session-id-collision.test.ts
+++ b/packages/core/tests/session-id-collision.test.ts
@@ -59,6 +59,16 @@ function cannedStateResponse(sessionId: string) {
 	};
 }
 
+function cannedResumedResponse(sessionId: string) {
+	return {
+		tag: "AcpSessionResumedResponse" as const,
+		val: {
+			sessionId,
+			mode: "native",
+		},
+	};
+}
+
 function sessionUpdateNotification(text: string): string {
 	return JSON.stringify({
 		jsonrpc: "2.0",
@@ -81,7 +91,7 @@ describe("colliding adapter sessionId isolation (I.4 / J.4)", () => {
 	});
 
 	test("a second createSession returning a colliding sessionId must not orphan the first session's handlers", async () => {
-		vm = await AgentOs.create({});
+		vm = await AgentOs.create({ defaultSoftware: false });
 
 		const internal = vm as unknown as {
 			_resolveAgentConfig(t: string): unknown;
@@ -151,5 +161,65 @@ describe("colliding adapter sessionId isolation (I.4 / J.4)", () => {
 			// Accepted: the original subscriber must still be wired up.
 			expect(firstEvents).toHaveLength(1);
 		}
+	});
+
+	test("resumeSession returning a colliding live sessionId is rejected without orphaning handlers", async () => {
+		vm = await AgentOs.create({ defaultSoftware: false });
+
+		const internal = vm as unknown as {
+			_resolveAgentConfig(t: string): unknown;
+			_resolveAdapterBin(p: string): string;
+			_sendAcpRequest(req: { tag: string }): Promise<unknown>;
+		};
+
+		vi.spyOn(internal, "_resolveAgentConfig").mockReturnValue({
+			acpAdapter: "@mock/adapter",
+			agentPackage: "@mock/agent",
+		});
+		vi.spyOn(internal, "_resolveAdapterBin").mockReturnValue(
+			"/root/node_modules/@mock/adapter/bin.js",
+		);
+		vi.spyOn(internal, "_sendAcpRequest").mockImplementation(
+			async (req: { tag: string }) => {
+				if (req.tag === "AcpCreateSessionRequest") {
+					return cannedCreatedResponse(COLLIDING_SESSION_ID);
+				}
+				if (req.tag === "AcpResumeSessionRequest") {
+					return cannedResumedResponse(COLLIDING_SESSION_ID);
+				}
+				if (req.tag === "AcpGetSessionStateRequest") {
+					return cannedStateResponse(COLLIDING_SESSION_ID);
+				}
+				throw new Error(`unexpected acp request ${req.tag}`);
+			},
+		);
+
+		const first = await vm.createSession("mock");
+		expect(first.sessionId).toBe(COLLIDING_SESSION_ID);
+
+		const firstEvents: JsonRpcNotification[] = [];
+		vm.onSessionEvent(first.sessionId, (n) => firstEvents.push(n));
+
+		await expect(
+			vm.resumeSession("external-session", "mock"),
+		).rejects.toThrow(`session id collision: ${COLLIDING_SESSION_ID}`);
+
+		const payload = encodeAcpEvent({
+			tag: "AcpSessionEvent",
+			val: {
+				sessionId: COLLIDING_SESSION_ID,
+				notification: sessionUpdateNotification("post-resume-collision"),
+			},
+		});
+		(
+			vm as unknown as {
+				_handleAcpExtEvent(env: {
+					namespace: string;
+					payload: Uint8Array;
+				}): void;
+			}
+		)._handleAcpExtEvent({ namespace: ACP_EXTENSION_NAMESPACE, payload });
+
+		expect(firstEvents).toHaveLength(1);
 	});
 });

--- a/packages/core/tests/wasm-permission-tiers.test.ts
+++ b/packages/core/tests/wasm-permission-tiers.test.ts
@@ -61,6 +61,7 @@ describe("WASM command permission tiers", () => {
 			env: { HOME: "/workspace" },
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map([["grep", "/__secure_exec/commands/000/grep"]]),
 		});
 
@@ -92,6 +93,7 @@ describe("WASM command permission tiers", () => {
 			env: { HOME: "/workspace" },
 			cwd: "/workspace",
 			localMounts: [],
+			sidecarMounts: [],
 			commandGuestPaths: new Map([["echo", "/__secure_exec/commands/000/echo"]]),
 		});
 

--- a/website/src/content/docs/docs/filesystem.mdx
+++ b/website/src/content/docs/docs/filesystem.mdx
@@ -115,15 +115,19 @@ registry.start();
 
 <TabItem label="In-memory">
 
+Use the built-in `memory` plugin for an ephemeral mounted directory in the native RivetKit `agentOS()` actor.
+
 ```ts
 import { agentOS, setup } from "@rivet-dev/agentos";
-import { createInMemoryFileSystem } from "@rivet-dev/agent-os-core";
 import pi from "@agentos-software/pi";
 
 const vm = agentOS({
   software: [pi],
   mounts: [
-    { path: "/home/agentos/scratch", driver: createInMemoryFileSystem() },
+    {
+      path: "/home/agentos/scratch",
+      plugin: { id: "memory", config: {} },
+    },
   ],
 });
 
@@ -132,6 +136,24 @@ registry.start();
 ```
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/filesystem)*
+
+</TabItem>
+
+<TabItem label="Custom JS VFS">
+
+Use `mountFs()` for a callback-backed JS filesystem driver. The driver must live in the same JS process as the `AgentOs` instance, such as direct core usage or a custom RivetKit actor that owns an `AgentOs` instance.
+
+```ts
+import { AgentOs, createInMemoryFileSystem } from "@rivet-dev/agentos-core";
+
+const vm = await AgentOs.create({ defaultSoftware: false });
+const driver = createInMemoryFileSystem();
+
+vm.mountFs("/home/agentos/scratch", driver);
+await vm.writeFile("/home/agentos/scratch/hello.txt", "hello");
+```
+
+The native `agentOS()` actor cannot accept `{ driver }` mounts in config because JS callback objects are not serializable across the native plugin boundary. Use `plugin` mounts there.
 
 </TabItem>
 
@@ -255,4 +277,3 @@ With no `mounts` configured, every VM boots an Alpine-based root filesystem with
 - `/etc`, `/lib`, `/opt`, `/root`, `/run`, `/srv`, `/tmp`, `/var`, `/mnt`: standard system paths.
 
 It is backed by the VM's own filesystem and persisted across sleep/wake. Nothing comes from or touches the host disk.
-


### PR DESCRIPTION
## What

- Add Agent OS core coverage that runtime mountFs routes through a plain JavaScript VFS driver.
- Keep the mount suite focused on filesystem behavior by disabling default command software for these tests.
- Add Rivet package coverage for the native boundary: plain JS VFS drivers are rejected there, while native memory mounts serialize into config.

## Why

This verifies the mountFs/custom JS VFS path at the Agent OS core layer and documents the Rivet native plugin boundary, where callback-backed JS VFS drivers cannot cross the NAPI config envelope.

Companion secure-exec PR: https://github.com/rivet-dev/secure-exec/pull/125

## Validation

- pnpm --dir packages/core exec vitest run tests/mount.test.ts --reporter=verbose --testTimeout=120000 --hookTimeout=120000
- pnpm --dir packages/agentos exec vitest run tests/actor.test.ts --reporter=verbose --testTimeout=120000 --hookTimeout=180000
- pnpm --dir packages/core check-types && pnpm --dir packages/agentos check-types
