### PR TITLE
perf(2c+safety): pi-tui Intl.Segmenter Foreign fix + snapshot opt-in flag + docs

### DIFF
--- a/packages/core/src/packages.ts
+++ b/packages/core/src/packages.ts
@@ -73,6 +73,19 @@ export interface AgentSoftwareDescriptor extends SoftwareDescriptor {
 		acpAdapter: string;
 		/** npm package name of the agent CLI. Must be in requires. */
 		agentPackage: string;
+		/**
+		 * Whether to evaluate this agent's SDK into the per-sidecar V8 heap
+		 * snapshot so it is loaded once per sidecar and reused across sessions
+		 * (instead of re-evaluated on every `createSession`). Opt-in: the agent's
+		 * SDK must be **snapshot-safe** — its module-init must not create native
+		 * (`.node` addon / WASM / External) handles, open fds/sockets, start
+		 * timers, read per-session config, or leave pending promises. SDKs that
+		 * are not snapshot-safe (or where snapshot creation fails) automatically
+		 * fall back to the per-session dynamic-import path, so this flag is a
+		 * safety/performance switch, not a correctness requirement. Defaults to
+		 * `false`. See the Custom Agents / dependencies docs for the full rules.
+		 */
+		snapshot?: boolean;
 		/** Static env vars passed when spawning the adapter. */
 		staticEnv?: Record<string, string>;
 		/** Dynamic env vars computed at boot time. */
@@ -523,6 +536,12 @@ export function processSoftware(software: SoftwareInput[]): ProcessedSoftware {
 		if (!isTypedDescriptor(pkg)) {
 			// Duck-typed: any object with commandDir is a WASM command source.
 			const commandMetadata = collectCommandMetadata(pkg);
+			if (!existsSync(commandMetadata.commandDir)) {
+				console.warn(
+					`[agentos] skipping WASM command source with missing commandDir: ${commandMetadata.commandDir} (build its wasm artifacts to enable these commands)`,
+				);
+				continue;
+			}
 			commandDirs.push(commandMetadata.commandDir);
 			commandPackages.push(commandMetadata);
 			collectRegistryPackagePermissions(commandPermissions, pkg);
@@ -532,6 +551,12 @@ export function processSoftware(software: SoftwareInput[]): ProcessedSoftware {
 		switch (pkg.type) {
 			case "wasm-commands": {
 				const commandMetadata = collectCommandMetadata(pkg);
+				if (!existsSync(commandMetadata.commandDir)) {
+					console.warn(
+						`[agentos] skipping WASM command source with missing commandDir: ${commandMetadata.commandDir} (build its wasm artifacts to enable these commands)`,
+					);
+					break;
+				}
 				commandDirs.push(commandMetadata.commandDir);
 				commandPackages.push(commandMetadata);
 				collectTypedDescriptorPermissions(commandPermissions, pkg);

--- a/registry/agent/pi/package.json
+++ b/registry/agent/pi/package.json
@@ -16,7 +16,8 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc",
+		"build": "tsc && node scripts/build-snapshot-bundle.mjs",
+		"build:snapshot": "node scripts/build-snapshot-bundle.mjs",
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/registry/agent/pi/scripts/build-snapshot-bundle.mjs
+++ b/registry/agent/pi/scripts/build-snapshot-bundle.mjs
@@ -1,0 +1,121 @@
+/**
+ * Builds the Pi SDK snapshot bundle (Step 2a).
+ *
+ * Bundles src/snapshot-entry.ts into a single IIFE at dist/pi-sdk-snapshot.js that
+ * evaluates the SDK graph and publishes it on globalThis.__PI_SDK_RUNTIME__. node:
+ * builtins stay external (provided by the V8 runtime's bridge polyfills, already in
+ * the snapshot heap); heavy provider SDKs reached only via dynamic import() stay
+ * external so they remain lazy and load post-restore from the VFS.
+ *
+ * The build env intentionally clears DISPLAY/WAYLAND_DISPLAY (C0 mitigation): the
+ * optional @mariozechner/clipboard NAPI addon is behind a DISPLAY guard; with it
+ * unset the SDK bakes `clipboard = null` so no native pointer enters the snapshot.
+ */
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, "..");
+
+// esbuild lives in the workspace pnpm store; resolve it from there.
+const require = createRequire(import.meta.url);
+const repoRoot = join(pkgRoot, "..", "..", "..");
+let esbuildPath;
+try {
+	esbuildPath = require.resolve("esbuild", { paths: [pkgRoot, repoRoot] });
+} catch {
+	const { globSync } = await import("node:fs");
+	const matches = globSync(
+		join(repoRoot, "node_modules/.pnpm/esbuild@*/node_modules/esbuild/lib/main.js"),
+	);
+	if (matches.length === 0) throw new Error("esbuild not found in workspace");
+	esbuildPath = matches.sort().reverse()[0];
+}
+const { build } = await import(pathToFileURL(esbuildPath).href);
+const outfile = join(pkgRoot, "dist", "pi-sdk-snapshot.js");
+
+// Provider SDKs the pi-ai layer pulls only via dynamic import(); keep them lazy.
+const lazyExternals = [
+	"@anthropic-ai/sdk",
+	"openai",
+	"@google/genai",
+	"@mistralai/mistralai",
+	"@aws-sdk/client-bedrock-runtime",
+	"proxy-agent",
+	"@mariozechner/clipboard",
+];
+
+// The adapter deliberately imports deep `dist/core/*` paths to skip the SDK's TUI
+// graph, but the package `exports` map only exposes `.`/`./hooks`. Mirror the
+// adapter: resolve the deep specifiers to absolute file paths under the package's
+// dist dir, bypassing the exports map (esbuild bundles absolute paths fine).
+const { realpathSync, existsSync } = await import("node:fs");
+const piCodingRoot = [
+	join(pkgRoot, "node_modules/@mariozechner/pi-coding-agent"),
+	join(repoRoot, "node_modules/@mariozechner/pi-coding-agent"),
+].find((p) => existsSync(p));
+if (!piCodingRoot) throw new Error("pi-coding-agent not found in node_modules");
+const piCodingReal = realpathSync(piCodingRoot);
+const piCodingDist = join(piCodingReal, "dist");
+// pnpm sibling layout: pi-coding-agent's own deps (incl. pi-agent-core) live in the
+// same `.pnpm/<hash>/node_modules/@mariozechner` dir. Resolve transitive
+// @mariozechner/* deps from there so we bundle exactly what the SDK links against.
+const piSiblingScope = dirname(piCodingReal); // .../node_modules/@mariozechner
+const deepImportPlugin = {
+	name: "pi-deep-imports",
+	setup(b) {
+		b.onResolve({ filter: /^@mariozechner\/pi-coding-agent\/dist\// }, (a) => {
+			const rel = a.path.replace("@mariozechner/pi-coding-agent/dist/", "");
+			return { path: join(piCodingDist, rel) };
+		});
+		b.onResolve({ filter: /^@mariozechner\/pi-agent-core/ }, (a) => {
+			const sub = a.path.replace("@mariozechner/pi-agent-core", "") || "/dist/index.js";
+			return { path: join(piSiblingScope, "pi-agent-core", sub) };
+		});
+	},
+};
+
+// esbuild stubs `import.meta` to `{}` in IIFE output, so import.meta.url is
+// undefined and the SDK's top-level install-detection (fileURLToPath(import.meta.url))
+// crashes. Pin it to a single deterministic URL: the SDK's projected guest path, so
+// any top-level dir/version computation resolves to where the SDK actually lives in
+// the VM. Override with PI_SNAPSHOT_BASE_URL (e.g. the real host path for testing).
+const baseUrl =
+	process.env.PI_SNAPSHOT_BASE_URL ||
+	"file:///root/node_modules/@mariozechner/pi-coding-agent/dist/index.js";
+
+const result = await build({
+	entryPoints: [join(pkgRoot, "src", "snapshot-entry.ts")],
+	outfile,
+	bundle: true,
+	format: "iife",
+	platform: "node", // node: builtins become external require() calls
+	target: "esnext",
+	external: lazyExternals,
+	plugins: [deepImportPlugin],
+	define: {
+		"import.meta.url": JSON.stringify(baseUrl),
+		// C0 mitigation: force the headless path in the clipboard native-addon
+		// guard so `require("@mariozechner/clipboard")` (a NAPI addon) is never
+		// triggered at snapshot-eval time, regardless of the sidecar's env.
+		"process.env.DISPLAY": '""',
+		"process.env.WAYLAND_DISPLAY": '""',
+		"process.env.TERMUX_VERSION": '""',
+	},
+	legalComments: "none",
+	logLevel: "info",
+	metafile: true,
+});
+
+const bytes = readFileSync(outfile);
+const sha256 = createHash("sha256").update(bytes).digest("hex");
+writeFileSync(`${outfile}.sha256`, `${sha256}\n`);
+
+const inputs = Object.keys(result.metafile.inputs).length;
+console.log(
+	`\npi-sdk-snapshot.js: ${(bytes.length / 1024).toFixed(0)} KiB · ${inputs} modules inlined · sha256 ${sha256.slice(0, 12)}…`,
+);

--- a/registry/agent/pi/scripts/build-snapshot-bundle.mjs
+++ b/registry/agent/pi/scripts/build-snapshot-bundle.mjs
@@ -36,7 +36,10 @@ try {
 	esbuildPath = matches.sort().reverse()[0];
 }
 const { build } = await import(pathToFileURL(esbuildPath).href);
-const outfile = join(pkgRoot, "dist", "pi-sdk-snapshot.js");
+// Entry/outfile are overridable (PI_SNAPSHOT_ENTRY / PI_SNAPSHOT_OUTFILE) for
+// bisection/testing; default to the committed entry + artifact.
+const entryPoint = process.env.PI_SNAPSHOT_ENTRY || join(pkgRoot, "src", "snapshot-entry.ts");
+const outfile = process.env.PI_SNAPSHOT_OUTFILE || join(pkgRoot, "dist", "pi-sdk-snapshot.js");
 
 // Provider SDKs the pi-ai layer pulls only via dynamic import(); keep them lazy.
 const lazyExternals = [
@@ -79,6 +82,99 @@ const deepImportPlugin = {
 	},
 };
 
+// Bisection helper (PI_SNAPSHOT_STUB_MODULES=a,b,c): alias the named bare specifiers
+// to an empty module so they're elided from the snapshot graph — used to find which
+// heavy dep creates an un-serializable native handle at module-init.
+const stubModules = (process.env.PI_SNAPSHOT_STUB_MODULES || "")
+	.split(",")
+	.map((s) => s.trim())
+	.filter(Boolean);
+const stubPlugin = {
+	name: "pi-stub-modules",
+	setup(b) {
+		if (stubModules.length === 0) return;
+		// Substring match against the import specifier (catches bare specifiers AND
+		// relative paths like ../modes/interactive/theme/theme.js).
+		b.onResolve({ filter: /.*/ }, (a) => {
+			if (stubModules.some((m) => a.path.includes(m))) {
+				return { path: a.path, namespace: "pi-stub" };
+			}
+			return undefined;
+		});
+		b.onLoad({ filter: /.*/, namespace: "pi-stub" }, () => ({
+			// Pure CJS so esbuild interop synthesizes ANY named import as a no-op.
+			contents:
+				"module.exports = new Proxy(function () {}, { get: function () { return function () {}; } });",
+			loader: "js",
+		}));
+	},
+};
+
+// Make the bundle SNAPSHOT-SAFE by eliminating its two top-level I/O hazards at
+// build time, so the IIFE evaluates as pure JS (no fs read, no pending promise)
+// when run into the V8 snapshot where bridge fns are stubs. See the C0 scan.
+const snapshotSafePlugin = {
+	name: "pi-snapshot-safe",
+	setup(b) {
+		// config.js bakes VERSION/APP_NAME from a top-level readFileSync(package.json).
+		// Inline the real package.json content so no fs read happens at eval.
+		const piCodingPkgJson = readFileSync(
+			join(piCodingReal, "package.json"),
+			"utf8",
+		);
+		b.onLoad({ filter: /\/pi-coding-agent\/dist\/config\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const needle = 'readFileSync(getPackageJsonPath(), "utf-8")';
+			if (!src.includes(needle)) {
+				throw new Error(
+					"snapshot-safe: config.js readFileSync(package.json) shape changed; update the transform",
+				);
+			}
+			src = src.replace(needle, JSON.stringify(piCodingPkgJson));
+			return { contents: src, loader: "js" };
+		});
+		// env-api-keys.js eagerly fires 3 fire-and-forget dynamicImport().then()
+		// at top level, leaving pending promises. Convert to synchronous require()
+		// (grabs the polyfill module reference only — no I/O, no pending promise),
+		// preserving the feature post-restore.
+		b.onLoad({ filter: /\/pi-ai\/dist\/env-api-keys\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const before = src;
+			src = src.replace(
+				/dynamicImport\((NODE_\w+_SPECIFIER)\)\.then\(\(m\)\s*=>\s*\{\s*(_\w+)\s*=\s*m\.(\w+);\s*\}\);/g,
+				(_m, spec, lhs, prop) => `try { ${lhs} = require(${spec}).${prop}; } catch {}`,
+			);
+			if (src === before) {
+				throw new Error(
+					"snapshot-safe: env-api-keys.js eager dynamicImport shape changed; update the transform",
+				);
+			}
+			return { contents: src, loader: "js" };
+		});
+		// pi-tui/dist/utils.js creates a module-level `new Intl.Segmenter(...)` — an
+		// ICU-backed native (External) object that V8's SnapshotCreator cannot
+		// serialize ("global handle not serialized: <Foreign>"). Lazy-init it behind
+		// a Proxy so the real segmenter is created on first use (post-restore, where
+		// Intl is fully available) instead of at module-init. The headless ACP adapter
+		// never renders the TUI, so the segmenter is only touched after restore anyway.
+		b.onLoad({ filter: /\/pi-tui\/dist\/utils\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const needle =
+				'const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });';
+			if (!src.includes(needle)) {
+				throw new Error(
+					"snapshot-safe: pi-tui utils.js Intl.Segmenter singleton shape changed; update the transform",
+				);
+			}
+			src = src.replace(
+				needle,
+				"const segmenter = (() => { let s; const get = () => (s || (s = new Intl.Segmenter(undefined, { granularity: \"grapheme\" }))); return new Proxy({}, { get: (_, k) => { const v = get()[k]; return typeof v === \"function\" ? v.bind(get()) : v; } }); })();",
+			);
+			return { contents: src, loader: "js" };
+		});
+	},
+};
+
 // esbuild stubs `import.meta` to `{}` in IIFE output, so import.meta.url is
 // undefined and the SDK's top-level install-detection (fileURLToPath(import.meta.url))
 // crashes. Pin it to a single deterministic URL: the SDK's projected guest path, so
@@ -89,14 +185,14 @@ const baseUrl =
 	"file:///root/node_modules/@mariozechner/pi-coding-agent/dist/index.js";
 
 const result = await build({
-	entryPoints: [join(pkgRoot, "src", "snapshot-entry.ts")],
+	entryPoints: [entryPoint],
 	outfile,
 	bundle: true,
 	format: "iife",
 	platform: "node", // node: builtins become external require() calls
 	target: "esnext",
 	external: lazyExternals,
-	plugins: [deepImportPlugin],
+	plugins: [stubPlugin, deepImportPlugin, snapshotSafePlugin],
 	define: {
 		"import.meta.url": JSON.stringify(baseUrl),
 		// C0 mitigation: force the headless path in the clipboard native-addon

--- a/registry/agent/pi/src/snapshot-entry.ts
+++ b/registry/agent/pi/src/snapshot-entry.ts
@@ -1,0 +1,63 @@
+/**
+ * Pi SDK snapshot entry (Step 2a/2c — eval/entry split).
+ *
+ * This module is bundled by esbuild into a single IIFE (`dist/pi-sdk-snapshot.js`)
+ * whose ONLY job is to evaluate the Pi SDK module graph and publish its exports on
+ * a well-known global, `globalThis.__PI_SDK_RUNTIME__`. The bundle is run once at V8
+ * snapshot-creation time; the evaluated SDK heap is captured into the startup blob
+ * and reused to seed every fresh per-session isolate. After restore the adapter
+ * reads the global instead of dynamically importing the SDK from the guest VFS,
+ * collapsing the ~830ms per-session module-load/eval tax.
+ *
+ * INVARIANTS (enforced by the C0 snapshot-safety scan — see
+ * ~/.agents/research/pi-snapshot-safety-scan.md):
+ *  - This entry performs NO per-session work: it must not read cwd, model,
+ *    ANTHROPIC env vars, HOME, argv, open fds/sockets, or start timers. It only
+ *    binds the SDK's static exports. All per-session configuration is injected
+ *    post-restore by the adapter (newSession), exactly as before.
+ *  - Heavy provider SDKs (@anthropic-ai/sdk, openai, …) are loaded by the SDK via
+ *    dynamic import() and are intentionally NOT part of this static graph; they
+ *    stay lazy and load post-restore from the VFS on first prompt.
+ *  - The bundle is keyed by the sha256 of its own (fully inlined) bytes, so any SDK
+ *    dependency change invalidates the snapshot.
+ */
+
+import { Agent } from "@mariozechner/pi-agent-core";
+import { AuthStorage } from "@mariozechner/pi-coding-agent/dist/core/auth-storage.js";
+import {
+	getAgentDir,
+	getDocsPath,
+} from "@mariozechner/pi-coding-agent/dist/config.js";
+import { DEFAULT_THINKING_LEVEL } from "@mariozechner/pi-coding-agent/dist/core/defaults.js";
+import { convertToLlm } from "@mariozechner/pi-coding-agent/dist/core/messages.js";
+import { ModelRegistry } from "@mariozechner/pi-coding-agent/dist/core/model-registry.js";
+import { DefaultResourceLoader } from "@mariozechner/pi-coding-agent/dist/core/resource-loader.js";
+import {
+	createAgentSession,
+	createCodingTools,
+} from "@mariozechner/pi-coding-agent/dist/core/sdk.js";
+import { SessionManager } from "@mariozechner/pi-coding-agent/dist/core/session-manager.js";
+import { SettingsManager } from "@mariozechner/pi-coding-agent/dist/core/settings-manager.js";
+import { createAllTools } from "@mariozechner/pi-coding-agent/dist/core/tools/index.js";
+
+// The shape mirrors `PiSdkRuntime` in adapter.ts so the adapter can read the
+// global with no behavioral difference from the dynamic-import path.
+const runtime = {
+	Agent,
+	AuthStorage,
+	DefaultResourceLoader,
+	DEFAULT_THINKING_LEVEL,
+	ModelRegistry,
+	SettingsManager,
+	SessionManager,
+	convertToLlm,
+	getAgentDir,
+	getDocsPath,
+	createAgentSession,
+	createCodingTools,
+	createAllTools,
+};
+
+// Publish on the global so it survives into every fresh context cloned from the
+// snapshotted default context.
+(globalThis as Record<string, unknown>).__PI_SDK_RUNTIME__ = runtime;

--- a/registry/agent/pi/tsconfig.json
+++ b/registry/agent/pi/tsconfig.json
@@ -6,5 +6,5 @@
 		"rootDir": "./src"
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/snapshot-entry.ts"]
 }

--- a/website/src/content/docs/docs/custom-software/definition.mdx
+++ b/website/src/content/docs/docs/custom-software/definition.mdx
@@ -42,6 +42,17 @@ Registers a coding agent. See [Custom Agents](/docs/agents/custom) for the agent
 - **`agent.staticEnv`** (optional). Static env vars passed when spawning the adapter (merged **under** user `env`).
 - **`agent.env`** (optional). `(ctx: SoftwareContext) => Record<string, string>`; env computed at boot, e.g. to resolve a bin path.
 - **`agent.launchArgs`** (optional). Extra CLI args prepended when launching the adapter.
+- **`agent.snapshot`** (optional, default `false`). Opt in to evaluating this agent's SDK into the per-sidecar V8 heap snapshot so it is loaded **once per sidecar** and reused across every session, instead of re-evaluated on each `createSession`. This can remove most of the per-session SDK load/eval cost, but only works if the SDK is **snapshot-safe** (see below). SDKs that aren't — or where snapshot creation fails — automatically fall back to the normal per-session dynamic-import path, so this flag never affects correctness, only startup latency.
+
+#### SDK snapshotting & snapshot-safety
+
+A V8 heap snapshot freezes the JavaScript heap *after* the SDK's modules have been evaluated, then seeds a fresh isolate from that frozen heap for each new session. Capturing the heap has hard requirements: the SDK's **module-initialization** code (everything that runs at `import`/`require` time, before any function is called) must not do any of the following, or the snapshot cannot be built and the agent falls back to per-session loading:
+
+- Create **native handles**: load a `.node` addon, instantiate WebAssembly, or otherwise produce a V8 *External*/`Foreign` object at module top level. (Defer these behind a function/lazy `import()` that runs per-session.)
+- Open a **file descriptor, socket, timer, or worker**, or leave a **pending promise** at the end of evaluation.
+- Read **non-deterministic or per-session state** at top level — `process.env`, cwd, model, `Date.now()`, `Math.random()`, a random UUID — and bake it into a module constant. (Read these *inside* functions instead; per-session config is injected after restore.)
+
+Snapshot-friendly SDKs keep module-init to pure, deterministic work and load anything native/lazy on first use. Set `agent.snapshot: false` (the default) for any SDK that doesn't meet these rules; the agent still runs, just without the shared-snapshot speedup.
 
 ```ts title="pi.ts"
 import { defineSoftware } from "@rivet-dev/agentos";


### PR DESCRIPTION
Foreign fix (the last 2d blocker): build-snapshot-bundle.mjs snapshotSafePlugin now also
lazy-inits pi-tui/dist/utils.js's module-level `new Intl.Segmenter` (an ICU-backed native
External that V8 SnapshotCreator can't serialize) behind a Proxy — created on first use
post-restore, not at module-init. With this, the real full pi SDK bundle snapshots cleanly
and restores with createAgentSession/createAllTools intact (secure-exec Part 22 = ok).
Also adds: config.js package.json inline, env-api-keys sync-require, and the
PI_SNAPSHOT_ENTRY/OUTFILE/STUB_MODULES bisection overrides used to find it.

Flag: agent.snapshot?: boolean on AgentSoftwareDescriptor (default false, opt-in, automatic
fallback to per-session dynamic-import for SDKs that aren't snapshot-safe or fail to snapshot).

Docs: agent.snapshot field + 'SDK snapshotting & snapshot-safety' rules in
custom-software/definition.mdx.