### PR TITLE
fix: agentos rivetkit runtime issues (SerializeState handler + client process/cmdline)

### DIFF
--- a/crates/agentos-actor-plugin/src/lib.rs
+++ b/crates/agentos-actor-plugin/src/lib.rs
@@ -267,6 +267,11 @@ async fn actor_loop(
             Some(abi::AbiEventTag::ConnOpen) => {
                 let _ = host.reply_ok(token, Vec::new());
             }
+            Some(abi::AbiEventTag::SerializeState) => {
+                // Agent OS persists durable data through SQLite and rebuilds VM/process
+                // state after wake, so there is no opaque actor state payload to return.
+                let _ = host.reply_ok(token, Vec::new());
+            }
             Some(abi::AbiEventTag::Sleep) => {
                 vars.clear();
                 vm::shutdown_vm(&host, &mut vm, "sleep").await;

--- a/crates/client/src/command_line.rs
+++ b/crates/client/src/command_line.rs
@@ -47,7 +47,7 @@ fn command_requires_shell(command: &str) -> bool {
     })
 }
 
-/// Whether a token is a POSIX shell builtin that cannot be spawned as a standalone command.
+/// Whether a token should run under the shell even when it has no metacharacters.
 fn is_posix_shell_builtin(command: &str) -> bool {
     matches!(
         command,
@@ -67,6 +67,9 @@ fn is_posix_shell_builtin(command: &str) -> bool {
             | "trap"
             | "umask"
             | "unset"
+            // Mirrors the TS sidecar client: direct wasm `pwd` reports the root
+            // preopen on Darwin, while `sh -c pwd` observes the process cwd.
+            | "pwd"
     )
 }
 
@@ -139,9 +142,11 @@ mod tests {
     /// A POSIX shell builtin head runs under `sh -c` even with no metacharacters.
     #[test]
     fn builtin_head_wraps_in_sh_c() {
-        let (command, args) = resolve_exec_command("cd /tmp").unwrap();
-        assert_eq!(command, "sh");
-        assert_eq!(args, vec!["-c".to_string(), "cd /tmp".to_string()]);
+        for line in ["cd /tmp", "pwd"] {
+            let (command, args) = resolve_exec_command(line).unwrap();
+            assert_eq!(command, "sh");
+            assert_eq!(args, vec!["-c".to_string(), line.to_string()]);
+        }
     }
 
     /// An empty or whitespace-only command line is an explicit error.

--- a/crates/client/src/process.rs
+++ b/crates/client/src/process.rs
@@ -34,6 +34,9 @@ const OBSERVED_PROCESS_TIME_LIMIT: usize = 4096;
 /// Maximum bytes captured by `exec` across stdout and stderr.
 const EXEC_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
+/// Default guest working directory for `exec`/`spawn`, matching the TS sidecar client.
+pub(crate) const DEFAULT_EXEC_CWD: &str = "/workspace";
+
 /// Base value for the synthetic display-pid sequence used by `spawn` (TS `SYNTHETIC_PID_BASE`). The
 /// first spawned process is assigned exactly this value.
 pub(crate) const SYNTHETIC_PID_BASE: u64 = 1_000_000;
@@ -67,7 +70,6 @@ pub type OutputCallback = Box<dyn FnMut(&[u8]) + Send>;
 /// `on_stdout`/`on_stderr` mirror the TS `ExecOptions.onStdout`/`onStderr` raw-byte streaming
 /// callbacks. For `exec` they fire for the duration of the call; for `spawn` they are seeded into the
 /// stdout/stderr fan-out at spawn time (matching the TS initial-handler-set behavior).
-#[derive(Default)]
 pub struct ExecOptions {
     pub env: BTreeMap<String, String>,
     pub cwd: Option<String>,
@@ -79,6 +81,23 @@ pub struct ExecOptions {
     pub file_path: Option<String>,
     pub cpu_time_limit_ms: Option<f64>,
     pub timing_mitigation: Option<TimingMitigation>,
+}
+
+impl Default for ExecOptions {
+    fn default() -> Self {
+        Self {
+            env: BTreeMap::new(),
+            cwd: Some(DEFAULT_EXEC_CWD.to_string()),
+            stdin: None,
+            timeout: None,
+            on_stdout: None,
+            on_stderr: None,
+            capture_stdio: None,
+            file_path: None,
+            cpu_time_limit_ms: None,
+            timing_mitigation: None,
+        }
+    }
 }
 
 /// Result of `exec`.
@@ -1212,10 +1231,18 @@ fn epoch_ms_now() -> f64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_exec_output, exited_pids_to_prune, prune_string_f64_map,
-        EXEC_OUTPUT_CAPTURE_LIMIT_BYTES,
+        append_exec_output, exited_pids_to_prune, prune_string_f64_map, ExecOptions,
+        DEFAULT_EXEC_CWD, EXEC_OUTPUT_CAPTURE_LIMIT_BYTES,
     };
     use scc::HashMap as SccHashMap;
+
+    #[test]
+    fn exec_options_default_uses_workspace_cwd() {
+        assert_eq!(
+            ExecOptions::default().cwd.as_deref(),
+            Some(DEFAULT_EXEC_CWD)
+        );
+    }
 
     #[test]
     fn append_exec_output_rejects_capture_over_limit() {


### PR DESCRIPTION
Fixes RivetKit actor runtime issues:

- **`SerializeState` handler** (`crates/agentos-actor-plugin/src/lib.rs`): the actor run loop had no arm for `AbiEventTag::SerializeState`, so RivetKit's serialize-state callback got a generic `event not supported by agent-os actor` error on every persist/sleep/destroy. Now replies OK with an empty payload — agent-os persists durable state via SQLite and rebuilds VM/process state on wake, so there is no opaque actor-state blob to return. Removes the noisy (non-fatal) shutdown error.
- `crates/client/src/command_line.rs`, `crates/client/src/process.rs`: related rivetkit runtime fixes.