### PR TITLE
perf(bench): make session.bench actually measure the agent-SDK snapshot

### DIFF
--- a/scripts/benchmarks/session.bench.ts
+++ b/scripts/benchmarks/session.bench.ts
@@ -56,6 +56,10 @@ const LANES = arg("lanes", "vm,bare-node").split(",");
 const GATE = flag("gate");
 const UPDATE_BASELINE = flag("update-baseline");
 const TRACE = flag("trace");
+// By default the vm lane reuses one sidecar across sessions (production pattern:
+// build the snapshot once, reuse it). Pass --fresh-vm-per-session for the cold
+// path (a fresh sidecar per session, so the snapshot cache is never reused).
+const FRESH_VM_PER_SESSION = flag("fresh-vm-per-session");
 
 // ── gate rules: p50 of deterministic metrics + the hardware-independent ratio ──
 const GATE_RULES: GateRule[] = [
@@ -83,17 +87,21 @@ async function ensureLlmock() {
 // ── workload resolution (robust to repo layout) ──────────────────────
 
 async function loadPiSoftware(): Promise<unknown> {
-	// Preferred: the published/installed software package. Variable specifier so
+	// Preferred: the in-repo registry build — that is the code under test, and the
+	// only build that carries the agent-SDK snapshot (agent.snapshot + the
+	// dist/sdk-snapshot.js bundle). The published @agentos-software/pi may predate
+	// the snapshot work, so benchmarking against it silently measures the
+	// non-snapshot fallback path and hides the optimization entirely.
+	const local = join(import.meta.dirname, "../../registry/agent/pi/dist/index.js");
+	if (existsSync(local)) return (await import(local)).default;
+	// Fallback: the published/installed software package. Variable specifier so
 	// this typechecks even when the package isn't installed in the dev workspace.
 	const piPkg = "@agentos-software/pi";
 	try {
 		return (await import(piPkg)).default;
 	} catch {
-		// Fallback: the in-repo registry workspace build.
-		const local = join(import.meta.dirname, "../../registry/agent/pi/dist/index.js");
-		if (existsSync(local)) return (await import(local)).default;
 		throw new Error(
-			"Could not resolve the pi software package (@agentos-software/pi or registry/agent/pi/dist). Build it first.",
+			"Could not resolve the pi software package (registry/agent/pi/dist or @agentos-software/pi). Build it first.",
 		);
 	}
 }
@@ -264,22 +272,80 @@ async function bareNodeLaneSample(
 // ── lanes ────────────────────────────────────────────────────────────
 type Sample = Record<string, number>;
 
-async function vmLaneSample(software: unknown): Promise<Sample> {
+// VM lane: create ONE VM/sidecar and loop createSession on it, so the
+// process-wide agent-SDK snapshot cache is exercised the way it is in production
+// (build-once-per-sidecar, then reuse). A fresh VM per session — the old
+// behavior — gives every session a cold cache, which hides the snapshot benefit
+// entirely. The WARMUP sessions build/warm the snapshot; the measured sessions
+// restore from the cached blob. vmCreate is a single create, reported as one
+// sample. To measure the cold per-VM path instead, pass --fresh-vm-per-session.
+async function runVmLane(
+	software: unknown,
+): Promise<Record<string, PhaseStats>> {
 	const { port, url } = await ensureLlmock();
+	const sessionEnv = {
+		ANTHROPIC_API_KEY: "bench-key",
+		ANTHROPIC_BASE_URL: url,
+	};
+	const sessionCreates: number[] = [];
+	const vmCreates: number[] = [];
+
+	if (FRESH_VM_PER_SESSION) {
+		// Cold path: fresh sidecar each session (snapshot cache never reused).
+		for (let i = 0; i < ITERATIONS + WARMUP; i++) {
+			const warm = i < WARMUP;
+			let t = performance.now();
+			const vm = await AgentOs.create({
+				software: [software] as never,
+				loopbackExemptPorts: [port],
+			});
+			const vmCreate = performance.now() - t;
+			t = performance.now();
+			const { sessionId } = await vm.createSession("pi", { env: sessionEnv });
+			const sessionCreate = performance.now() - t;
+			vm.closeSession(sessionId);
+			await vm.dispose();
+			if (warm) continue;
+			vmCreates.push(vmCreate);
+			sessionCreates.push(sessionCreate);
+			console.error(
+				`[vm] iter ${i - WARMUP}: vmCreate=${vmCreate.toFixed(0)} sessionCreate=${sessionCreate.toFixed(0)} ms`,
+			);
+		}
+		return { vmCreate: stats(vmCreates), sessionCreate: stats(sessionCreates) };
+	}
+
+	// Reused path (default): one sidecar, N sessions — snapshot built once.
 	let t = performance.now();
 	const vm = await AgentOs.create({
 		software: [software] as never,
 		loopbackExemptPorts: [port],
 	});
-	const vmCreate = performance.now() - t;
-	t = performance.now();
-	const { sessionId } = await vm.createSession("pi", {
-		env: { ANTHROPIC_API_KEY: "bench-key", ANTHROPIC_BASE_URL: url },
-	});
-	const sessionCreate = performance.now() - t;
-	vm.closeSession(sessionId);
-	await vm.dispose();
-	return { vmCreate, sessionCreate };
+	vmCreates.push(performance.now() - t);
+	// closeSession() is fire-and-forget; await the internal teardown promise
+	// between iterations so adapter processes/isolates don't pile up in the
+	// shared sidecar and confound the next createSession measurement.
+	const closePromises = (
+		vm as unknown as { _sessionClosePromises: Map<string, Promise<void>> }
+	)._sessionClosePromises;
+	try {
+		for (let i = 0; i < ITERATIONS + WARMUP; i++) {
+			const warm = i < WARMUP;
+			t = performance.now();
+			const { sessionId } = await vm.createSession("pi", { env: sessionEnv });
+			const sessionCreate = performance.now() - t;
+			vm.closeSession(sessionId);
+			await closePromises.get(sessionId)?.catch(() => {});
+			if (warm) continue;
+			sessionCreates.push(sessionCreate);
+			console.error(
+				`[vm] iter ${i - WARMUP}: sessionCreate=${sessionCreate.toFixed(0)} ms (reused sidecar)`,
+			);
+		}
+	} finally {
+		await vm.dispose();
+	}
+	return { vmCreate: stats(vmCreates), sessionCreate: stats(sessionCreates) };
 }
 
 async function runLane(
@@ -426,8 +492,10 @@ async function main() {
 
 	if (LANES.includes("vm")) {
 		const software = await loadPiSoftware();
-		console.error("\n=== lane: vm (AgentOs + createSession) ===");
-		lanes.vm = await runLane("vm", () => vmLaneSample(software));
+		console.error(
+			`\n=== lane: vm (AgentOs + createSession${FRESH_VM_PER_SESSION ? ", fresh sidecar/session" : ", reused sidecar"}) ===`,
+		);
+		lanes.vm = await runVmLane(software);
 	}
 
 	if (LANES.includes("bare-node")) {


### PR DESCRIPTION
The session benchmark was measuring the non-snapshot path on both axes, so it
showed no difference between snapshot on/off:
- loadPiSoftware() preferred the published @agentos-software/pi (no agent.snapshot,
  no dist/sdk-snapshot.js); now prefer the in-repo registry build (the code under
  test, which carries the snapshot bundle), falling back to the published package.
- vm lane created a fresh sidecar per session, so the process-wide snapshot cache
  (build-once-per-sidecar) was never reused. Add a reused-sidecar lane (default)
  that creates one VM and loops createSession, with awaited session teardown so
  adapter processes don't pile up and confound the measurement. --fresh-vm-per-session
  keeps the old cold path.

With a snapshot-capable sidecar + local pi, this measures createSession p50
~405ms (snapshot on) vs ~994ms (off) in release.