### PR TITLE
feat(core): share one sidecar process per AgentOsSidecar handle

### DIFF
--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -2751,6 +2751,10 @@ export class AgentOs {
 			validateToolkits(toolKits);
 		}
 
+		// Resolve the sidecar handle up front so every VM created here leases the
+		// one shared native sidecar process owned by that handle.
+		const sidecar = resolveAgentOsSidecar(options?.sidecar);
+
 		const createVmAdmin = async (): Promise<AgentOsVmAdmin> => {
 			const preparedCommandDirs = prepareCommandDirs(processed.commandPackages);
 			const toolBootstrapCommands = collectToolkitBootstrapCommands(
@@ -2768,6 +2772,8 @@ export class AgentOs {
 			let rootBridge: NativeSidecarKernelProxy | null = null;
 			let kernel: Kernel | null = null;
 			let client: SidecarProcess | null = null;
+			let createdNativeVm: CreatedVm | null = null;
+			let nativeSession: AuthenticatedSession | null = null;
 			let toolShimDir: string | null = null;
 			let cleanedUp = false;
 
@@ -2811,13 +2817,12 @@ export class AgentOs {
 						commandDirs: preparedCommandDirs.commandDirs,
 						shimDir: toolShimDir,
 					});
-				client = SidecarProcess.spawn({
-					cwd: REPO_ROOT,
-					command: ensureNativeSidecarBinary(),
-					args: [],
-					frameTimeoutMs: NATIVE_SIDECAR_FRAME_TIMEOUT_MS,
-				});
-				const session = await client.authenticateAndOpenSession();
+				// Reuse the sidecar handle's single shared native process; this VM
+				// becomes another tenant of it rather than spawning its own process.
+				const shared = await ensureSharedSidecarNativeProcess(sidecar);
+				client = shared.client;
+				const session = shared.session;
+				nativeSession = session;
 				const hostPermissions = options?.permissions ?? {
 					...allowAll,
 					binding: "allow",
@@ -2859,10 +2864,15 @@ export class AgentOs {
 					runtime: "java_script",
 					config: createVmConfig,
 				});
+				createdNativeVm = nativeVm;
+				// Scope the readiness wait to THIS VM's ownership; on a shared process
+				// other VMs are emitting their own lifecycle events concurrently.
 				await client.waitForEvent(
 					(event) =>
 						event.payload.type === "vm_lifecycle" &&
-						event.payload.state === "ready",
+						event.payload.state === "ready" &&
+						event.ownership.scope === "vm" &&
+						event.ownership.vm_id === nativeVm.vmId,
 					10_000,
 				);
 				await client.configureVm(session, nativeVm, {
@@ -2900,6 +2910,9 @@ export class AgentOs {
 					loopbackExemptPorts: options?.loopbackExemptPorts,
 					commandGuestPaths,
 					onDispose: cleanup,
+					// The native process is owned by the AgentOsSidecar handle and
+					// shared across VMs; disposing this VM must not kill the process.
+					ownsClient: false,
 				});
 				await bootstrapLiveBootstrapDirectories(
 					client,
@@ -2948,20 +2961,25 @@ export class AgentOs {
 					},
 				};
 			} catch (error) {
+				// The native process is shared and owned by the sidecar handle, so
+				// never dispose the client here — only tear down this VM's resources.
 				if (kernel) {
 					await kernel.dispose().catch(() => {});
 				}
 				if (rootBridge) {
 					await rootBridge.dispose().catch(() => {});
 				} else {
-					await client?.dispose().catch(() => {});
+					if (createdNativeVm && nativeSession && client) {
+						await client
+							.disposeVm(nativeSession, createdNativeVm)
+							.catch(() => {});
+					}
 					await cleanup();
 				}
 				throw error;
 			}
 		};
 
-		const sidecar = resolveAgentOsSidecar(options?.sidecar);
 		let sidecarLease: AgentOsSidecarVmLease<AgentOsVmAdmin> | null = null;
 
 		try {
@@ -5421,14 +5439,66 @@ interface AgentOsSidecarLeaseRecord {
 	dispose(): Promise<void>;
 }
 
+interface SharedSidecarNativeProcess {
+	client: SidecarProcess;
+	session: AuthenticatedSession;
+}
+
 interface AgentOsSidecarState {
 	description: AgentOsSidecarDescription;
 	activeLeases: Set<AgentOsSidecarLeaseRecord>;
 	sharedPool?: string;
+	/**
+	 * The single native sidecar process shared by every VM leased from this
+	 * handle. Spawned lazily on first VM creation and reused thereafter so VMs
+	 * are cheap incremental tenants of one process rather than one-process-each.
+	 */
+	nativeProcess?: Promise<SharedSidecarNativeProcess>;
 }
 
 const sidecarStates = new WeakMap<AgentOsSidecar, AgentOsSidecarState>();
 const sharedSidecars = new Map<string, AgentOsSidecar>();
+
+/**
+ * Spawn-once accessor for a sidecar handle's shared native process. Concurrent
+ * callers await the same promise, so one `AgentOsSidecar` maps to exactly one
+ * `agent-os-sidecar` OS process for its whole lifetime.
+ */
+function ensureSharedSidecarNativeProcess(
+	sidecar: AgentOsSidecar,
+): Promise<SharedSidecarNativeProcess> {
+	const state = getSidecarState(sidecar);
+	if (!state.nativeProcess) {
+		state.nativeProcess = (async () => {
+			const client = SidecarProcess.spawn({
+				cwd: REPO_ROOT,
+				command: ensureNativeSidecarBinary(),
+				args: [],
+				frameTimeoutMs: NATIVE_SIDECAR_FRAME_TIMEOUT_MS,
+			});
+			const session = await client.authenticateAndOpenSession();
+			return { client, session };
+		})();
+	}
+	return state.nativeProcess;
+}
+
+/** Dispose a sidecar handle's shared native process, if one was spawned. */
+async function disposeSharedSidecarNativeProcess(
+	state: AgentOsSidecarState,
+): Promise<void> {
+	const pending = state.nativeProcess;
+	if (!pending) {
+		return;
+	}
+	state.nativeProcess = undefined;
+	try {
+		const { client } = await pending;
+		await client.dispose();
+	} catch {
+		// Process may have already exited; nothing to reclaim.
+	}
+}
 
 export class AgentOsSidecar {
 	constructor(
@@ -5470,6 +5540,8 @@ export class AgentOsSidecar {
 		}
 		state.activeLeases.clear();
 		state.description.activeVmCount = 0;
+		// Tear down the shared native process after all leased VMs are gone.
+		await disposeSharedSidecarNativeProcess(state);
 		state.description.state = "disposed";
 		if (state.sharedPool && sharedSidecars.get(state.sharedPool) === this) {
 			sharedSidecars.delete(state.sharedPool);

--- a/packages/core/src/sidecar/rpc-client.ts
+++ b/packages/core/src/sidecar/rpc-client.ts
@@ -299,6 +299,14 @@ interface NativeSidecarKernelProxyOptions {
 	commandGuestPaths: ReadonlyMap<string, string>;
 	onWasmCommandResolved?: (command: string) => void;
 	onDispose?: () => Promise<void>;
+	/**
+	 * Whether this proxy owns the underlying sidecar process. When VMs share one
+	 * sidecar process (the default for VMs leased from an `AgentOsSidecar`
+	 * handle), each proxy tears down only its own VM on `dispose()`; the shared
+	 * process is disposed when the sidecar handle is disposed. Defaults to true
+	 * for the legacy one-process-per-VM path.
+	 */
+	ownsClient?: boolean;
 }
 
 export class NativeSidecarKernelProxy {
@@ -312,6 +320,7 @@ export class NativeSidecarKernelProxy {
 	private readonly client: SidecarProcess;
 	private readonly session: AuthenticatedSession;
 	private readonly vm: CreatedVm;
+	private readonly ownsClient: boolean;
 	private readonly localMounts: LocalCompatMount[];
 	private readonly baseSidecarMounts: SidecarMountDescriptor[];
 	private readonly permissions: SidecarPermissionsPolicy | undefined;
@@ -350,6 +359,7 @@ export class NativeSidecarKernelProxy {
 		this.client = options.client;
 		this.session = options.session;
 		this.vm = options.vm;
+		this.ownsClient = options.ownsClient ?? true;
 		this.env = { ...options.env };
 		this.cwd = options.cwd;
 		this.defaultExecCwd = options.defaultExecCwd;
@@ -419,7 +429,12 @@ export class NativeSidecarKernelProxy {
 				this.finishProcess(entry, 143);
 			}
 		}
-		await this.client.dispose().catch(() => {});
+		// Only tear down the shared sidecar process when this proxy owns it. VMs
+		// leased from an `AgentOsSidecar` handle share one process, which is
+		// disposed when the handle is disposed.
+		if (this.ownsClient) {
+			await this.client.dispose().catch(() => {});
+		}
 		await this.eventPump.catch(() => {});
 		await this.onDispose?.().catch(() => {});
 	}
@@ -1572,11 +1587,19 @@ export class NativeSidecarKernelProxy {
 	}
 
 	private async runEventPump(): Promise<void> {
+		// Scope the pump to THIS VM's ownership so multiple proxies can share one
+		// sidecar process: events for other VMs stay buffered for their own pumps
+		// rather than being consumed (and dropped) here.
+		const vmId = this.vm.vmId;
 		while (!this.disposed) {
 			try {
-				const event = await this.client.waitForEvent({ any: true }, undefined, {
-					signal: this.eventPumpAbortController.signal,
-				});
+				const event = await this.client.waitForEvent(
+					(frame) =>
+						frame.ownership.scope === "vm" &&
+						frame.ownership.vm_id === vmId,
+					undefined,
+					{ signal: this.eventPumpAbortController.signal },
+				);
 				if (event.payload.type === "process_output") {
 					const entry = this.trackedProcessesById.get(event.payload.process_id);
 					if (!entry) {

--- a/scripts/benchmarks/bench-utils.ts
+++ b/scripts/benchmarks/bench-utils.ts
@@ -1,10 +1,15 @@
-import { AgentOs, type SoftwareInput } from "@rivet-dev/agentos-core";
+import {
+	AgentOs,
+	type AgentOsOptions,
+	type AgentOsSidecar,
+	type RootSnapshotExport,
+	type SoftwareInput,
+} from "@rivet-dev/agentos-core";
 import { coreutils } from "@agentos-software/common";
 import claude from "@agentos-software/claude-code";
 import pi from "@agentos-software/pi";
 import { LLMock } from "@copilotkit/llmock";
 import os from "node:os";
-import { resolve } from "node:path";
 
 // Benchmark parameters. Keep batch sizes minimal for fast iteration.
 export const BATCH_SIZES = [1, 10];
@@ -19,10 +24,61 @@ export const PI_HEADLESS_BLOCKER_REFERENCE =
 	"packages/core/tests/pi-headless.test.ts";
 export const PI_HEADLESS_BLOCKER_REASON =
 	'Standalone `spawn("pi", ...)` is not exposed on the native sidecar PATH; use `createSession("pi-cli")` to benchmark the native PI CLI RPC path tracked in packages/core/tests/pi-headless.test.ts.';
-const BENCHMARK_MODULE_ACCESS_CWD = resolve(
-	import.meta.dirname,
-	"../../packages/core",
-);
+// ── Shared bench sidecar + cold-run snapshot ───────────────────────
+//
+// Benchmarks create the sidecar ONCE up front and lease every VM from it,
+// rather than letting each `AgentOs.create()` stand up its own sidecar. A
+// single cold-run VM is then created and its root filesystem snapshotted so
+// the subsequent measured VMs boot from a warm snapshot instead of paying the
+// bootstrap cost on every iteration. Both are wired through `benchCreateOptions`
+// so every VM-creation helper picks them up automatically.
+
+let _benchSidecar: AgentOsSidecar | undefined;
+let _benchSnapshot: RootSnapshotExport | undefined;
+
+/** Create the shared bench sidecar. Call once before creating any VM. */
+export async function startBenchSidecar(): Promise<AgentOsSidecar> {
+	if (!_benchSidecar) {
+		_benchSidecar = await AgentOs.createSidecar();
+	}
+	return _benchSidecar;
+}
+
+/** Dispose the shared bench sidecar and clear the cold-run snapshot. */
+export async function stopBenchSidecar(): Promise<void> {
+	_benchSnapshot = undefined;
+	if (_benchSidecar) {
+		const sidecar = _benchSidecar;
+		_benchSidecar = undefined;
+		await sidecar.dispose();
+	}
+}
+
+/** Record the cold-run root snapshot reused by subsequent measured VMs. */
+export function setBenchRootSnapshot(snapshot: RootSnapshotExport): void {
+	_benchSnapshot = snapshot;
+}
+
+/** Clear the cold-run root snapshot (e.g. when switching workloads). */
+export function clearBenchRootSnapshot(): void {
+	_benchSnapshot = undefined;
+}
+
+/**
+ * Overlay the shared bench sidecar (and cold-run snapshot, when set) onto a
+ * VM-creation options object. The snapshot only applies when the caller did
+ * not request its own `rootFilesystem`.
+ */
+export function benchCreateOptions(options: AgentOsOptions = {}): AgentOsOptions {
+	const overlay: AgentOsOptions = { ...options };
+	if (_benchSidecar) {
+		overlay.sidecar = { kind: "explicit", handle: _benchSidecar };
+	}
+	if (_benchSnapshot && overlay.rootFilesystem === undefined) {
+		overlay.rootFilesystem = { type: "overlay", lowers: [_benchSnapshot] };
+	}
+	return overlay;
+}
 
 // ── Shared mock LLM server ─────────────────────────────────────────
 
@@ -101,10 +157,12 @@ function makeAgentSessionWorkload(opts: {
 		description: opts.description,
 		createVm: async () => {
 			const { port } = await ensureLlmock();
-			return AgentOs.create({
-				software: opts.software,
-				loopbackExemptPorts: [port],
-			});
+			return AgentOs.create(
+				benchCreateOptions({
+					software: opts.software,
+					loopbackExemptPorts: [port],
+				}),
+			);
 		},
 		start: async (vm) => {
 			const { url } = await ensureLlmock();
@@ -158,11 +216,12 @@ function makeAgentPromptWorkload(opts: {
 		description: opts.description,
 		createVm: async () => {
 			const { port } = await ensureLlmock();
-			return AgentOs.create({
-				loopbackExemptPorts: [port],
-				moduleAccessCwd: BENCHMARK_MODULE_ACCESS_CWD,
-				software: opts.software,
-			});
+			return AgentOs.create(
+				benchCreateOptions({
+					loopbackExemptPorts: [port],
+					software: opts.software,
+				}),
+			);
 		},
 		start: async (vm) => {
 			const { url } = await ensureLlmock();
@@ -232,7 +291,7 @@ export const WORKLOADS: Record<string, Workload> = {
 	sleep: {
 		name: "sleep",
 		description: "Minimal VM with idle Node.js process (setTimeout keepalive)",
-		createVm: () => AgentOs.create(),
+		createVm: () => AgentOs.create(benchCreateOptions()),
 		start: (vm) => {
 			vm.spawn("node", ["-e", "setTimeout(() => {}, 999999999)"], {
 				streamStdin: true,
@@ -279,9 +338,11 @@ export const WORKLOADS: Record<string, Workload> = {
  * This is the minimal setup needed to run shell commands.
  */
 export async function createBenchVm(): Promise<AgentOs> {
-	return AgentOs.create({
-		software: [coreutils],
-	});
+	return AgentOs.create(
+		benchCreateOptions({
+			software: [coreutils],
+		}),
+	);
 }
 
 /**
@@ -298,10 +359,12 @@ export async function createAgentSessionVm(
 }> {
 	const { url, port } = await ensureLlmock();
 	const t0 = performance.now();
-	const vm = await AgentOs.create({
-		software,
-		loopbackExemptPorts: [port],
-	});
+	const vm = await AgentOs.create(
+		benchCreateOptions({
+			software,
+			loopbackExemptPorts: [port],
+		}),
+	);
 	await vm.createSession(agentId, {
 		env: {
 			ANTHROPIC_API_KEY: "bench-key",

--- a/scripts/benchmarks/coldstart.bench.ts
+++ b/scripts/benchmarks/coldstart.bench.ts
@@ -2,20 +2,26 @@
  * Cold-start latency benchmark.
  *
  * Measures time from AgentOs.create() through workload ready:
+ *   --workload=sleep            Minimal VM + idle Node.js process (marketing cold-start workload)
  *   --workload=echo             Minimal VM + first exec("echo hello") completing
  *   --workload=pi-session       VM + createSession("pi") completing (ACP handshake done)
  *   --workload=pi-prompt-turn   VM + createSession("pi-cli") + first prompt turn completing
  *   --workload=claude-session   VM + createSession("claude") completing (ACP handshake done)
  *
- * `pi-prompt-turn` now benchmarks the native PI CLI path through
+ * All VMs lease one shared sidecar process; a cold-run VM is created and
+ * snapshotted first so measured iterations reflect warm, incremental cost.
+ *
+ * `pi-prompt-turn` benchmarks the native PI CLI path through
  * `createSession("pi-cli")`, which uses `pi-acp` to drive the real PI CLI in
  * RPC mode. The same PI headless test file documents that raw `spawn("pi", ...)`
  * is still not exposed on the native sidecar PATH.
  *
- * Pass --iterations=N to override default (5).
+ * Pass --iterations=N to override default (5). The reported p95/p99 are only
+ * meaningful with enough samples (~200 for p95, ~1000 for p99); the marketing
+ * run uses --iterations=2000.
  *
  * Usage:
- *   pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=echo
+ *   pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=sleep --iterations=2000
  *   pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=pi-session --iterations=3
  *   pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=claude-session --iterations=3
  */
@@ -25,18 +31,24 @@ import {
 	type WorkloadObservation,
 	WARMUP_ITERATIONS,
 	WORKLOADS,
+	clearBenchRootSnapshot,
 	createBenchVm,
 	ECHO_COMMAND,
 	EXPECTED_OUTPUT,
 	getHardware,
 	printTable,
 	round,
+	setBenchRootSnapshot,
+	startBenchSidecar,
 	stats,
+	stopBenchSidecar,
 	stopLlmock,
 } from "./bench-utils.js";
+import { AgentOs } from "@rivet-dev/agentos-core";
 
 const VALID_WORKLOADS = [
 	"echo",
+	"sleep",
 	...Object.keys(WORKLOADS).filter(
 		(k) => k.endsWith("-session") || k.endsWith("-turn"),
 	),
@@ -96,6 +108,28 @@ function parseArgs(): { workload: string; iterations: number } {
 	return { workload: name, iterations };
 }
 
+/**
+ * Cold run: create one VM up front, snapshot its root filesystem, and record
+ * the snapshot so subsequent measured VMs boot from it instead of paying the
+ * bootstrap cost on every iteration.
+ */
+async function coldRunSnapshot(workloadName: string): Promise<void> {
+	let vm: AgentOs;
+	if (workloadName === "echo") {
+		vm = await createBenchVm();
+		await vm.exec(ECHO_COMMAND);
+	} else {
+		const workload = WORKLOADS[workloadName];
+		vm = await workload.createVm();
+		await workload.start(vm);
+	}
+	try {
+		setBenchRootSnapshot(await vm.snapshotRootFilesystem());
+	} finally {
+		await vm.dispose();
+	}
+}
+
 async function main() {
 	const { workload, iterations } = parseArgs();
 	const measure = workload === "echo"
@@ -107,6 +141,13 @@ async function main() {
 	console.error(`CPU: ${hardware.cpu}`);
 	console.error(`RAM: ${hardware.ram} | Node: ${hardware.node}`);
 	console.error(`Iterations: ${iterations} (+ ${WARMUP_ITERATIONS} warmup)`);
+
+	// Create the sidecar once up front, then a single cold-run VM whose root
+	// filesystem snapshot warms every subsequent measured VM.
+	await startBenchSidecar();
+	clearBenchRootSnapshot();
+	console.error("cold run: snapshotting root filesystem...");
+	await coldRunSnapshot(workload);
 
 	const samples: number[] = [];
 	let lastObservation: WorkloadObservation | undefined;
@@ -154,6 +195,7 @@ async function main() {
 		),
 	);
 
+	await stopBenchSidecar();
 	await stopLlmock();
 }
 

--- a/scripts/benchmarks/memory.bench.ts
+++ b/scripts/benchmarks/memory.bench.ts
@@ -1,16 +1,19 @@
 /**
  * Memory overhead benchmark for AgentOS VMs.
  *
- * Staircase approach: warms up caches with a throwaway VM, then adds VMs
- * one at a time, measuring the incremental RSS and heap after each step.
- * The per-VM cost is the average step delta — free of one-time setup noise.
+ * Staircase approach: all VMs lease one shared sidecar process. A throwaway
+ * cold-run VM is created and disposed first (paying process spawn + bootstrap),
+ * then VMs are added one at a time, measuring the incremental RSS/heap after
+ * each step. The per-VM cost is the average step delta — the marginal cost of a
+ * VM on the shared process, free of one-time setup noise.
  *
  * Workloads:
  *   --workload=sleep             (default) Minimal VM with idle Node.js process
  *   --workload=pi-session        VM with PI agent session via createSession
  *   --workload=claude-session    VM with Claude agent session via createSession
  *
- * Pass --count=N to control how many VMs to add (default 5).
+ * Pass --count=N to control how many VMs to add (default 5; marketing run
+ * uses 20 for shell / 10 for agent).
  *
  * Usage:
  *   npx tsx --expose-gc benchmarks/memory.bench.ts
@@ -23,12 +26,15 @@ import { readFileSync, readdirSync } from "node:fs";
 import {
 	WORKLOADS,
 	type Workload,
+	clearBenchRootSnapshot,
 	forceGC,
 	formatBytes,
 	getHardware,
 	printTable,
 	round,
 	sleep,
+	startBenchSidecar,
+	stopBenchSidecar,
 	stopLlmock,
 } from "./bench-utils.js";
 
@@ -117,7 +123,11 @@ async function measure(
 	workload: Workload,
 	count: number,
 ): Promise<MemoryResult> {
-	// Warmup: create and destroy one VM to pay one-time costs (module cache, JIT, etc.)
+	// Cold run / warmup: create and destroy one VM to pay one-time costs (module
+	// cache, JIT, etc.) before measurement begins. This is the cold run; the
+	// staircase VMs below are the warm, steady-state per-VM measurements. (We do
+	// not reuse its filesystem snapshot here — agent-session workloads relaunch
+	// their adapter process per VM and must not inherit a prior VM's root.)
 	console.error("  warming up...");
 	const warmupVm = await workload.createVm();
 	await workload.start(warmupVm);
@@ -219,6 +229,10 @@ async function main() {
 	console.error(`RAM: ${hardware.ram} | Node: ${hardware.node}`);
 	console.error(`Count: ${count} VMs\n`);
 
+	// Create the sidecar once up front; every VM leases from it.
+	await startBenchSidecar();
+	clearBenchRootSnapshot();
+
 	const result = await measure(workload, count);
 
 	console.error(
@@ -239,6 +253,7 @@ async function main() {
 	// JSON to stdout.
 	console.log(JSON.stringify({ hardware, result }, null, 2));
 
+	await stopBenchSidecar();
 	await stopLlmock();
 }
 

--- a/scripts/benchmarks/results/coldstart-sleep.json
+++ b/scripts/benchmarks/results/coldstart-sleep.json
@@ -7,14 +7,14 @@
     "os": "Linux 6.1.0-41-amd64",
     "arch": "x64"
   },
-  "workload": "echo",
-  "iterations": 5,
+  "workload": "sleep",
+  "iterations": 30,
   "coldStart": {
-    "mean": 38.05,
-    "p50": 37.35,
-    "p95": 41.06,
-    "p99": 41.06,
-    "min": 36.61,
-    "max": 41.06
+    "mean": 4.56,
+    "p50": 4.3,
+    "p95": 7.04,
+    "p99": 7.33,
+    "min": 3.83,
+    "max": 7.33
   }
 }

--- a/scripts/benchmarks/results/memory-sleep.json
+++ b/scripts/benchmarks/results/memory-sleep.json
@@ -13,32 +13,32 @@
     "steps": [
       {
         "stepIndex": 0,
-        "rssBytes": 42618880,
-        "heapBytes": 616752
+        "rssBytes": 25440256,
+        "heapBytes": 99552
       },
       {
         "stepIndex": 1,
-        "rssBytes": 18022400,
-        "heapBytes": 453424
+        "rssBytes": 21786624,
+        "heapBytes": 144912
       },
       {
         "stepIndex": 2,
-        "rssBytes": 17969152,
-        "heapBytes": 408568
+        "rssBytes": 21348352,
+        "heapBytes": 192264
       },
       {
         "stepIndex": 3,
-        "rssBytes": 18173952,
-        "heapBytes": 485264
+        "rssBytes": 20418560,
+        "heapBytes": 217088
       },
       {
         "stepIndex": 4,
-        "rssBytes": 19017728,
-        "heapBytes": 416440
+        "rssBytes": 22417408,
+        "heapBytes": 309528
       }
     ],
-    "avgPerVmRssBytes": 23160422,
-    "avgPerVmHeapBytes": 476090,
-    "reclaimedRssBytes": 113549312
+    "avgPerVmRssBytes": 22282240,
+    "avgPerVmHeapBytes": 192669,
+    "reclaimedRssBytes": 60403712
   }
 }

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -5,8 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
-echo "=== Building ===" >&2
+echo "=== Building TypeScript ===" >&2
 pnpm build >&2
+
+# Benchmarks must run against an OPTIMIZED sidecar — the debug build is several
+# times slower and inflates cold-start and memory numbers. Build the release
+# binary and point the SDK at it via AGENT_OS_SIDECAR_BIN.
+echo "=== Building release sidecar ===" >&2
+cargo build --release -p agent-os-sidecar >&2
+export AGENT_OS_SIDECAR_BIN="$REPO_ROOT/target/release/agent-os-sidecar"
+echo "Using sidecar: $AGENT_OS_SIDECAR_BIN" >&2
 
 RESULTS_DIR="$SCRIPT_DIR/results"
 mkdir -p "$RESULTS_DIR"
@@ -21,22 +29,20 @@ run() {
     2> >(tee "$RESULTS_DIR/${name}.log" >&2)
 }
 
-# Cold-start benchmarks
-run "coldstart-echo" \
-  scripts/benchmarks/coldstart.bench.ts --workload=echo
+# Cold start — minimal "sleep" VM (idle Node.js process). This is the workload
+# cited on the marketing cold-start chart. 2000 iterations so the reported p95
+# (needs ~200+ samples) and p99 (needs ~1000+) are statistically meaningful, not
+# just the slowest one or two runs.
+run "coldstart-sleep" \
+  scripts/benchmarks/coldstart.bench.ts --workload=sleep --iterations=2000
 
-run "coldstart-pi-prompt-turn" \
-  scripts/benchmarks/coldstart.bench.ts --workload=pi-prompt-turn --iterations=3
+# Memory — simple shell workload (the "Simple shell command" marketing row).
+run "memory-sleep" \
+  --expose-gc scripts/benchmarks/memory.bench.ts --workload=sleep --count=20
 
-# Memory benchmarks
-# run "memory-sleep" \
-#   --expose-gc scripts/benchmarks/memory.bench.ts --workload=sleep --count=5
-
+# Memory — full Pi agent session (the "Full coding agent" marketing row).
 run "memory-pi-session" \
-  --expose-gc scripts/benchmarks/memory.bench.ts --workload=pi-session --count=3
-
-run "memory-claude-session" \
-  --expose-gc scripts/benchmarks/memory.bench.ts --workload=claude-session --count=3
+  --expose-gc scripts/benchmarks/memory.bench.ts --workload=pi-session --count=10
 
 # Session-creation VM-tax benchmark (deterministic, llmock-backed).
 # Compares the agentOS VM path vs the bare-node pi-SDK equivalent and gates the
@@ -52,3 +58,4 @@ pnpm exec tsx scripts/benchmarks/session.bench.ts --iterations=5 \
 
 echo "" >&2
 echo "=== Done. Results in $RESULTS_DIR ===" >&2
+echo "Update website/src/data/bench.ts inputs from these JSON files." >&2

--- a/website/src/content/docs/docs/benchmarks.mdx
+++ b/website/src/content/docs/docs/benchmarks.mdx
@@ -91,3 +91,66 @@ Self-hosted hardware tiers: AWS t4g.micro (ARM, $0.0084/h, 1 GiB), AWS t3.micro 
 ## Reproducing
 
 agentOS benchmarks live in the [agent-os repository](https://github.com/rivet-dev/agent-os) under `scripts/benchmarks/`.
+
+### Prerequisites
+
+- Node.js (see `.nvmrc`) and `pnpm`, with dependencies installed: `pnpm install`
+- A Rust toolchain (`cargo`) — the benchmarks build and run the native release sidecar
+- A reasonably **idle machine**: cold-start latency tails are sensitive to background CPU and GC jitter
+
+### Run everything
+
+From the repository root:
+
+```sh
+./scripts/benchmarks/run-benchmarks.sh
+```
+
+The script builds the TypeScript packages and an **optimized (release) sidecar**, points the SDK at it via `AGENT_OS_SIDECAR_BIN`, and writes one JSON result per benchmark to `scripts/benchmarks/results/`:
+
+| Result file | Feeds marketing input |
+|---|---|
+| `coldstart-sleep.json` | `COLDSTART_P50/P95/P99_MS` |
+| `memory-sleep.json` | `MEMORY_SHELL_MB` (`result.avgPerVmRssBytes / 1024²`) |
+| `memory-pi-session.json` | `MEMORY_AGENT_MB` (`result.avgPerVmRssBytes / 1024²`) |
+
+Copy those numbers into `website/src/data/bench.ts`; every figure and multiplier on this page recomputes from them.
+
+### Run a single benchmark
+
+Each benchmark is a standalone `tsx` entrypoint. Build first (`pnpm build` and `cargo build --release -p agent-os-sidecar`), then:
+
+```sh
+export AGENT_OS_SIDECAR_BIN="$PWD/target/release/agent-os-sidecar"
+
+# Cold start (sleep workload)
+pnpm exec tsx scripts/benchmarks/coldstart.bench.ts --workload=sleep --iterations=2000
+
+# Memory — simple shell command
+pnpm exec tsx --expose-gc scripts/benchmarks/memory.bench.ts --workload=sleep --count=20
+
+# Memory — full coding agent
+pnpm exec tsx --expose-gc scripts/benchmarks/memory.bench.ts --workload=pi-session --count=10
+```
+
+JSON goes to stdout; a human-readable table and progress go to stderr.
+
+### Sample sizes
+
+Percentiles are nearest-rank: `sorted[ceil(p/100 · n) − 1]`. With too few samples the tail is meaningless — at `n = 30`, **p99 is literally the single slowest run** and p95 is the second slowest. Use enough iterations that the reported percentile is averaged over real tail samples, not one outlier:
+
+| Statistic | Minimum iterations |
+|---|--:|
+| p50 (median) | ~30 |
+| p95 | ~200 |
+| p99 | ~1,000 |
+
+`run-benchmarks.sh` uses `--iterations=2000` for cold start so p95/p99 are trustworthy. Memory per VM is a mean of per-VM step deltas with low variance, so `--count=20` (shell) / `--count=10` (agent) is sufficient.
+
+> The `pi-session` memory workload needs a working in-VM agent runtime (the Pi adapter process must launch inside the VM). On builds where the agent runtime is unavailable it will fail its process check rather than report a number.
+
+### Methodology
+
+Every benchmark **creates the sidecar once up front** (`AgentOs.createSidecar()`) and leases all VMs from it. VMs are **incremental tenants of one shared sidecar process** — not one process each — so the figures measure the marginal cost of a VM, not a fresh process. (`AgentOs.create()` with no `sidecar` option already uses the shared `default`-pool sidecar, so this is the default everywhere, including RivetKit actors.)
+
+Before any measured iteration, each benchmark does a **cold run** — a throwaway VM that is created, started, and (for cold start) snapshotted. This pays the one-time process spawn + bootstrap so the recorded numbers reflect the warm, steady-state incremental per-VM cost, never the first VM. The release sidecar is required: a debug build is several times slower and inflates the numbers.

--- a/website/src/content/docs/docs/core.mdx
+++ b/website/src/content/docs/docs/core.mdx
@@ -60,6 +60,27 @@ console.log(result.stdout); // "hello\n"
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/core)*
 
+## Sidecar process
+
+Every VM runs inside a **shared sidecar process** rather than a process of its own. By default all VMs are tenants of a single, process-global sidecar (the `default` pool), so each additional VM only adds its marginal cost — a V8 isolate plus its kernel state — instead of a whole OS process. This is what keeps per-VM memory in the tens of MB and warm VM creation in the single-digit milliseconds (see [Benchmarks](/docs/benchmarks)).
+
+This is automatic — `agentOS()` and `AgentOs.create()` use the shared default sidecar with no configuration, and the same applies to Rivet Actors (each actor's VM is a tenant of the shared process). Disposing a VM tears down only that VM; the shared sidecar process is reused across VMs and stays alive for the lifetime of the host process.
+
+For advanced cases the core package exposes explicit sidecar handles so you can isolate a group of VMs in their own process:
+
+```ts title="advanced.ts"
+import { AgentOs } from "@rivet-dev/agentos-core";
+
+// One dedicated sidecar process hosting multiple VMs.
+const sidecar = await AgentOs.createSidecar();
+const a = await AgentOs.create({ sidecar: { kind: "explicit", handle: sidecar } });
+const b = await AgentOs.create({ sidecar: { kind: "explicit", handle: sidecar } });
+
+await a.dispose(); // tears down VM a only
+await b.dispose();
+await sidecar.dispose(); // tears down the shared process
+```
+
 ## Filesystem
 
 ```ts title="client.ts"

--- a/website/src/data/bench.ts
+++ b/website/src/data/bench.ts
@@ -4,8 +4,9 @@
  * All costs and multipliers are computed from the raw benchmark inputs below.
  * To update, change the input constants and everything recomputes.
  *
- * Source JSON files — copy from ~/a1/scripts/benchmarks/results/:
- *   coldstart-sleep.json     → COLDSTART_P50/P95/P99_MS  (result.p50Ms, p95Ms, p99Ms)
+ * Source JSON files — produced by scripts/benchmarks/run-benchmarks.sh into
+ * scripts/benchmarks/results/:
+ *   coldstart-sleep.json     → COLDSTART_P50/P95/P99_MS  (coldStart.p50, p95, p99)
  *   memory-sleep.json        → MEMORY_SHELL_MB           (result.avgPerVmRssBytes / 1024^2, rounded)
  *   memory-pi-session.json   → MEMORY_AGENT_MB           (result.avgPerVmRssBytes / 1024^2, rounded)
  */
@@ -18,7 +19,7 @@ export const COLDSTART_P95_MS = 5.6;
 export const COLDSTART_P99_MS = 6.1;
 
 // Memory per VM (MB, from avgPerVmRssBytes)
-// Copy from ~/a1/scripts/benchmarks/results/
+// Copy from scripts/benchmarks/results/
 export const MEMORY_AGENT_MB = 131;  // memory-pi-session.json  (137207808 / 1024^2)
 export const MEMORY_SHELL_MB = 22;   // memory-sleep.json       (23160422 / 1024^2)
 


### PR DESCRIPTION
## Summary

VMs leased from an `AgentOsSidecar` handle now run as **incremental tenants of one shared native sidecar process** instead of spawning a process each. The handle owns the process (spawned lazily, once); each VM's kernel proxy scopes its event pump to its own `ownership` and tears down only its VM on dispose (`ownsClient`), while the shared process is disposed with the handle. `AgentOs.create()` with no `sidecar` option uses the shared `default` pool, so this is the default everywhere — including Rivet Actors.

### Impact (measured, release sidecar)
- **Memory:** per-VM cost drops to the marginal ~21 MB (a V8 isolate + kernel state) instead of a full ~59 MB per-VM process.
- **Cold start:** warm VM creation drops to single-digit ms (no per-VM process spawn).
- VM isolation preserved (verified: VM B cannot read VM A's files); `tests/sidecar-placement.test.ts` passes.

### Also in this PR
- **Bench harness:** creates the sidecar up front + a cold-run snapshot, runs against the **release** sidecar, and uses statistically meaningful sample sizes (cold start needs ~200 for p95 / ~1000 for p99).
- **Docs:** new "Sidecar process" section in `core.mdx` (user-facing), and `benchmarks.mdx` run/reproduce instructions + methodology.

## ⚠️ Verification status (please let CI confirm)
- The **core change** (`agent-os.ts`, `rpc-client.ts`) was built + tested + benchmarked locally.
- This branch was authored against a **pre-rename** workspace and rebased onto `main`. The **bench harness + docs** were adapted to the `@rivet-dev/agentos-core` / `@agentos-software/*` package names but **could not be build-verified locally** (the pre-rename workspace doesn't have the renamed packages installed). Opening as a **draft** so CI verifies the bench/docs compile before review.