### PR TITLE
fix(core): make recursive mkdir a single write-side op (no per-component exists walk)

### DIFF
--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -3264,14 +3264,13 @@ export class AgentOs {
 	/** Recursively create directories (mkdir -p). */
 	private async _mkdirp(path: string): Promise<void> {
 		this._assertWritableAbsolutePath(path);
-		const parts = path.split("/").filter(Boolean);
-		let current = "";
-		for (const part of parts) {
-			current += `/${part}`;
-			if (!(await this.#kernel.exists(current))) {
-				await this.#kernel.mkdir(current);
-			}
-		}
+		// `kernel.mkdir` is already recursive (it defaults to recursive=true on both
+		// the native sidecar and compat kernels) and creating an existing directory is
+		// a no-op, so a single call is sufficient. Do NOT probe each ancestor with
+		// `exists()` first: on the native sidecar every read-side op
+		// (exists/stat/readFile) triggers a full shadow-tree walk, so a per-component
+		// exists() loop makes `mkdir -p` cost O(components * tree).
+		await this.#kernel.mkdir(path);
 	}
 
 	async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {

--- a/packages/core/tests/filesystem.test.ts
+++ b/packages/core/tests/filesystem.test.ts
@@ -2,8 +2,9 @@ import { resolve } from "node:path";
 import type { Fixture, ToolCall } from "@copilotkit/llmock";
 import { moduleAccessMounts } from "./helpers/node-modules-mount.js";
 import claude from "@agentos-software/claude-code";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AgentOs } from "../src/index.js";
+import { getAgentOsKernel } from "../src/test/runtime.js";
 import {
 	createAnthropicFixture,
 	startLlmock,
@@ -64,6 +65,35 @@ describe("filesystem operations", () => {
 		await vm.writeFile("/tmp/roundtrip.txt", content);
 		const data = await vm.readFile("/tmp/roundtrip.txt");
 		expect(new TextDecoder().decode(data)).toBe(content);
+	});
+
+	// Regression guard: `mkdir(path, { recursive: true })` must NOT probe each
+	// ancestor with a read-side `exists()`. On the native sidecar every read-side op
+	// triggers a full shadow-tree walk, so a per-component exists() loop made
+	// `mkdir -p` cost O(components * tree) -- a major source of session-creation
+	// latency on populated VMs. The recursive kernel mkdir is sufficient on its own.
+	test("recursive mkdir issues one mkdir and zero exists() probes", async () => {
+		const kernel = getAgentOsKernel(vm);
+		const deepPath = "/tmp/mkdirp-no-walk/a/b/c/d/e";
+		const existsSpy = vi.spyOn(kernel, "exists");
+		const mkdirSpy = vi.spyOn(kernel, "mkdir");
+
+		await vm.mkdir(deepPath, { recursive: true });
+
+		expect(existsSpy).not.toHaveBeenCalled();
+		expect(mkdirSpy).toHaveBeenCalledTimes(1);
+		expect(mkdirSpy).toHaveBeenCalledWith(deepPath);
+
+		existsSpy.mockRestore();
+		mkdirSpy.mockRestore();
+
+		// Behavior is preserved: every intermediate dir exists and is writable, and
+		// repeating the call is a no-op (idempotent).
+		await vm.writeFile(`${deepPath}/leaf.txt`, "ok");
+		expect(new TextDecoder().decode(await vm.readFile(`${deepPath}/leaf.txt`))).toBe(
+			"ok",
+		);
+		await vm.mkdir(deepPath, { recursive: true });
 	});
 
 	test("writeFile is visible to WASM guest commands", async () => {


### PR DESCRIPTION
## Problem

`AgentOs.mkdir(path, { recursive: true })` (`_mkdirp`) probed every ancestor with a read-side `exists()` before each `mkdir`:

```ts
for (const part of parts) {
  current += `/${part}`;
  if (!(await this.#kernel.exists(current))) {
    await this.#kernel.mkdir(current);
  }
}
```

On the native sidecar **every read-side fs op (`exists`/`stat`/`readFile`) triggers a full shadow-tree reconciliation walk** in secure-exec. So a per-component `exists()` loop makes `mkdir -p /a/b/c/d` cost **O(components × whole-shadow-tree)** — a major contributor to the session-creation latency seen on populated VMs (each `mkdir` step paying a multi-second walk).

## Fix

`kernel.mkdir` already defaults to recursive on both the native sidecar and compat kernels, and creating an existing directory is a no-op, so a single write-side call is sufficient (write-side ops skip the walk):

```ts
await this.#kernel.mkdir(path);
```

## Test

Adds a regression test (`recursive mkdir issues one mkdir and zero exists() probes`) asserting recursive mkdir issues exactly one `mkdir` and **zero** `exists()` probes, while preserving behavior (all intermediate dirs created and writable, idempotent on repeat).

> Note: this is the client-side half. The underlying secure-exec bug — read-side fs ops unconditionally re-walking the entire shadow tree — is fixed separately in the secure-exec repo.