### PR TITLE
Website: agent beta flags, LLM credential docs, nav cleanup

### DIFF
--- a/website/docs.config.mjs
+++ b/website/docs.config.mjs
@@ -20,7 +20,6 @@ export const siteConfig = {
 
 	topNav: [
 		{ label: "Use Cases", href: "/use-cases" },
-		{ label: "Pricing", href: "/pricing" },
 		{ label: "Registry", href: "/registry" },
 		{ label: "Docs", href: "/docs", match: "/docs" },
 	],
@@ -59,8 +58,8 @@ export const siteConfig = {
 					label: "Agents",
 					items: [
 						{ slug: "docs/agents/pi", label: "Pi", attrs: { "data-icon-src": "/images/registry/pi.svg" } },
-						{ slug: "docs/agents/claude", label: "ClaudeCode", attrs: { "data-icon-src": "/images/registry/claude-code.svg" } },
-						{ slug: "docs/agents/codex", label: "Codex", attrs: { "data-icon-src": "/images/registry/codex.svg" } },
+						{ slug: "docs/agents/claude", label: "ClaudeCode", badge: { text: "Beta", variant: "caution" }, attrs: { "data-icon-src": "/images/registry/claude-code.svg" } },
+						{ slug: "docs/agents/codex", label: "Codex", badge: { text: "Beta", variant: "caution" }, attrs: { "data-icon-src": "/images/registry/codex.svg" } },
 						{ slug: "docs/agents/opencode", label: "OpenCode", attrs: { "data-icon-src": "/images/registry/opencode.svg" } },
 						{ slug: "docs/agents/custom", label: "Custom Agents", attrs: { "data-icon": "wrench" } },
 					],
@@ -80,7 +79,7 @@ export const siteConfig = {
 				{ slug: "docs/processes", label: "Processes & Shell", attrs: { "data-icon": "terminal" } },
 				{ slug: "docs/networking", label: "Networking & Previews", attrs: { "data-icon": "globe" } },
 				{ slug: "docs/cron", label: "Cron Jobs", attrs: { "data-icon": "clock" } },
-				{ slug: "docs/sandbox", label: "Sandbox Mounting", attrs: { "data-icon": "hardDrive" } },
+				{ slug: "docs/sandbox", label: "Sandbox Mounting", badge: { text: "Beta", variant: "caution" }, attrs: { "data-icon": "hardDrive" } },
 				{ slug: "docs/js-runtime", label: "JavaScript Runtime", attrs: { "data-icon": "nodejs" } },
 				{ slug: "docs/permissions", attrs: { "data-icon": "key" } },
 				{ slug: "docs/resource-limits", label: "Resource Limits", attrs: { "data-icon": "gauge" } },

--- a/website/src/components/marketing/registry/RegistryPageClient.tsx
+++ b/website/src/components/marketing/registry/RegistryPageClient.tsx
@@ -333,6 +333,17 @@ function CategorySection({
 									Coming Soon
 								</span>
 							)}
+							{entry.beta && (
+								<span
+									className={
+										light
+											? "shrink-0 rounded-full border border-ink/15 px-1.5 py-0.5 text-[10px] text-ink-faint"
+											: "shrink-0 rounded-full border border-white/20 px-1.5 py-0.5 text-[10px] text-white/50"
+									}
+								>
+									Beta
+								</span>
+							)}
 						</div>
 						<p
 							className={

--- a/website/src/content/docs/docs/agents/claude.mdx
+++ b/website/src/content/docs/docs/agents/claude.mdx
@@ -44,6 +44,19 @@ Read [Sessions](/docs/sessions) first for session options, streaming events, pro
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/agents/claude)*
 
+## LLM Credentials
+
+Set the relevant variable(s) on the session's `env`, sourced from your server's environment:
+
+- `ANTHROPIC_API_KEY` — Anthropic API key (direct API).
+- `ANTHROPIC_AUTH_TOKEN` — bearer token for proxy / OAuth auth.
+- `ANTHROPIC_BASE_URL` — route through a gateway or proxy endpoint.
+- `ANTHROPIC_MODEL` — override the default model.
+- `CLAUDE_CODE_USE_BEDROCK=1` — use Amazon Bedrock (auth via the AWS credential chain: `AWS_REGION`, `AWS_PROFILE`, …).
+- `CLAUDE_CODE_USE_VERTEX=1` — use Google Vertex AI (auth via Google Cloud credentials).
+
+See [LLM Credentials](/docs/llm-credentials), and Claude Code's [environment variables](https://code.claude.com/docs/en/env-vars) for the full list.
+
 ## Skills
 
 Claude Code discovers [agent skills](https://docs.claude.com/en/docs/claude-code/skills) from `SKILL.md` files under its skills directory. Write the skill into the VM before creating a session and Claude Code loads it automatically.

--- a/website/src/content/docs/docs/agents/codex.mdx
+++ b/website/src/content/docs/docs/agents/codex.mdx
@@ -44,6 +44,16 @@ Read [Sessions](/docs/sessions) first for session options, streaming events, pro
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/agents/codex)*
 
+## LLM Credentials
+
+Set the relevant variable(s) on the session's `env`, sourced from your server's environment:
+
+- `OPENAI_API_KEY` — OpenAI API key (built-in `openai` provider).
+- `OPENAI_BASE_URL` — route through a gateway or OpenAI-compatible endpoint.
+- Custom providers — defined in `~/.codex/config.toml`; each provider's `env_key` names the variable Codex reads for its key (e.g. `AZURE_OPENAI_API_KEY`, `MISTRAL_API_KEY`).
+
+See [LLM Credentials](/docs/llm-credentials), and Codex's [config reference](https://developers.openai.com/codex/config-reference) for details.
+
 ## Skills
 
 Codex discovers `SKILL.md` files from its skills directory. Write the skill into the VM before creating a session and Codex loads it automatically.

--- a/website/src/content/docs/docs/agents/opencode.mdx
+++ b/website/src/content/docs/docs/agents/opencode.mdx
@@ -44,6 +44,19 @@ Read [Sessions](/docs/sessions) first for session options, streaming events, pro
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/agents/opencode)*
 
+## LLM Credentials
+
+OpenCode auto-detects a provider when its key is present on the session's `env`, sourced from your server's environment. Common variables:
+
+- `ANTHROPIC_API_KEY` — Anthropic (Claude), the default.
+- `OPENAI_API_KEY` — OpenAI.
+- `OPENROUTER_API_KEY` — OpenRouter.
+- `GEMINI_API_KEY` — Google Gemini.
+- `GROQ_API_KEY` — Groq.
+- …plus Amazon Bedrock, Azure, Google Vertex, and 70+ providers via [models.dev](https://models.dev).
+
+See [LLM Credentials](/docs/llm-credentials), and OpenCode's [providers docs](https://opencode.ai/docs/providers/) for the full list.
+
 ## Skills
 
 OpenCode discovers `SKILL.md` files from its skills directory. Write the skill into the VM before creating a session and OpenCode loads it automatically.

--- a/website/src/content/docs/docs/agents/pi.mdx
+++ b/website/src/content/docs/docs/agents/pi.mdx
@@ -44,6 +44,15 @@ Read [Sessions](/docs/sessions) first for session options, streaming events, pro
 
 *[See Full Example](https://github.com/rivet-dev/agent-os/tree/main/examples/docs/agents/pi)*
 
+## LLM Credentials
+
+Set the relevant variable on the session's `env`, sourced from your server's environment:
+
+- `ANTHROPIC_API_KEY` — Anthropic (Claude), the default.
+- Other providers — use the provider-named key (e.g. `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`).
+
+See [LLM Credentials](/docs/llm-credentials), and Pi's [providers docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) for the full list.
+
 ## Skills
 
 Pi discovers `SKILL.md` files from its skills directory. Write the skill into the VM before creating a session and Pi loads it automatically.

--- a/website/src/data/registry.ts
+++ b/website/src/data/registry.ts
@@ -6,6 +6,9 @@ export interface RegistryEntryBase {
 	description: string;
 	types: ("file-system" | "tool" | "agent" | "sandbox-extension" | "software")[];
 	featured?: boolean;
+	// Marks an entry as in beta — renders a "Beta" pill on the registry card
+	// and detail page.
+	beta?: boolean;
 	// Lucide icon name, resolved via REGISTRY_ICONS. Used when no `image` is
 	// provided. Must be a serializable string so it survives the Astro island
 	// prop boundary.
@@ -72,6 +75,7 @@ export const registry: RegistryEntry[] = [
 		slug: "claude-code",
 		title: "Claude Code",
 		status: "docs",
+		beta: true,
 		docsHref: "/docs/agents/claude",
 		package: "@agentos-software/claude-code",
 		agentId: "claude",
@@ -84,6 +88,7 @@ export const registry: RegistryEntry[] = [
 		slug: "codex",
 		title: "Codex",
 		status: "docs",
+		beta: true,
 		docsHref: "/docs/agents/codex",
 		package: "@agentos-software/codex",
 		agentId: "codex",
@@ -405,6 +410,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes directly on the local machine for development and testing.",
+		beta: true,
 		types: ["sandbox-extension"],
 		icon: "Monitor",
 	},
@@ -415,6 +421,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes in Docker containers for isolated local execution.",
+		beta: true,
 		types: ["sandbox-extension"],
 		image: "/images/registry/docker.svg",
 	},
@@ -425,6 +432,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes on E2B's cloud infrastructure for secure, ephemeral environments.",
+		beta: true,
 		types: ["sandbox-extension"],
 		featured: true,
 		image: "/images/registry/e2b.svg",
@@ -436,6 +444,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes on Daytona's managed development environments.",
+		beta: true,
 		types: ["sandbox-extension"],
 		image: "/images/registry/daytona.svg",
 	},
@@ -446,6 +455,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes on Modal's serverless cloud infrastructure.",
+		beta: true,
 		types: ["sandbox-extension"],
 		featured: true,
 		image: "/images/registry/modal.svg",
@@ -457,6 +467,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes on Vercel's edge and serverless platform.",
+		beta: true,
 		types: ["sandbox-extension"],
 		image: "/images/registry/vercel.svg",
 	},
@@ -467,6 +478,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes using the ComputeSDK compute provider.",
+		beta: true,
 		types: ["sandbox-extension"],
 		image: "/images/registry/computesdk.svg",
 	},
@@ -477,6 +489,7 @@ export const registry = setup({ use: { vm } });`,
 		package: "sandbox-agent",
 		description:
 			"Run sandboxes on Sprites' cloud sandbox infrastructure.",
+		beta: true,
 		types: ["sandbox-extension"],
 		image: "/images/registry/sprites.svg",
 	},

--- a/website/src/pages/registry/[slug].astro
+++ b/website/src/pages/registry/[slug].astro
@@ -149,6 +149,11 @@ const EntryIcon = entry.icon ? REGISTRY_ICONS[entry.icon] : undefined;
 							Coming Soon
 						</span>
 					)}
+					{entry.beta && (
+						<span class="rounded-full border border-ink/15 px-2.5 py-1 text-xs text-ink-faint">
+							Beta
+						</span>
+					)}
 				</div>
 
 				<div class="mt-4 flex gap-2">


### PR DESCRIPTION
## Summary
- Beta badges on **Claude Code**, **Codex**, and **Sandbox Mounting** in the docs sidebar (caution variant, matching the existing "Coming Soon" pill).
- Beta pills on registry index cards + detail pages for the agents and the 8 sandbox-mounting providers.
- Per-agent **LLM Credentials** sections listing the available env vars with upstream sources (Claude Code, Codex, OpenCode, Pi).
- Remove the **Pricing** tab from the header nav.