### PR TITLE
feat(website): lead with 281x agent cost figure

### DIFF
--- a/website/src/components/marketing/diagrams/ExecutionDensity.tsx
+++ b/website/src/components/marketing/diagrams/ExecutionDensity.tsx
@@ -60,7 +60,7 @@ function AutoHeight({ children }: { children: ReactNode }) {
 
 export const ExecutionDensity = ({ workload, onWorkloadChange }: { workload: WorkloadKey; onWorkloadChange: (w: WorkloadKey) => void }) => {
 	const reduced = useReducedMotion();
-	const [tierIdx, setTierIdx] = useState(0); // AWS ARM default
+	const [tierIdx, setTierIdx] = useState(0); // Hetzner ARM default
 	const [inView, setInView] = useState(false);
 
 	const wl = benchWorkloads[workload];

--- a/website/src/components/marketing/solutions/AgentOSPage.tsx
+++ b/website/src/components/marketing/solutions/AgentOSPage.tsx
@@ -689,7 +689,7 @@ const Hero = () => {
 	const heroStats = [
 		{ value: `${Math.round(benchColdStart[2].sandbox / benchColdStart[2].agentOS)}×`, label: 'faster cold starts', sub: 'vs. fastest sandbox', href: '#bench-cold-start' },
 		{ value: `${benchWorkloads.agent.memory.multiplier.split('x')[0]}×`, label: 'less memory', sub: 'per agent · vs. sandbox', href: '#bench-memory' },
-		{ value: `${Math.max(...Object.values(benchWorkloads).flatMap((w) => w.cost.map((t) => t.ratio)))}×`, label: 'cheaper to run', sub: 'vs. cheapest sandbox', href: '#bench-cost' },
+		{ value: `${Math.max(...benchWorkloads.agent.cost.map((t) => t.ratio))}×`, label: 'cheaper to run', sub: 'per agent · vs. cheapest sandbox', href: '#bench-cost' },
 	];
 
 	// Auto-cycle through agents starting 2.5s before stroke animation ends

--- a/website/src/data/bench.ts
+++ b/website/src/data/bench.ts
@@ -46,10 +46,10 @@ export const SANDBOX_MIN_MEMORY_MB = SANDBOX_MIN_MEMORY_GIB * 1024;
 // ── Self-hosted hardware pricing ──
 
 export const HARDWARE = [
-	{ label: 'AWS ARM',     costPerHour: 0.0084,                      memoryMb: 1024 },
-	{ label: 'AWS x86',     costPerHour: 0.0104,                      memoryMb: 1024 },
 	{ label: 'Hetzner ARM', costPerHour: 3.29 * 1.09 / (30 * 24),    memoryMb: 4096 }, // €3.29/mo
 	{ label: 'Hetzner x86', costPerHour: 5.39 * 1.09 / (30 * 24),    memoryMb: 4096 }, // €5.39/mo
+	{ label: 'AWS ARM',     costPerHour: 0.0084,                      memoryMb: 1024 },
+	{ label: 'AWS x86',     costPerHour: 0.0104,                      memoryMb: 1024 },
 ] as const;
 
 export const UTILIZATION = 0.7;

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const {
   title,
-  description = "A portable open-source operating system for agents. ~6 ms coldstarts, 32x cheaper than sandboxes. Powered by WebAssembly and V8 isolates.",
+  description = "A portable open-source operating system for agents. ~6 ms coldstarts, 281x cheaper than sandboxes. Powered by WebAssembly and V8 isolates.",
   canonicalUrl,
   ogImage = "https://agentos-sdk.dev/og.png",
 } = Astro.props;


### PR DESCRIPTION
Updates the marketing site to lead with the coding-agent cost figure (281×, Hetzner ARM) instead of the minimal-shell figure (1738×).

## Changes
- **Hero stat** (`AgentOSPage.tsx`): the "cheaper to run" stat now scopes to the agent workload's best tier (Hetzner ARM = **281×**) instead of `Math.max` across *all* workloads, which was surfacing the 22 MB shell workload's 1738×. Now consistent with the sibling cold-start / "less memory · per agent" stats; sub-label updated to "per agent · vs. cheapest sandbox".
- **Cost section order** (`bench.ts`): reordered `HARDWARE` so the Hetzner pair sits above the AWS pair in the "Cost Per Execution-Second" toggle/ledger (default tier is now Hetzner ARM).
- **Head meta** (`Layout.astro`): default description now reads "281x cheaper than sandboxes" (was 32x).
- Updated the stale `// AWS ARM default` comment in `ExecutionDensity.tsx`.

Note: a hardcoded `1738×` remains in `MosaicAnnouncement.tsx`, but that only renders on the internal `/internal/marketing` page, not the public homepage hero.