### PR TITLE
fix(actor-plugin): live sessionEvent streaming over the RivetKit actor path

### DIFF
--- a/crates/agentos-actor-plugin/src/actions/session.rs
+++ b/crates/agentos-actor-plugin/src/actions/session.rs
@@ -99,13 +99,33 @@ fn spawn_event_capture(
         // stream (on abort / channel close) is the unsubscribe.
         let _subscription = subscription;
         while let Some(notification) = stream.next().await {
-            let event_json = match serde_json::to_string(&notification) {
-                Ok(json) => json,
+            let event_value = match serde_json::to_value(&notification) {
+                Ok(value) => value,
                 Err(error) => {
                     tracing::warn!(?error, "failed to encode captured session event");
                     continue;
                 }
             };
+            // Live-stream to connected clients (`conn.on("sessionEvent")`) before
+            // persisting. The RivetKit event wire is CBOR, and the broadcast body
+            // is the array of handler ARGUMENTS the client spreads into the
+            // listener (`handler(...body)`). The quickstart listener is
+            // `(data) => data.event`, so the single argument is `{"event": <…>}`
+            // and the body is `[{"event": <notification>}]`. (A bare object trips
+            // the client's "Spread syntax requires …iterable"; JSON bytes trip
+            // "length over 4294967295".) Without this broadcast the events were
+            // only written to SQLite and never reached live subscribers, so
+            // `sessionEvent` streaming silently delivered nothing.
+            let mut cbor = Vec::new();
+            if ciborium::into_writer(
+                &serde_json::json!([{ "event": event_value }]),
+                &mut cbor,
+            )
+            .is_ok()
+            {
+                let _ = ctx.broadcast(b"sessionEvent".to_vec(), cbor);
+            }
+            let event_json = event_value.to_string();
             if let Err(error) = insert_session_event(&ctx, &external, &event_json).await {
                 tracing::warn!(?error, external, "failed to persist captured session event");
             }

--- a/crates/agentos-actor-plugin/src/lib.rs
+++ b/crates/agentos-actor-plugin/src/lib.rs
@@ -29,6 +29,7 @@ mod persistence_e2e;
 
 use std::sync::Arc;
 
+
 /// Process-global plugin state created once per `dlopen` (spec §5.2): the
 /// plugin's own tokio runtime (`enable_all` — the time driver is required by
 /// agentos-client hot paths).
@@ -212,17 +213,34 @@ async fn actor_loop(
     pool: String,
     cancel: CancellationToken,
 ) {
-    let mut vm: Option<agentos_client::AgentOs> = None;
-    let mut vars = actions::Vars::default();
     // Ensure the agent-os schema exists before handling events (best-effort;
     // mirrors rivetkit-agent-os run.rs).
     if host.sql_is_enabled() {
         let _ = persistence::migrate(&host).await;
     }
+    // The VM handle + actor vars live on a dedicated worker task that drains
+    // stateful jobs (Action/Http/Sleep/Destroy) serially in submission order.
+    // The event loop below only forwards those jobs and answers
+    // connection-lifecycle events (ConnPreflight/ConnOpen/SerializeState) inline.
+    // This is what keeps the loop responsive: a cold VM bring-up (>5s) on the
+    // first action no longer blocks the loop, so a queued ConnOpen is still
+    // answered within RivetKit's 5s websocket-setup deadline. Previously
+    // `ensure_vm().await` ran inline in this loop, so the first action starved
+    // ConnOpen, the actor websocket connection setup timed out at 5000ms, and
+    // live `sessionEvent` streaming silently delivered zero events.
+    let (job_tx, job_rx) = tokio::sync::mpsc::unbounded_channel::<ActorJob>();
+    let worker = tokio::spawn(actor_worker(
+        host.clone(),
+        sidecar_path,
+        config,
+        pool,
+        job_rx,
+        cancel.clone(),
+    ));
     // Signal readiness: the native-plugin factory uses manual startup-ready, so
     // the host's `start()` caller blocks until we report this. The VM is brought
-    // up lazily on the first action, so the actor is ready once the schema is in
-    // place and the event loop is about to run.
+    // up lazily on the first action (on the worker), so the actor is ready once
+    // the schema is in place and the event loop is about to run.
     host.startup_ready(true, "");
     loop {
         let event = tokio::select! {
@@ -234,6 +252,92 @@ async fn actor_loop(
         };
         match abi::AbiEventTag::from_u32(tag) {
             Some(abi::AbiEventTag::Action) => {
+                if job_tx.send(ActorJob::Action { token, payload }).is_err() {
+                    let _ = host.reply_err(token, "agent-os actor worker unavailable");
+                }
+            }
+            Some(abi::AbiEventTag::Http) => {
+                if job_tx.send(ActorJob::Http { token, payload }).is_err() {
+                    let _ = host.reply_err(token, "agent-os actor worker unavailable");
+                }
+            }
+            Some(abi::AbiEventTag::ConnPreflight) => {
+                let _ = host.reply_ok(token, Vec::new());
+            }
+            Some(abi::AbiEventTag::ConnOpen) => {
+                let _ = host.reply_ok(token, Vec::new());
+            }
+            Some(abi::AbiEventTag::Subscribe) => {
+                // Accept the connection's event subscription (e.g. `sessionEvent`)
+                // so RivetKit registers it and routes matching broadcasts to this
+                // connection. Subscription state is tracked by RivetKit core; the
+                // plugin only needs to accept. Previously this fell through to the
+                // generic "event not supported" reply, which REJECTED every
+                // subscription — so the connection was never registered and every
+                // broadcast (sessionEvent, vmBooted, ...) was silently dropped,
+                // making live `sessionEvent` streaming deliver nothing.
+                let _ = host.reply_ok(token, Vec::new());
+            }
+            Some(abi::AbiEventTag::SerializeState) => {
+                // Agent OS persists durable data through SQLite and rebuilds VM/process
+                // state after wake, so there is no opaque actor state payload to return.
+                let _ = host.reply_ok(token, Vec::new());
+            }
+            Some(abi::AbiEventTag::Sleep) => {
+                if job_tx.send(ActorJob::Sleep { token }).is_err() {
+                    let _ = host.reply_ok(token, Vec::new());
+                }
+            }
+            Some(abi::AbiEventTag::Destroy) => {
+                if job_tx.send(ActorJob::Destroy { token }).is_err() {
+                    let _ = host.reply_ok(token, Vec::new());
+                }
+            }
+            Some(t) if t.needs_reply() => {
+                let _ = host.reply_err(token, "event not supported by agent-os actor");
+            }
+            _ => {}
+        }
+    }
+    // Stream closed (cancel/teardown): stop accepting new jobs and let the
+    // worker drain in-flight work + shut the VM down before we return.
+    drop(job_tx);
+    let _ = worker.await;
+}
+
+/// Stateful actor jobs serviced by the worker task in submission order. Keeping
+/// VM-touching work (bring-up, action dispatch, HTTP proxy, shutdown) off the
+/// event loop is what lets the loop answer connection-lifecycle events promptly.
+enum ActorJob {
+    Action { token: u64, payload: Vec<u8> },
+    Http { token: u64, payload: Vec<u8> },
+    Sleep { token: u64 },
+    Destroy { token: u64 },
+}
+
+/// Owns the VM handle + actor vars and processes `ActorJob`s serially. Runs as a
+/// sibling task to `actor_loop`; the loop forwards jobs and never blocks on the
+/// VM, so a slow cold boot can't starve connection setup.
+async fn actor_worker(
+    host: host_ctx::HostCtx,
+    sidecar_path: String,
+    config: Arc<config::AgentOsConfigJson>,
+    pool: String,
+    mut job_rx: tokio::sync::mpsc::UnboundedReceiver<ActorJob>,
+    cancel: CancellationToken,
+) {
+    let mut vm: Option<agentos_client::AgentOs> = None;
+    let mut vars = actions::Vars::default();
+    loop {
+        let job = tokio::select! {
+            _ = cancel.cancelled() => break,
+            job = job_rx.recv() => match job {
+                Some(job) => job,
+                None => break,
+            },
+        };
+        match job {
+            ActorJob::Action { token, payload } => {
                 if let Err(error) =
                     vm::ensure_vm(&host, &sidecar_path, &config, &pool, &mut vm).await
                 {
@@ -255,37 +359,22 @@ async fn actor_loop(
                     }
                 }
             }
-            Some(abi::AbiEventTag::Http) => {
+            ActorJob::Http { token, payload } => {
                 // Preview proxy: do NOT bring the VM up for HTTP (matches r6's
                 // run loop, which passes `vm.as_ref()`); no VM → 404.
                 let response = http::proxy_preview(&host, vm.as_ref(), &payload).await;
                 let _ = host.reply_ok(token, response);
             }
-            Some(abi::AbiEventTag::ConnPreflight) => {
-                let _ = host.reply_ok(token, Vec::new());
-            }
-            Some(abi::AbiEventTag::ConnOpen) => {
-                let _ = host.reply_ok(token, Vec::new());
-            }
-            Some(abi::AbiEventTag::SerializeState) => {
-                // Agent OS persists durable data through SQLite and rebuilds VM/process
-                // state after wake, so there is no opaque actor state payload to return.
-                let _ = host.reply_ok(token, Vec::new());
-            }
-            Some(abi::AbiEventTag::Sleep) => {
+            ActorJob::Sleep { token } => {
                 vars.clear();
                 vm::shutdown_vm(&host, &mut vm, "sleep").await;
                 let _ = host.reply_ok(token, Vec::new());
             }
-            Some(abi::AbiEventTag::Destroy) => {
+            ActorJob::Destroy { token } => {
                 vars.clear();
                 vm::shutdown_vm(&host, &mut vm, "destroy").await;
                 let _ = host.reply_ok(token, Vec::new());
             }
-            Some(t) if t.needs_reply() => {
-                let _ = host.reply_err(token, "event not supported by agent-os actor");
-            }
-            _ => {}
         }
     }
     // Stream closed (cancel/teardown): best-effort VM shutdown.

--- a/crates/agentos-actor-plugin/src/vm.rs
+++ b/crates/agentos-actor-plugin/src/vm.rs
@@ -75,7 +75,13 @@ pub(crate) async fn ensure_vm(
         .await
         .map_err(|error| format!("agent-os vm bring-up failed: {error}"))?;
     *vm = Some(handle);
-    let _ = host.broadcast(b"vmBooted".to_vec(), b"{}".to_vec());
+    // CBOR array of handler args (`handler(...body)`): the listener takes one
+    // object argument, so the body is `[{}]`. JSON bytes / a bare object trip the
+    // client's CBOR decoder ("length over 4294967295" / "Spread requires iterable").
+    let mut cbor = Vec::new();
+    if ciborium::into_writer(&serde_json::json!([{}]), &mut cbor).is_ok() {
+        let _ = host.broadcast(b"vmBooted".to_vec(), cbor);
+    }
     Ok(())
 }
 
@@ -87,8 +93,10 @@ pub(crate) async fn shutdown_vm(host: &HostCtx, vm: &mut Option<AgentOs>, reason
     if let Err(error) = handle.shutdown().await {
         host.log_warn(&format!("agent-os vm shutdown error ({reason}): {error}"));
     }
-    let payload = format!("{{\"reason\":\"{reason}\"}}");
-    let _ = host.broadcast(b"vmShutdown".to_vec(), payload.into_bytes());
+    let mut cbor = Vec::new();
+    if ciborium::into_writer(&serde_json::json!([{ "reason": reason }]), &mut cbor).is_ok() {
+        let _ = host.broadcast(b"vmShutdown".to_vec(), cbor);
+    }
 }
 
 /// Durable-storage callback: routes a sidecar fs op to actor SQLite via


### PR DESCRIPTION
The published 0.2.1 quickstart streamed ZERO sessionEvents (conn.on("sessionEvent")).
Root-caused three distinct bugs in the native actor plugin, each blocking the next:

1. actor_loop starvation (WS-setup timeout). The single event loop ran
   ensure_vm().await inline on the first action; a cold VM boot (>5s) starved the
   queued ConnOpen, so RivetKit-core failed connection setup at 5000ms
   ("actor websocket connection setup timed out after 5000 ms") and no events
   could flow. Fix: move VM-touching work (Action/Http/Sleep/Destroy) onto a
   dedicated serial worker task; the loop now answers connection-lifecycle events
   inline and never blocks on the VM.

2. Subscribe event rejected. RivetKit delivers an AbiEventTag::Subscribe to the
   plugin when a client subscribes to an event name; the loop had no arm, so it
   hit the generic "event not supported" reply, REJECTING every subscription. With
   no subscription registered, broadcast() (which filters on is_subscribed) routed
   zero events to the connection. Fix: accept Subscribe inline (reply_ok).

3. sessionEvent broadcast missing + mis-encoded. spawn_event_capture only persisted
   each event to SQLite and never broadcast it. Added the broadcast, encoded as the
   RivetKit event wire expects: a CBOR array of handler arguments
   ([{ "event": <notification> }]) so the client `(data) => data.event` listener
   receives it. Also fixed vmBooted/vmShutdown, which had the same JSON-instead-of-
   CBOR encoding bug.

Verified locally against the published 0.2.1 npm packages with AGENTOS_PLUGIN_BIN
override + a real Anthropic key: 13 live session/update events stream end-to-end.

Known residual: a timing race remains between subscription registration and the
event burst (reliable under normal/slower timing, ~50% under rapid back-to-back
connections). The action reaches the plugin ~before the subscribe, and the engine
spawns actions without blocking, so this appears to live in the RivetKit
client/engine subscribe-vs-action ordering (preview dep), not the plugin.