### PR TITLE
docs(claude): warn about the agentos-core version pin that hangs tool execution (#1542)

### DIFF
--- a/website/src/content/docs/docs/agents/claude.mdx
+++ b/website/src/content/docs/docs/agents/claude.mdx
@@ -8,6 +8,30 @@ import { Aside } from '@astrojs/starlight/components';
 
 import CodeGroup from '@rivet-dev/docs-theme/components/CodeGroup.astro';
 
+<Aside type="caution" title="Install a single, current agentos-core">
+The Claude agent's tools (Write, Bash, skills, and sub-agents) run through the shared
+secure-exec sidecar. The fix for a sidecar lifecycle bug that otherwise **hangs tool
+execution for 120s** with `timed out waiting for sidecar protocol frame for ext` landed in
+`@rivet-dev/agentos-core@0.2.2` (secure-exec-sidecar `0.3.2`).
+
+`@agentos-software/claude-code` currently pins `@rivet-dev/agentos-core` to an exact older
+version, so a default `npm install @rivet-dev/agentos-core @agentos-software/claude-code`
+can resolve **two** copies of `agentos-core` and route tool execution through the older,
+unfixed sidecar. Until the adapter is republished against `0.2.2`, force a single current
+version:
+
+```json title="package.json"
+{
+  "overrides": {
+    "@rivet-dev/agentos-core": "0.2.2"
+  }
+}
+```
+
+(`pnpm` / `yarn` users: use `pnpm.overrides` / `resolutions`.) See
+[#1542](https://github.com/rivet-dev/agentos/issues/1542) for the full root-cause trace.
+</Aside>
+
 ## Quick start
 
 <CodeGroup>


### PR DESCRIPTION
## What

Adds a caution callout to the Claude agent docs about a version-pin gotcha that **hangs all tool execution** (Write / Bash / skills / sub-agents) for 120s with:

```
timed out waiting for sidecar protocol frame for ext
```

## Why

`@agentos-software/claude-code` pins `@rivet-dev/agentos-core` to an **exact older version**, so a default `npm install @rivet-dev/agentos-core @agentos-software/claude-code` resolves **two** copies of `agentos-core` and routes the agent's tool path through the older, unfixed `secure-exec-sidecar 0.3.1`.

That sidecar version has a shared-sidecar lifecycle bug: when a per-VM `sidecar_response` arrives after its VM was torn down, the pre-fix sidecar treats `UnmatchedResponse`/`DuplicateResponse` as fatal, the stdin read loop exits, the sidecar stops servicing frames, and every pending `ext` request hangs to the 120s timeout. The defensive fix landed in `secure-exec-sidecar 0.3.2` (secure-exec #133) and ships in `@rivet-dev/agentos-core@0.2.2`.

Verified: forcing `@rivet-dev/agentos-core@0.2.2` across the tool path via `overrides` removes the hang.

Full end-to-end root-cause trace (Rust sidecar + TS host, file:line) is in **#1542**.

## This PR

Documents the `overrides` workaround in `agents/claude.mdx` so a fresh install doesn't silently run the unfixed sidecar. The proper fix — republishing `@agentos-software/claude-code` with its `@rivet-dev/agentos-core` dependency bumped to `0.2.2` — is maintainer-side (that package has no public repo); this callout is a stopgap until then.