### PR TITLE
fix(docs): convert opencode <Aside> to <Warning> (fixes build)

### DIFF
--- a/website/src/content/docs/docs/agents/opencode.mdx
+++ b/website/src/content/docs/docs/agents/opencode.mdx
@@ -31,11 +31,11 @@ See [LLM Credentials](/docs/llm-credentials), and OpenCode's [providers docs](ht
 
 To pin a specific model — or point a provider at a custom endpoint — write an OpenCode config file into the VM before creating the session. OpenCode reads `<HOME>/.config/opencode/opencode.json` (the agent's `HOME` is `/home/agentos` by default).
 
-<Aside type="caution">
+<Warning>
 Two settings will silently produce an **empty response** if wrong:
 - The Anthropic provider **`baseURL` must end in `/v1`** (`https://api.anthropic.com/v1`). Without `/v1`, OpenCode calls `…/messages` and Anthropic returns `404 Not Found`.
 - The **`model` must be a current model id.** A retired id returns a `404 not_found_error` and the turn ends with zero output.
-</Aside>
+</Warning>
 
 ```ts
 // Write the config before creating the session


### PR DESCRIPTION
The docs migration left one Starlight `<Aside type="caution">` in `agents/opencode.mdx`. The de-Starlighted theme doesn't define `Aside`, so the build failed at `/docs/agents/opencode/` with *'Expected component Aside to be defined'* (Railway build #1555). Converts it to `<Warning>` (the theme's callout, already used 4× in agentOS docs).

Verified: `astro build` (119 pages) **and** the full `website/Dockerfile` Docker build both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)