### PR TITLE
fix(docker): don't leak FA Pro token into build logs

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -17,8 +17,9 @@ ARG DOCS_THEME_SHA=450c498555135098c6a927adfdf13458be9be22a
 # build variable (passed via --build-arg locally). It is only referenced in this
 # discarded build stage — the final caddy image never contains it.
 ARG FONTAWESOME_PACKAGE_TOKEN
-RUN export FONTAWESOME_PACKAGE_TOKEN="$FONTAWESOME_PACKAGE_TOKEN" \
- && git clone https://github.com/rivet-dev/docs-theme.git /theme \
+# The ARG is already in this RUN's environment, so the icons generate reads
+# FONTAWESOME_PACKAGE_TOKEN directly — we don't echo it into the build log.
+RUN git clone https://github.com/rivet-dev/docs-theme.git /theme \
  && git -C /theme checkout "$DOCS_THEME_SHA" \
  && pnpm -C /theme install \
  && pnpm -C /theme/packages/theme/vendor/icons run gen:manifest \


### PR DESCRIPTION
The website Dockerfile `export`-ed `FONTAWESOME_PACKAGE_TOKEN` in a RUN, which printed the token value into Railway build logs (and tripped BuildKit's `SecretsUsedInArgOrEnv`). The ARG is already in the RUN env, so the icons generate reads it directly — no echo. Verified: full Docker build passes (119 pages, image) and the token no longer appears in the build log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)