### PR TITLE
chore(deps): pin rivetkit + @rivetkit/react to native-plugin inspectorTabs build (qkwmksyy.d2859b0)

### DIFF
--- a/examples/agent-to-agent/package.json
+++ b/examples/agent-to-agent/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/agentos-typecheck/package.json
+++ b/examples/agentos-typecheck/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/approvals/package.json
+++ b/examples/approvals/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/bindings/package.json
+++ b/examples/bindings/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/browser-terminal/package.json
+++ b/examples/browser-terminal/package.json
@@ -20,12 +20,12 @@
 		"@agentos-software/ripgrep": "catalog:",
 		"@agentos-software/sqlite3": "catalog:",
 		"@rivet-dev/agentos": "workspace:*",
-		"@rivetkit/react": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
+		"@rivetkit/react": "catalog:rivetkit",
 		"@xterm/addon-fit": "^0.10.0",
 		"@xterm/xterm": "^5.5.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/react": "^19.0.0",

--- a/examples/browser-terminal/server.ts
+++ b/examples/browser-terminal/server.ts
@@ -1,13 +1,10 @@
 import common from "@agentos-software/common";
-import curl from "@agentos-software/curl";
-import git from "@agentos-software/git";
-import jq from "@agentos-software/jq";
-import ripgrep from "@agentos-software/ripgrep";
-import sqlite3 from "@agentos-software/sqlite3";
 import { agentOS, setup } from "@rivet-dev/agentos";
 
+// TEMP (local debug): only `common` (sha 42d8146) has valid projected packs;
+// `sqlite3` (efc374f) is missing its `dist/package`, so it's dropped for now.
 const shellVm = agentOS({
-	software: [common, git, curl, ripgrep, jq, sqlite3],
+	software: [common],
 });
 
 export const registry = setup({ use: { shellVm } });

--- a/examples/claude/package.json
+++ b/examples/claude/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/codex/package.json
+++ b/examples/codex/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/core/package.json
+++ b/examples/core/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/crash-course/package.json
+++ b/examples/crash-course/package.json
@@ -8,7 +8,7 @@
     "@rivet-dev/agentos": "workspace:*",
     "@rivet-dev/agentos-core": "workspace:*",
     "@rivet-dev/agentos-sandbox": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
+    "rivetkit": "catalog:rivetkit",
     "sandbox-agent": "^0.4.2",
     "dockerode": "^4.0.9",
     "get-port": "^7.1.0",

--- a/examples/cron/package.json
+++ b/examples/cron/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/custom/package.json
+++ b/examples/custom/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/debugging/package.json
+++ b/examples/debugging/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/filesystem/package.json
+++ b/examples/filesystem/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/js-runtime/package.json
+++ b/examples/js-runtime/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/llm-credentials/package.json
+++ b/examples/llm-credentials/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/multiplayer/package.json
+++ b/examples/multiplayer/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/networking/package.json
+++ b/examples/networking/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/opencode/package.json
+++ b/examples/opencode/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/permissions/package.json
+++ b/examples/permissions/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/persistence/package.json
+++ b/examples/persistence/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/pi/package.json
+++ b/examples/pi/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/processes/package.json
+++ b/examples/processes/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/quickstart-app/package.json
+++ b/examples/quickstart-app/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
+    "rivetkit": "catalog:rivetkit",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/examples/quickstart/agent-session/package.json
+++ b/examples/quickstart/agent-session/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/bash/package.json
+++ b/examples/quickstart/bash/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/cron/package.json
+++ b/examples/quickstart/cron/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/filesystem/package.json
+++ b/examples/quickstart/filesystem/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/git/package.json
+++ b/examples/quickstart/git/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/hello-world/package.json
+++ b/examples/quickstart/hello-world/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/network/package.json
+++ b/examples/quickstart/network/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/nodejs/package.json
+++ b/examples/quickstart/nodejs/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -33,7 +33,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/pi-extensions/package.json
+++ b/examples/quickstart/pi-extensions/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/processes/package.json
+++ b/examples/quickstart/processes/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/s3-filesystem/package.json
+++ b/examples/quickstart/s3-filesystem/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/sandbox/package.json
+++ b/examples/quickstart/sandbox/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/quickstart/tools/package.json
+++ b/examples/quickstart/tools/package.json
@@ -19,7 +19,7 @@
 		"@agentos-software/pi": "catalog:",
 		"zod": "^4.1.11",
 		"@rivet-dev/agentos": "workspace:*",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+		"rivetkit": "catalog:rivetkit"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/examples/resource-limits/package.json
+++ b/examples/resource-limits/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/sessions/package.json
+++ b/examples/sessions/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/software/package.json
+++ b/examples/software/package.json
@@ -21,7 +21,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/webhooks/package.json
+++ b/examples/webhooks/package.json
@@ -8,7 +8,7 @@
     "@rivet-dev/agentos": "workspace:*",
     "@rivet-dev/agentos-core": "workspace:*",
     "@rivet-dev/agentos-sandbox": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
+    "rivetkit": "catalog:rivetkit",
     "hono": "^4.6.0",
     "sandbox-agent": "^0.4.2",
     "dockerode": "^4.0.9",

--- a/examples/workflows/package.json
+++ b/examples/workflows/package.json
@@ -18,7 +18,7 @@
     "@agentos-software/pi": "catalog:",
     "zod": "^4.1.11",
     "@rivet-dev/agentos": "workspace:*",
-    "rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585"
+    "rivetkit": "catalog:rivetkit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/agentos/package.json
+++ b/packages/agentos/package.json
@@ -57,8 +57,8 @@
 		"@agentos-software/common": "catalog:",
 		"@rivet-dev/agentos-core": "workspace:*",
 		"@rivet-dev/agentos-sidecar": "workspace:*",
-		"@rivetkit/react": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
-		"rivetkit": "0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585",
+		"@rivetkit/react": "catalog:rivetkit",
+		"rivetkit": "catalog:rivetkit",
 		"zod": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,13 @@ catalogs:
     '@secure-exec/sandbox':
       specifier: 0.0.0-nathan-agentos-package-resolution.0bf7dcb
       version: 0.0.0-nathan-agentos-package-resolution.0bf7dcb
+  rivetkit:
+    '@rivetkit/react':
+      specifier: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+    rivetkit:
+      specifier: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
 
 overrides:
   '@rivet-dev/agentos-core': workspace:*
@@ -189,8 +196,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -214,8 +221,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agentos
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -254,8 +261,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -303,8 +310,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -352,8 +359,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -395,8 +402,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/agentos
       '@rivetkit/react':
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -410,8 +417,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
     devDependencies:
       '@types/react':
         specifier: ^19.0.0
@@ -465,8 +472,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -514,8 +521,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -563,8 +570,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -612,8 +619,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -661,8 +668,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -710,8 +717,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -759,8 +766,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -808,8 +815,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -857,8 +864,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -906,8 +913,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -955,8 +962,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1004,8 +1011,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1053,8 +1060,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1102,8 +1109,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1151,8 +1158,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1200,8 +1207,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1249,8 +1256,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1298,8 +1305,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1350,8 +1357,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1402,8 +1409,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1451,8 +1458,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1500,8 +1507,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1549,8 +1556,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1598,8 +1605,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1647,8 +1654,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1696,8 +1703,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1745,8 +1752,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1794,8 +1801,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1843,8 +1850,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1892,8 +1899,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1941,8 +1948,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1990,8 +1997,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2039,8 +2046,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2088,8 +2095,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2137,8 +2144,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2195,8 +2202,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2247,8 +2254,8 @@ importers:
         specifier: ^4.6.0
         version: 4.12.9
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2296,8 +2303,8 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2327,11 +2334,11 @@ importers:
         specifier: workspace:*
         version: link:../sidecar-binary
       '@rivetkit/react':
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))
       rivetkit:
-        specifier: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-        version: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+        specifier: catalog:rivetkit
+        version: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -4427,102 +4434,102 @@ packages:
     resolution: {integrity: sha512-3qndQUQXLdwafMEqfhz24hUtDPcsf1Bu3q52Kb8MqeH8JUh3h6R4HYW3ZJXiQsLcyYyFM68PuIwlLRlg1xDEpg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@rivetkit/engine-cli-darwin-arm64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-DZvB5MzOKsZxwHjaX53IZ1ZQBkuaPdem2WgRJrjmOizk/1h3961mWyFsOPf025T4z04RATAL1/M/z8lRFHP8qQ==}
+  '@rivetkit/engine-cli-darwin-arm64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-kPzGTfdIIR5qAZpZDDRXC3OtGd8Jh/dZb/Pbmd03k/2DT12ILUHmI2DZg829icylExSSmhfRVjUSYsjRw8rmug==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-darwin-x64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-7BFsc+B3fSLUdReSKnJb8EYL8usK+460hwlF5CPxrgyplNGf/XFAhJ7mf3vCnaIc/4s05Ln3yIOs5Mw/dkYEqw==}
+  '@rivetkit/engine-cli-darwin-x64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-0rJcsIttFzycpR4J/ciECjPk+KzlVFeJwTPobhG9anWHycq8GpCuQx9ipgBA++01tZYo/x7kEfSU+dNdrxqsEA==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-QSKV0qU/+oaQiGPIn7wT4GpFoggY/uSdRnqHI0LmmMqtSa8w/wM9McmQFtgL0/E4O6ZRvoqycpx93uWgJEfx4g==}
+  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-jXh2SgMHm/JPwVGOlFSO1NGMy7/2t4lNwU/iSwX4CN1px9Nrr4Ud8n0FY58VHcU4Ppv1tWAdWEWsOlF5EZlr8Q==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-9MHlNOJY5nQA5Z/L23fFiPrmsYw5WzAT+1e7dmB8Jtkv67uGmpoagnVhGgqWv7mfXtf3Fx9w01OXLiHTSadKuA==}
+  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-pDBkdi5la//sp7Uq1KXDR4eXbwO0l/HmQCnosbgWHWz8OBL62RcueeYWQt181Gl7VIsINm1QB7mihUcbcECVxw==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/engine-cli@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-eLWWKYD2wvYz5Eb4EKvEd5cmPX+aPutwjNa3N+vf+w5/zdpvSzhcwNHqsDNm12aLo/ReVoxs1P4G4MLd5ZNgdw==}
+  '@rivetkit/engine-cli@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-7fq+rJt5+bujGV+Q0esDY3OJrzRUhEpYd2EV0oVUI+pcIRyYJMx2y7KrMUucqTFOr77O/NDlmSGTfD4cStRfrg==}
     engines: {node: '>= 20.0.0'}
 
-  '@rivetkit/engine-envoy-protocol@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-qsPCbHgunKzJXRaobnrYnHeWvo+Gcv+AZvb7oVYnbl5MuE+Mykuc+elRdHt8kiBrabKwsqEL8tYO2jSRQJDHqw==}
+  '@rivetkit/engine-envoy-protocol@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-2u0MPsYLMSuwaX0amz52kZX4wsh3PmbczjPb4AoSk1hCbycf1IN3Vkj3RR87ZwMTlLYKkcpgq8fHPlxoPSkftQ==}
 
-  '@rivetkit/framework-base@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-nfdRT1mhkOhkfZL7bUWbZGlAmekzO321W3xNlUp8zccvGbUjMF6ah+ZsfURBxWBzD30WMFQ8s1mWw6bnrAYqLQ==}
+  '@rivetkit/framework-base@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-513zdVQgSYQeQ3nXu5RTjVxvwhpAcfn6bKXpcb9XLFli+wux07oTcszo6HCsqfeChEO19LAXWysWbEDMzwYU3g==}
 
   '@rivetkit/on-change@6.0.1':
     resolution: {integrity: sha512-QBN/KRBXLJdCgN4gBTL3XAc/zKm58atSnieXWMOyFSPmo6F1/yIVV/LTRdvAktfCttrGx7W6c32i/lwqCHWnsQ==}
     engines: {node: '>=20'}
 
-  '@rivetkit/react@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-M1U9XgmbsLKw67GsqmWoD6C7oenl6tRjA07V9i+aZGJaTkIf03xexOrOn8P06Agt69TOcg6XRc0Xy2Rhwi514g==}
+  '@rivetkit/react@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-7iHF3wGl4y2S+v700QgXEqBOjtJr/5AZ20qfD5rwE3dtBY8H5Smw4FllJTxBuUrdzHjZ2L7C8LyGALWi/5e1NQ==}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-jrIWFZV4qB8/Jxv1Xi/uIeEqKrg99UpW07QEKHWq8wrPIRL8hihAUlFYDzTUv0xYdQg7cGGaORaL8h8xmgvYCg==}
+  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-TQPCk1U2Z7otH9ehV7NEEksRT/hzEsLyMaA7ZpkMKxOr8bBNWkES7U+YY5fc7mLFdWR/N15iN7SU0koxJE7PjA==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-aPX4l0DutwT8A9pm2fBFXGvYCaA0SRGV99irDHHZJp5x2L/K/Md6Ja+rG46Rs39tjF9AzdjHfFRniWWfZE1gYA==}
+  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-wAuJIR0efIcpaQQvWgniZ0qOy6x5+/V+/agACJhQVSjj7P29kY0piEBKLKDtP0M4gTd6GGzBAe5oNY0t785/0w==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-ZO0sxI092CoKUfXok7pWsPJBYn6iItdCjVb4w2eu4MLkqjQEm1oa5eDLkJ7RfHi1H6tr+rZZiuxgBxpj9yHtLw==}
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-A+kuGvc9RJjUflPVHbHPkQSH4xyjasbVMNRfq2ISdaJ/CnNcmrexJ4F+5Mm2VPz61gxNjkSoyk8tPupz07CZnw==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-o4bS4zsL0yrpcgrfdYJnK14pjVfDJwI5KhbHOBSS16+oXij8BiACnRDmZMJvQvn6YV7hcRP3g5rkyurgLbmhCw==}
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-jo7WcmJ7hjWpi/8DUlWu1x2JtHfEAiY21QdNy5VZ23Dtg/pzKzDAn4m6myPB/s8MS+nAOiJcruWTH16qMHAeWw==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-re4xEiHSC6gLkX8RYGnOkgJK1v39D7xDlBaVn+Cs6vo0FpUyy9/E0w09KWMxbWMJXblm8FG3jEy3M1tLjo8Itg==}
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-hcHO0FkMQITQ3taSJ0084DVDRysOep3eBzv8cwgA0qJhIzzd5EF+4qo4QO4woEdnDYCGMBJZLByYyEPFY3WSOQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-EaU65tYeIuauvzqWYRlN11wYw50zPhoK0Secer//dkFCnVkRjvbp9Md/oz0Ya/w1Wo38wSCawdabP2btByszCw==}
+  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-Xx8DWZwdWBZdkqSbR7UdPR1nrZH53tK4r0kSM9Y670GGwgBHg3mesaYshPs/B0XzEFVybF5vS/0ToIi97T/LIw==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-/ubV14pzntlgW3WJ6l8m78Tnvy57WMGK5ukJWczcRz3Fcq6CoSuhgP5v3F8Em+vyn+B0OqcclEt9gGJukrgUBw==}
+  '@rivetkit/rivetkit-napi@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-uSBQFnTSuh+YMjdRR34KAS7QJQpkVXNleNdzLoCic1XdRyIh13KvuX3+JR3bbk3S32euM7ZeScy3kve8c3nuyA==}
     engines: {node: '>= 20.0.0'}
 
   '@rivetkit/rivetkit-wasm@2.3.2':
     resolution: {integrity: sha512-HNBzh6uQFi4ZYL0tHAZ6nrYKoGCfa+kObLCwdS+/ZzGePV7WGUl20Do1bHjBtnVgp9UwzQu+lka8kFwKfqm6WA==}
 
-  '@rivetkit/traces@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-eqT8RRG2gM3hJxR42ghnRxCaE/6T39adz61E3GsjoiDIExsJmwGEA9RoRMe2x5FU4I4eDFg8HD/pmR60GrNp/g==}
+  '@rivetkit/traces@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-4yXOCC2rPncF/aNBhW4KU6CF56Bo9Sslidj311eY0iGqCxRBpQhI57Y5eX8Ho5DNXmVTobjP6USxeWp6Oymmvg==}
     engines: {node: '>=18.0.0'}
 
-  '@rivetkit/virtual-websocket@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-HWaRTiuFBXKH+UgIEuhwOtuu33jq57CgdQMgobtehvg/TQSqmo3vaCFVeQGOhIbAkUP5VU2K+dC/jZLiVJ/THA==}
+  '@rivetkit/virtual-websocket@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-Rd3MdziVAS4Ut/dqcLfN9pMCRLOSqK7n/AunWtI6Xr72y+0jh7gwFVYmZRJGyGamnfJFTKTQnbnhg+KGkyu+wg==}
 
-  '@rivetkit/workflow-engine@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
-    resolution: {integrity: sha512-EcipnvCJnMwFiMKbioPaPO5MTuIiaSDQgKHmauHrgaVwDPFKFo85C7WT1ZmMRjfzkFrvNFKG/BE+MfxlAXjynA==}
+  '@rivetkit/workflow-engine@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
+    resolution: {integrity: sha512-Nh+tlQT9FoBsznHfRujeT/hlgj/4k4d3M7+0ogZpCmPhuwim0cjiog6fL18bfehr7BPobvSH0SInqLvF3kPPWA==}
     engines: {node: '>=18.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
@@ -6988,8 +6995,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rivetkit@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585:
-    resolution: {integrity: sha512-dmZUxgTfZJJxj6BTfb8FZG8Pa8xEAv2T1K7Kov8z7Zwb0mYHyjKsgSJ+ojBe6JWIJmviKLXt2XEXZHOncmzRpQ==}
+  rivetkit@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0:
+    resolution: {integrity: sha512-3kXHTXMv6u/P29xul+8YnqCmkhyj3TYJxl1f40yyjWqbrxhAPR7qoW+mDY3NTIMX6xpXuiqnR9gp9pSPiM4s0A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       drizzle-kit: ^0.31.2
@@ -9348,8 +9355,8 @@ snapshots:
   '@mistralai/mistralai@1.14.1(bufferutil@4.1.0)':
     dependencies:
       ws: 8.20.0(bufferutil@4.1.0)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9567,34 +9574,34 @@ snapshots:
 
   '@rivetkit/bare-ts@0.6.2': {}
 
-  '@rivetkit/engine-cli-darwin-arm64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-cli-darwin-arm64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/engine-cli-darwin-x64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-cli-darwin-x64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/engine-cli@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-cli@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optionalDependencies:
-      '@rivetkit/engine-cli-darwin-arm64': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/engine-cli-darwin-x64': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/engine-cli-linux-arm64-musl': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/engine-cli-linux-x64-musl': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/engine-cli-darwin-arm64': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/engine-cli-darwin-x64': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/engine-cli-linux-arm64-musl': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/engine-cli-linux-x64-musl': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
 
-  '@rivetkit/engine-envoy-protocol@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/engine-envoy-protocol@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
 
-  '@rivetkit/framework-base@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))':
+  '@rivetkit/framework-base@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))':
     dependencies:
       '@tanstack/store': 0.7.7
       fast-deep-equal: 3.1.3
-      rivetkit: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+      rivetkit: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -9631,13 +9638,13 @@ snapshots:
 
   '@rivetkit/on-change@6.0.1': {}
 
-  '@rivetkit/react@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))':
+  '@rivetkit/react@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0(bufferutil@4.1.0))':
     dependencies:
-      '@rivetkit/framework-base': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+      '@rivetkit/framework-base': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
       '@tanstack/react-store': 0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      rivetkit: 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
+      rivetkit: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -9672,48 +9679,48 @@ snapshots:
       - sqlite3
       - ws
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     optional: true
 
-  '@rivetkit/rivetkit-napi@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/rivetkit-napi@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     dependencies:
       '@napi-rs/cli': 2.18.4
-      '@rivetkit/engine-envoy-protocol': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/engine-envoy-protocol': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
     optionalDependencies:
-      '@rivetkit/rivetkit-napi-darwin-arm64': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/rivetkit-napi-darwin-x64': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/rivetkit-napi-linux-arm64-musl': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/rivetkit-napi-linux-x64-gnu': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/rivetkit-napi-linux-x64-musl': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/rivetkit-napi-darwin-arm64': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/rivetkit-napi-darwin-x64': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/rivetkit-napi-linux-arm64-musl': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/rivetkit-napi-linux-x64-gnu': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/rivetkit-napi-linux-x64-musl': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
 
   '@rivetkit/rivetkit-wasm@2.3.2': {}
 
-  '@rivetkit/traces@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/traces@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
       fdb-tuple: 1.0.0
       vbare: 0.0.4
 
-  '@rivetkit/virtual-websocket@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585': {}
+  '@rivetkit/virtual-websocket@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0': {}
 
-  '@rivetkit/workflow-engine@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585':
+  '@rivetkit/workflow-engine@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
@@ -12307,18 +12314,18 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rivetkit@0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0)):
+  rivetkit@0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.20.0(bufferutil@4.1.0)):
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.9)(zod@4.3.6)
       '@rivetkit/bare-ts': 0.6.2
-      '@rivetkit/engine-cli': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/engine-envoy-protocol': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/engine-cli': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/engine-envoy-protocol': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
       '@rivetkit/on-change': 6.0.1
-      '@rivetkit/rivetkit-napi': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/rivetkit-napi': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
       '@rivetkit/rivetkit-wasm': 2.3.2
-      '@rivetkit/traces': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/virtual-websocket': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
-      '@rivetkit/workflow-engine': 0.0.0-stack-feat-react-support-connecting-to-actors-by-id-in-useactor-ykouompz.5720585
+      '@rivetkit/traces': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/virtual-websocket': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+      '@rivetkit/workflow-engine': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
       cbor-x: 1.6.4
       drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)
       hono: 4.12.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,13 @@ catalog:
   '@secure-exec/sandbox': 0.0.0-nathan-agentos-package-resolution.0bf7dcb
 # <<< secure-exec catalog <<<
 
+# rivetkit runtime + react bindings. Same-version lockstep with the sidecar;
+# pinned once here and referenced everywhere via `catalog:rivetkit`.
+catalogs:
+  rivetkit:
+    rivetkit: 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+    '@rivetkit/react': 0.0.0-stack-feat-rivetkit-forward-inspector-tabs-to-native-plugin-actors-qkwmksyy.d2859b0
+
 overrides:
   '@rivetkit/rivetkit-wasm': 2.3.2
   '@mariozechner/pi-tui': 0.60.0


### PR DESCRIPTION
Also drop the broken @agentos-software/sqlite3 pack (efc374f, missing its dist/package manifest) from the browser-terminal example so the pinned setup boots a VM.