### PR TITLE
fix(publish): unblock crates.io release (V8-bridge staging + aliased vfs version bump)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -437,6 +437,24 @@ jobs:
           pnpm --filter=publish exec tsx src/ci/bin.ts bump-versions \
             --version ${{ needs.context.outputs.version }} \
             --version-only
+      - name: Stage vendored V8 bridge bundles and base filesystem
+        run: |
+          set -euo pipefail
+          # crates/{execution,v8-runtime}/assets/generated is gitignored; the
+          # published crates fall back to the vendored bundle (build-support
+          # copy_vendored_bundle) and panic if it is absent. Stage it here.
+          for crate in execution v8-runtime; do
+            out="crates/${crate}/assets/generated"
+            mkdir -p "$out"
+            node packages/build-tools/scripts/build-v8-bridge.mjs --out-dir "$out"
+          done
+          git add -f crates/execution/assets/generated crates/v8-runtime/assets/generated
+          # The single committed base filesystem lives in the vfs crate; the
+          # kernel and native-sidecar crates vendor a copy for isolated publish
+          # builds (their build.rs falls back to assets/base-filesystem.json).
+          mkdir -p crates/kernel/assets crates/native-sidecar/assets
+          cp crates/vfs/assets/base-filesystem.json crates/kernel/assets/base-filesystem.json
+          cp crates/vfs/assets/base-filesystem.json crates/native-sidecar/assets/base-filesystem.json
       - name: Dry-run crate publish
         if: ${{ needs.context.outputs.trigger != 'release' }}
         run: |

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -189,6 +189,14 @@ export async function bumpCargoVersions(
 		/((?:agentos|agent-os)-[a-z0-9-]+ = \{ path = "crates\/[^"]+", version = ")[^"]+(" \})/g,
 		`$1${version}$2`,
 	);
+	// Also bump aliased AgentOS-owned crate deps declared as
+	// `<alias> = { package = "agentos-...", path = "crates/...", version = "..." }`
+	// (e.g. `vfs = { package = "agentos-vfs-core", ... }`), which the pattern
+	// above misses because the line starts with the alias key, not `agentos-`.
+	next = next.replace(
+		/(\{ package = "(?:agentos|agent-os)-[a-z0-9-]+", path = "crates\/[^"]+", version = ")[^"]+(" \})/g,
+		`$1${version}$2`,
+	);
 
 	if (next === cargoToml) {
 		log.info(`Cargo.toml Rust versions already set to ${version}`);


### PR DESCRIPTION
Two release-pipeline fixes found by diffing the pre-flip pipeline:

- **R1** — publish-crates stages the V8-bridge bundle + base-filesystem (isolated `cargo publish` verify builds otherwise panic on the missing vendored bundle).
- **R2** — version bumper handles the aliased `vfs = { package = "agentos-vfs-core" }` dep (otherwise dependents publish with an unsatisfiable `= 0.0.1`).

Validation-only branch findings (separate): most of the V1 'regressions' are on unchanged code (pre-existing/environmental); real remaining surface is the package_projection tar-mount reconciliation. Not in this PR.