### PR TITLE
fix(registry): compile http_get_test against the patched wasi sysroot

### DIFF
--- a/registry/native/c/Makefile
+++ b/registry/native/c/Makefile
@@ -67,7 +67,7 @@ COMMANDS_DIR ?= ../target/wasm32-wasip1/release/commands
 COMMANDS := zip unzip envsubst sqlite3 curl http_get
 
 # Programs requiring patched sysroot (Tier 2+ custom host imports)
-PATCHED_PROGRAMS := isatty_test getpid_test getppid_test getppid_verify userinfo pipe_test dup_test spawn_child spawn_exit_code pipeline kill_child waitpid_return waitpid_edge syscall_coverage getpwuid_test signal_tests sigaction_self sigaction_behavior delayed_tcp_echo delayed_kill pipe_edge tcp_accept_spawn tcp_echo tcp_server http_server udp_echo unix_socket signal_handler http_get dns_lookup sqlite3_cli curl wget fs_probe
+PATCHED_PROGRAMS := http_get_test isatty_test getpid_test getppid_test getppid_verify userinfo pipe_test dup_test spawn_child spawn_exit_code pipeline kill_child waitpid_return waitpid_edge syscall_coverage getpwuid_test signal_tests sigaction_self sigaction_behavior delayed_tcp_echo delayed_kill pipe_edge tcp_accept_spawn tcp_echo tcp_server http_server udp_echo unix_socket signal_handler http_get dns_lookup sqlite3_cli curl wget fs_probe
 
 # Discover all .c source files in programs/
 ALL_SOURCES := $(wildcard programs/*.c)


### PR DESCRIPTION
- `http_get_test.c` includes `<netdb.h>` but was missing from `PATCHED_PROGRAMS`, so CI runners without the patched wasi-libc sysroot compiled it against the vanilla wasi-sdk sysroot and the publish WASM Commands job failed