### PR TITLE
fix(runtime): packed-agent module resolution, symlink-leaf mount semantics, and net timeout sentinel

### DIFF
--- a/crates/client/tests/loopback_probe_e2e.rs
+++ b/crates/client/tests/loopback_probe_e2e.rs
@@ -1,0 +1,61 @@
+//! Guest fetch -> host loopback via `loopback_exempt_ports`, asserting the
+//! response body arrives byte-clean. Regression gate for the net-poll timeout
+//! sentinel: a guest/sidecar sentinel mismatch base64-decodes the sentinel
+//! string into phantom bytes injected into EVERY guest TCP stream (this broke
+//! all guest HTTP, including agent SDK -> LLM traffic).
+mod common;
+use agentos_client::config::{
+    AgentOsConfig, PatternPermissions, PermissionMode, Permissions,
+};
+use agentos_client::ExecOptions;
+use std::io::Write;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn guest_fetch_reaches_host_loopback() {
+    if !common::sidecar_available() {
+        eprintln!("skip: sidecar not built");
+        return;
+    }
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        use std::io::Read;
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-length: 12\r\nconnection: close\r\n\r\nPROBE_PONG!\n",
+            );
+        }
+    });
+    common::ensure_sidecar_env();
+    let os = agentos_client::AgentOs::create(AgentOsConfig {
+        loopback_exempt_ports: vec![port],
+        permissions: Some(Permissions {
+            network: Some(PatternPermissions::Mode(PermissionMode::Allow)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+    .await
+    .expect("create VM");
+    let script = format!(
+        "fetch('http://127.0.0.1:{port}/').then(r=>r.text()).then(t=>console.log('BODY:'+t)).catch(e=>{{console.error('FETCHERR:'+e.message+' cause:'+(e.cause&&e.cause.message));process.exit(3)}})"
+    );
+    let args = vec![String::from("-e"), script];
+    let result = os
+        .exec_argv("node", &args, ExecOptions::default())
+        .await
+        .expect("exec");
+    println!(
+        "exit={} stdout={:?} stderr={:?}",
+        result.exit_code, result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("PROBE_PONG"),
+        "stdout={:?} stderr={:?}",
+        result.stdout,
+        result.stderr
+    );
+}

--- a/crates/client/tests/pi_session_e2e.rs
+++ b/crates/client/tests/pi_session_e2e.rs
@@ -53,7 +53,12 @@ fn pi_module_cwd() -> Option<String> {
         .then(|| root.to_string_lossy().into_owned())
 }
 
-fn pi_package_dir() -> Option<PathBuf> {
+fn pi_package_path() -> Option<PathBuf> {
+    // Prefer the packed .aospkg — the artifact the registry actually ships.
+    let aospkg = repo_root().join("registry/agent/pi/dist/package.aospkg");
+    if aospkg.is_file() {
+        return std::fs::canonicalize(aospkg).ok();
+    }
     let dir = repo_root().join("registry/agent/pi/dist/package");
     if dir.join("agentos-package.json").is_file() {
         std::fs::canonicalize(dir).ok()
@@ -131,8 +136,8 @@ async fn pi_session_create_prompt_close() {
         );
         return;
     };
-    let Some(package_dir) = pi_package_dir() else {
-        eprintln!("skipping pi_session_create_prompt_close: Pi package dir not materialized");
+    let Some(package_path) = pi_package_path() else {
+        eprintln!("skipping pi_session_create_prompt_close: Pi package is not built");
         return;
     };
 
@@ -141,16 +146,24 @@ async fn pi_session_create_prompt_close() {
     let port = llmock.port();
 
     common::ensure_sidecar_env();
-    let os = AgentOs::create(AgentOsConfig {
-        mounts: vec![node_modules_mount(
-            package_dir
+    // Packed .aospkg packages carry node_modules inside the mount tar and the
+    // runtime resolves them through the kernel VFS — no host mount needed. The
+    // transition-dir fallback still exercises the host node_modules mount.
+    let mounts = if package_path.is_file() {
+        Vec::new()
+    } else {
+        vec![node_modules_mount(
+            package_path
                 .join("node_modules")
                 .to_string_lossy()
                 .into_owned(),
-        )],
+        )]
+    };
+    let os = AgentOs::create(AgentOsConfig {
+        mounts,
         loopback_exempt_ports: vec![port],
         packages: vec![PackageRef {
-            path: package_dir.to_string_lossy().into_owned(),
+            path: package_path.to_string_lossy().into_owned(),
         }],
         permissions: Some(Permissions {
             network: Some(PatternPermissions::Mode(PermissionMode::Allow)),

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -3887,9 +3887,17 @@ impl LocalBridgeState {
         mode: ModuleResolveMode,
     ) -> Option<String> {
         if self.js_runtime_denies_specifier(specifier) {
+            if std::env::var("AGENTOS_MODULE_READER_TRACE").is_ok() {
+                eprintln!("resolve DENIED: {specifier} from {from_dir}");
+            }
             return None;
         }
-        self.with_module_resolver(|resolver| resolver.resolve_module(specifier, from_dir, mode))
+        let resolved =
+            self.with_module_resolver(|resolver| resolver.resolve_module(specifier, from_dir, mode));
+        if resolved.is_none() && std::env::var("AGENTOS_MODULE_READER_TRACE").is_ok() {
+            eprintln!("resolve MISS: {specifier} from {from_dir} mode={mode:?}");
+        }
+        resolved
     }
 
     /// jsRuntime resolution gate. Denies builtin and bare/relative imports per the

--- a/crates/native-sidecar/src/execution.rs
+++ b/crates/native-sidecar/src/execution.rs
@@ -11119,15 +11119,81 @@ fn build_module_reader(
         })
         .collect();
 
+    // Packed package-version leaves: module resolution reads packed
+    // `node_modules` content straight from the `.aospkg` mount index (shared
+    // mmap cache; no kernel access), mirroring what the guest sees through the
+    // kernel tar mount. `(guest_path, aospkg_path, tar_root)` triples.
+    let mut package_tars: Vec<(String, String, String)> = vm
+        .configuration
+        .mounts
+        .iter()
+        .filter(|mount| mount.plugin.id == "agentos_packages")
+        .filter_map(|mount| {
+            let config = serde_json::from_str::<Value>(&mount.plugin.config).ok()?;
+            if config.get("kind").and_then(Value::as_str) != Some("tar") {
+                return None;
+            }
+            let tar_path = config.get("tarPath").and_then(Value::as_str)?.to_owned();
+            let root = config
+                .get("root")
+                .and_then(Value::as_str)
+                .unwrap_or("/")
+                .to_owned();
+            Some((normalize_path(&mount.guest_path), tar_path, root))
+        })
+        .collect();
+    // `<pkg>/current -> <version>` symlink leaves: alias the current prefix to
+    // the same tar so modules that self-locate through `current` (rather than
+    // the realpathed version dir) still resolve.
+    let current_aliases: Vec<(String, String, String)> = vm
+        .configuration
+        .mounts
+        .iter()
+        .filter(|mount| mount.plugin.id == "agentos_packages")
+        .filter_map(|mount| {
+            let config = serde_json::from_str::<Value>(&mount.plugin.config).ok()?;
+            if config.get("kind").and_then(Value::as_str) != Some("singleSymlink") {
+                return None;
+            }
+            let link_path = normalize_path(&mount.guest_path);
+            let target = config.get("target").and_then(Value::as_str)?;
+            let resolved_target = if target.starts_with('/') {
+                normalize_path(target)
+            } else {
+                let parent = Path::new(&link_path).parent()?.to_str()?;
+                normalize_path(&format!("{parent}/{target}"))
+            };
+            package_tars
+                .iter()
+                .find(|(guest, _, _)| *guest == resolved_target)
+                .map(|(_, tar_path, root)| (link_path, tar_path.clone(), root.clone()))
+        })
+        .collect();
+    package_tars.extend(current_aliases);
+
     let guest_entrypoint = resolved
         .env
         .get("AGENTOS_GUEST_ENTRYPOINT")
         .map(|path| normalize_path(path));
     if let Some(guest_entrypoint) = guest_entrypoint.as_deref() {
-        let entrypoint_in_read_only_mount = pairs.iter().any(|(guest_path, _)| {
-            guest_entrypoint == guest_path
-                || guest_entrypoint.starts_with(&format!("{guest_path}/"))
-        });
+        // Package entrypoints may still carry their pre-realpath launch path
+        // (`/opt/agentos/bin/<cmd>` or `<pkg>/current/...` symlink leaves), so
+        // gate on EVERY agentos_packages mount prefix, not just the tar leaves.
+        let package_mount_prefixes: Vec<String> = vm
+            .configuration
+            .mounts
+            .iter()
+            .filter(|mount| mount.plugin.id == "agentos_packages")
+            .map(|mount| normalize_path(&mount.guest_path))
+            .collect();
+        let entrypoint_in_read_only_mount = pairs
+            .iter()
+            .map(|(guest_path, _)| guest_path)
+            .chain(package_mount_prefixes.iter())
+            .any(|guest_path| {
+                guest_entrypoint == guest_path
+                    || guest_entrypoint.starts_with(&format!("{guest_path}/"))
+            });
         if !entrypoint_in_read_only_mount {
             return None;
         }
@@ -11145,7 +11211,21 @@ fn build_module_reader(
         .collect();
     pairs.extend(extra_roots);
 
-    crate::plugins::host_dir::HostDirModuleReader::from_mounts(pairs)
+    if std::env::var("AGENTOS_MODULE_READER_TRACE").is_ok() {
+        eprintln!(
+            "module-reader: entrypoint={:?} host_pairs={} package_tars={:?}",
+            resolved.env.get("AGENTOS_GUEST_ENTRYPOINT"),
+            pairs.len(),
+            package_tars
+                .iter()
+                .map(|(guest, _, _)| guest.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+    crate::plugins::host_dir::HostDirModuleReader::from_mounts_and_package_tars(
+        pairs,
+        package_tars,
+    )
 }
 
 fn host_node_modules_root(path: &Path) -> Option<PathBuf> {

--- a/crates/native-sidecar/src/filesystem.rs
+++ b/crates/native-sidecar/src/filesystem.rs
@@ -974,11 +974,41 @@ impl ModuleFsReader for ProcessModuleFsReader<'_> {
 /// `__resolve_module` / `__load_file` / `__module_format` /
 /// `__batch_resolve_modules` methods (mapped from the guest bridge's
 /// `_resolveModule` / `_loadFile` / `_moduleFormat` / `_batchResolveModules`).
+/// The `/opt/agentos/pkgs/<name>/<version>` root containing `guest_entrypoint`,
+/// when the entrypoint lives inside a projected package. `current` is a valid
+/// version segment here — the resolver canonicalizes it through the kernel.
+fn agentos_package_version_root(guest_entrypoint: &str) -> Option<String> {
+    let rest = guest_entrypoint.strip_prefix("/opt/agentos/pkgs/")?;
+    let mut parts = rest.split('/');
+    let name = parts.next().filter(|part| !part.is_empty())?;
+    let version = parts.next().filter(|part| !part.is_empty())?;
+    Some(format!("/opt/agentos/pkgs/{name}/{version}"))
+}
+
+fn is_bare_module_specifier(specifier: &str) -> bool {
+    !(specifier.starts_with('/')
+        || specifier.starts_with("./")
+        || specifier.starts_with("../")
+        || specifier == "."
+        || specifier == ".."
+        || specifier.starts_with('#')
+        || specifier.starts_with("file:"))
+}
+
 pub(crate) fn service_javascript_module_sync_rpc(
     kernel: &mut SidecarKernel,
     process: &mut ActiveProcess,
     request: &JavascriptSyncRpcRequest,
 ) -> Result<Value, SidecarError> {
+    // Self-contained package processes (agent adapters, packed JS commands)
+    // carry their whole dependency closure inside the package mount. A bare
+    // specifier that misses from an unpackaged context (a parent module path
+    // like `/root` from cwd-based requires) retries from the package's own
+    // version root, so packed packages resolve exactly what they shipped.
+    let package_fallback_from = process
+        .env
+        .get("AGENTOS_GUEST_ENTRYPOINT")
+        .and_then(|entrypoint| agentos_package_version_root(entrypoint));
     let mut cache = std::mem::take(&mut process.module_resolution_cache);
     let value = {
         let reader = ProcessModuleFsReader {
@@ -999,10 +1029,19 @@ pub(crate) fn service_javascript_module_sync_rpc(
                     _ if request.method == "_resolveModuleSync" => ModuleResolveMode::Require,
                     _ => ModuleResolveMode::Import,
                 };
-                resolver
-                    .resolve_module(specifier, parent, mode)
-                    .map(Value::String)
-                    .unwrap_or(Value::Null)
+                let mut resolved = resolver.resolve_module(specifier, parent, mode);
+                if resolved.is_none() && is_bare_module_specifier(specifier) {
+                    if let Some(fallback_from) = package_fallback_from
+                        .as_deref()
+                        .filter(|fallback| *fallback != parent)
+                    {
+                        resolved = resolver.resolve_module(specifier, fallback_from, mode);
+                    }
+                }
+                if resolved.is_none() && std::env::var("AGENTOS_MODULE_READER_TRACE").is_ok() {
+                    eprintln!("kernel-resolve MISS: {specifier} from {parent} mode={mode:?}");
+                }
+                resolved.map(Value::String).unwrap_or(Value::Null)
             }
             "__load_file" | "_loadFile" | "_loadFileSync" => {
                 let path = javascript_sync_rpc_arg_str(&request.args, 0, "module load path")?;

--- a/crates/native-sidecar/src/plugins/host_dir.rs
+++ b/crates/native-sidecar/src/plugins/host_dir.rs
@@ -22,6 +22,7 @@ use agentos_kernel::mount_table::{
     MountedFileSystem, MountedVirtualFileSystem, ReadOnlyFileSystem,
 };
 use agentos_kernel::resource_accounting::DEFAULT_MAX_PREAD_BYTES;
+use vfs::posix::TarFileSystem;
 use agentos_kernel::vfs::{
     normalize_path, VfsError, VfsResult, VirtualDirEntry, VirtualFileSystem, VirtualStat,
     VirtualTimeSpec, VirtualUtimeSpec,
@@ -1020,7 +1021,50 @@ impl VirtualFileSystem for HostDirFilesystem {
 struct HostDirModuleMount {
     /// Normalized guest mount point, e.g. `/root/node_modules`.
     guest_prefix: String,
-    filesystem: HostDirFilesystem,
+    filesystem: ModuleMountBackend,
+}
+
+/// Backing filesystem for one module-reader mount: an anchored host dir
+/// (`host_dir`/`module_access` mounts) or a packed `.aospkg` tar
+/// (`agentos_packages` package-version leaves). Both are read-only and safe to
+/// use off the service loop — the tar reader serves mmap-backed byte ranges
+/// from the shared identity-keyed archive cache and never touches the kernel.
+#[allow(dead_code)]
+#[derive(Clone)]
+enum ModuleMountBackend {
+    Host(HostDirFilesystem),
+    Tar(TarFileSystem),
+}
+
+#[allow(dead_code)]
+impl ModuleMountBackend {
+    fn realpath(&self, path: &str) -> VfsResult<String> {
+        match self {
+            Self::Host(fs) => fs.realpath(path),
+            Self::Tar(fs) => VirtualFileSystem::realpath(fs, path),
+        }
+    }
+
+    fn read_file(&mut self, path: &str) -> VfsResult<Vec<u8>> {
+        match self {
+            Self::Host(fs) => fs.read_file(path),
+            Self::Tar(fs) => VirtualFileSystem::read_file(fs, path),
+        }
+    }
+
+    fn stat(&mut self, path: &str) -> VfsResult<VirtualStat> {
+        match self {
+            Self::Host(fs) => fs.stat(path),
+            Self::Tar(fs) => VirtualFileSystem::stat(fs, path),
+        }
+    }
+
+    fn exists(&self, path: &str) -> bool {
+        match self {
+            Self::Host(fs) => fs.exists(path),
+            Self::Tar(fs) => VirtualFileSystem::exists(fs, path),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -1098,10 +1142,56 @@ impl HostDirModuleReader {
                 .ok()?;
                 Some(HostDirModuleMount {
                     guest_prefix: normalize_path(guest_path.as_ref()),
-                    filesystem,
+                    filesystem: ModuleMountBackend::Host(filesystem),
                 })
             })
             .collect::<Vec<_>>();
+        if entries.is_empty() {
+            return None;
+        }
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.guest_prefix.len()));
+        entries.dedup_by(|left, right| left.guest_prefix == right.guest_prefix);
+        Some(Self { mounts: entries })
+    }
+
+    /// Build a reader from host-dir pairs plus packed package-version tar
+    /// mounts (`(guest_path, aospkg_path, tar_root)`), so module resolution
+    /// reads packed `node_modules` content directly from the `.aospkg` mount
+    /// index off the service loop. Unopenable mounts are skipped.
+    pub(crate) fn from_mounts_and_package_tars<I, G, H>(
+        mounts: I,
+        package_tars: Vec<(String, String, String)>,
+    ) -> Option<Self>
+    where
+        I: IntoIterator<Item = (G, H)>,
+        G: AsRef<str>,
+        H: AsRef<Path>,
+    {
+        let mut entries = mounts
+            .into_iter()
+            .filter_map(|(guest_path, host_path)| {
+                let filesystem = HostDirFilesystem::new_with_read_limit(
+                    host_path.as_ref(),
+                    Some(MAX_HOST_DIR_READ_BYTES),
+                )
+                .ok()?;
+                Some(HostDirModuleMount {
+                    guest_prefix: normalize_path(guest_path.as_ref()),
+                    filesystem: ModuleMountBackend::Host(filesystem),
+                })
+            })
+            .collect::<Vec<_>>();
+        entries.extend(
+            package_tars
+                .into_iter()
+                .filter_map(|(guest_path, tar_path, root)| {
+                    let filesystem = TarFileSystem::open_at(&tar_path, &root).ok()?;
+                    Some(HostDirModuleMount {
+                        guest_prefix: normalize_path(&guest_path),
+                        filesystem: ModuleMountBackend::Tar(filesystem),
+                    })
+                }),
+        );
         if entries.is_empty() {
             return None;
         }
@@ -1286,5 +1376,49 @@ fn virtual_dirname(path: &str) -> String {
     match normalized.rsplit_once('/') {
         Some((head, _)) if !head.is_empty() => head.to_owned(),
         _ => String::from("/"),
+    }
+}
+
+#[cfg(test)]
+mod tar_module_reader_tests {
+    use super::*;
+    use agentos_execution::{ModuleResolveMode, ModuleResolver};
+
+    #[test]
+    fn tar_reader_resolves_packed_node_modules() {
+        let aospkg = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../registry/agent/pi/dist/package.aospkg");
+        if !aospkg.is_file() {
+            eprintln!("skip: pi aospkg not built");
+            return;
+        }
+        let mut reader = HostDirModuleReader::from_mounts_and_package_tars(
+            Vec::<(String, std::path::PathBuf)>::new(),
+            vec![(
+                String::from("/opt/agentos/pkgs/pi/0.2.1"),
+                aospkg.to_string_lossy().into_owned(),
+                String::from("/"),
+            )],
+        )
+        .expect("reader");
+        let probe = "/opt/agentos/pkgs/pi/0.2.1/node_modules/@anthropic-ai/sdk/package.json";
+        assert!(reader.path_exists(probe), "packed package.json must exist");
+        assert!(reader.read_to_string(probe).is_some(), "packed package.json must read");
+        let mut cache = Default::default();
+        let dyn_reader: &mut dyn ModuleFsReader = &mut reader;
+        let mut resolver = ModuleResolver::new(dyn_reader, &mut cache);
+        let resolved = resolver.resolve_module(
+            "@anthropic-ai/sdk",
+            "/opt/agentos/pkgs/pi/0.2.1/node_modules/@agentos-software/pi/dist/adapter.js",
+            ModuleResolveMode::Require,
+        );
+        assert!(resolved.is_some(), "require-mode resolution from the packed tar");
+        let resolved_import = resolver.resolve_module(
+            "@anthropic-ai/sdk",
+            "/opt/agentos/pkgs/pi/0.2.1/node_modules/@agentos-software/pi/dist/adapter.js",
+            ModuleResolveMode::Import,
+        );
+        assert!(resolved_import.is_some(), "import-mode resolution from the packed tar");
+        assert!(resolved.is_some(), "must resolve @anthropic-ai/sdk from the packed tar");
     }
 }

--- a/crates/vfs/src/posix/mount_table.rs
+++ b/crates/vfs/src/posix/mount_table.rs
@@ -866,6 +866,27 @@ impl MountTable {
             .unwrap_or(false)
     }
 
+    /// Resolve a path for a LINK-LEAF operation (lstat/readlink) that must
+    /// follow INTERMEDIATE symlinks but not the final component. When the
+    /// lexical route lands inside a symlink-root leaf mount at a descendant
+    /// path, the component being operated on is not the mount's own symlink —
+    /// resolve the parent across mounts and re-route, keeping the leaf
+    /// unresolved. `relative == "/"` (the symlink itself) keeps the raw route
+    /// so `lstat(<pkg>/current)` still reports the symlink.
+    fn resolve_link_leaf_index(&self, path: &str) -> VfsResult<(usize, String)> {
+        let normalized = normalize_path(path);
+        let raw = self.resolve_index(&normalized)?;
+        if raw.1 == "/" || !self.mount_is_symlink_leaf(raw.0) {
+            return Ok(raw);
+        }
+        let parent = parent_path(&normalized);
+        let leaf = basename(&normalized);
+        match self.realpath(&parent) {
+            Ok(resolved_parent) => self.resolve_index(&join_path(&resolved_parent, &leaf)),
+            Err(_) => Ok(raw),
+        }
+    }
+
     fn resolve_content_index(&self, path: &str) -> VfsResult<(usize, String)> {
         let raw = self.resolve_index(&normalize_path(path))?;
         if !self.mount_is_symlink_leaf(raw.0) {
@@ -964,7 +985,12 @@ impl VirtualFileSystem for MountTable {
 
     fn read_dir(&mut self, path: &str) -> VfsResult<Vec<String>> {
         let normalized = normalize_path(path);
-        let (index, relative_path) = self.resolve_index(&normalized)?;
+        // Directory listings are content ops: a path that descends through a
+        // symlink-root leaf mount (`<pkg>/current -> <version>`) must be
+        // followed into the target mount, exactly like read_file/stat. Child
+        // mounts still merge on the LEXICAL path — mount points attach to the
+        // caller-visible path, not the resolved target.
+        let (index, relative_path) = self.resolve_content_index(&normalized)?;
         let mut entries = self.mounts[index].filesystem.read_dir(&relative_path)?;
         let child_mounts = self.child_mount_basenames(&normalized);
         if child_mounts.is_empty() {
@@ -979,7 +1005,7 @@ impl VirtualFileSystem for MountTable {
 
     fn read_dir_limited(&mut self, path: &str, max_entries: usize) -> VfsResult<Vec<String>> {
         let normalized = normalize_path(path);
-        let (index, relative_path) = self.resolve_index(&normalized)?;
+        let (index, relative_path) = self.resolve_content_index(&normalized)?;
         let mut entries = self.mounts[index]
             .filesystem
             .read_dir_limited(&relative_path, max_entries)?;
@@ -1004,7 +1030,7 @@ impl VirtualFileSystem for MountTable {
 
     fn read_dir_with_types(&mut self, path: &str) -> VfsResult<Vec<VirtualDirEntry>> {
         let normalized = normalize_path(path);
-        let (index, relative_path) = self.resolve_index(&normalized)?;
+        let (index, relative_path) = self.resolve_content_index(&normalized)?;
         let mut entries = self.mounts[index]
             .filesystem
             .read_dir_with_types(&relative_path)?;
@@ -1102,7 +1128,9 @@ impl VirtualFileSystem for MountTable {
     }
 
     fn exists(&self, path: &str) -> bool {
-        self.resolve_index(path)
+        // `exists` follows symlinks like POSIX access(); route through the
+        // content resolver so paths under a symlink-root leaf mount resolve.
+        self.resolve_content_index(path)
             .map(|(index, relative_path)| self.mounts[index].filesystem.exists(&relative_path))
             .unwrap_or(false)
     }
@@ -1224,12 +1252,12 @@ impl VirtualFileSystem for MountTable {
     }
 
     fn read_link(&self, path: &str) -> VfsResult<String> {
-        let (index, relative_path) = self.resolve_index(path)?;
+        let (index, relative_path) = self.resolve_link_leaf_index(path)?;
         self.mounts[index].filesystem.read_link(&relative_path)
     }
 
     fn lstat(&self, path: &str) -> VfsResult<VirtualStat> {
-        let (index, relative_path) = self.resolve_index(path)?;
+        let (index, relative_path) = self.resolve_link_leaf_index(path)?;
         self.mounts[index].filesystem.lstat(&relative_path)
     }
 

--- a/crates/vfs/src/posix/tar_fs.rs
+++ b/crates/vfs/src/posix/tar_fs.rs
@@ -42,6 +42,7 @@ const MAX_TAR_SYMLINKS: usize = 40;
 /// `/opt/agentos/pkgs/<pkg>/<version>`. Managed commands and `current` aliases
 /// are separate symlink leaf mounts, while parent directories stay writable
 /// overlay directories so user-installed files can coexist with managed ones.
+#[derive(Clone)]
 pub struct TarFileSystem {
     archive: Arc<CachedTarArchive>,
     root: String,

--- a/packages/build-tools/bridge-src/builtins/net.ts
+++ b/packages/build-tools/bridge-src/builtins/net.ts
@@ -1066,7 +1066,11 @@ function createAcceptedClientHandle(socketId, info) {
   };
 }
 
-var NET_BRIDGE_TIMEOUT_SENTINEL = "__secure_exec_net_timeout__";
+// Must match JAVASCRIPT_NET_TIMEOUT_SENTINEL in crates/native-sidecar/src/execution.rs.
+// A mismatched sentinel is NOT a soft failure: every no-data poll response then
+// falls through to base64 decoding and injects the decoded sentinel bytes into
+// the socket stream as phantom data.
+var NET_BRIDGE_TIMEOUT_SENTINEL = "__agentos_net_timeout__";
 
 var NET_BRIDGE_POLL_DELAY_MS = 10;
 


### PR DESCRIPTION
- Fix the guest net-poll timeout sentinel drift (`__secure_exec_net_timeout__` vs `__agentos_net_timeout__`): every idle socket poll base64-decoded the sentinel into 17 phantom bytes injected into every guest TCP stream, breaking all guest HTTP since the agentos flip (predates the .aospkg work; confirmed against a pre-flip-era sidecar). New `loopback_probe_e2e` gates it
- Kernel mount-table POSIX semantics through symlink-root leaf mounts (`<pkg>/current -> <version>`): `read_dir*`/`exists` now follow cross-mount symlinks like `read_file`/`stat`, and `lstat`/`read_link` follow intermediate symlinks while keeping the final component
- Module resolution for packed packages: the bridge module reader now serves `.aospkg` tar mounts (with `current` aliases) alongside host-dir mounts, and kernel-side bare-specifier resolution falls back to the process's own package version root — self-contained agent closures resolve what they ship (pi's lazy `require('@anthropic-ai/sdk')` from an unpackaged parent path)
- pi and pty e2e suites now run against the packed `.aospkg` artifact (dir fixtures remain the fallback); pi prompt round-trips through the real SDK to a host llmock end-to-end