### PR TITLE
test(native-sidecar): bench package projection against tar extraction with cold-cache and read-all spans

### DIFF
--- a/crates/native-sidecar/tests/projection_bench.rs
+++ b/crates/native-sidecar/tests/projection_bench.rs
@@ -5,8 +5,7 @@
 //! mount from its precomputed index. The tar is never extracted.
 //!
 //! ## What is timed
-//! The timed span, per sample, is **load time only** — the work the sidecar
-//! does at VM configure time for an already-packed `.aospkg`:
+//! Per sample, four spans are timed:
 //!   1. `read_package_manifest_from_path(<pkg>.aospkg)`
 //!        → read the 16-byte header, decode the chunk1 `PackageManifest`
 //!          (commands included)
@@ -16,11 +15,34 @@
 //!        → decode the precomputed chunk2 mount index + mmap the mount tar
 //!          (cold each sample: the identity-keyed archive cache holds only
 //!          weak refs, so dropping the fs between samples re-loads the index)
+//!   4. read every regular file in the mounted tar back out through the VFS
+//!        → recursive `read_dir_with_types` walk + `read_file` on each file,
+//!          summing bytes. This proves the mount serves real content and
+//!          bounds the total cost of "install + read everything".
+//! `FULL load` is steps 1–3 (the honest "install" span — content reads happen
+//! later, on demand). `load + read ALL bytes` is steps 1–4 and is the
+//! conservative upper bound to quote against extraction-based installs.
+//!
+//! ## Extraction baseline
+//! Each target also runs an in-process `tar::Archive::unpack` of the same
+//! source `package.tar` into a fresh directory per sample (removed outside
+//! the timed span). This is what an extract-style installer (apt/dpkg, plain
+//! `tar -x`) must do at minimum, steel-manned in agentOS's *disfavor*: no
+//! fork/exec, no decompression, no dpkg bookkeeping, no fsync.
+//!
 //! Pack time (scanning a source `package.tar` and encoding the `.aospkg`
 //! header/manifest/index — the "compile" step) is explicitly NOT counted: it
 //! happens once at package build time, not at VM load. It is printed once per
 //! target as an informational `pack (excluded)` line.
 //! Nothing else (no ConfigureVm / no VM boot) is included.
+//!
+//! ## Page cache
+//! By default samples run warm (a warmup loop touches everything first).
+//! Set `PROJ_BENCH_COLD=1` to `posix_fadvise(DONTNEED)` the `.aospkg` (and
+//! the baseline's source tar) before every sample, evicting its page cache
+//! so each sample pays real disk reads. Warm-vs-cold is the difference
+//! between "VM N+1 loads a package another VM already touched" and "first
+//! load after boot".
 //!
 //! ## Reproducibility
 //! Fixed warmup + sample count, deterministic on-disk inputs. Each sample
@@ -35,12 +57,15 @@
 //!
 //! Then runs the repo's built registry tars (skipped with a note if a tar is
 //! absent, e.g. in a clean checkout that has not built `dist/`):
-//!   - coreutils: `registry/software/coreutils/dist/package.tar`  (small-ish, many commands)
-//!   - tar:       `registry/software/tar/dist/package.tar`        (single wasm binary)
+//!   - coreutils: `registry/software/coreutils/dist/package.tar` (large, many commands)
+//!   - tar:       `registry/software/tar/dist/package.tar`       (single wasm binary)
+//!   - git:       `registry/software/git/dist/package.tar`       (the package the
+//!                marketing install comparison talks about)
 //! Override the source tars via env:
 //!   PROJ_BENCH_COREUTILS_TAR=/abs/package.tar  PROJ_BENCH_TAR_TAR=/abs/package.tar
+//!   PROJ_BENCH_GIT_TAR=/abs/package.tar
 //! Tune the run via env: PROJ_BENCH_SAMPLES (default 30), PROJ_BENCH_WARMUP
-//! (default 2).
+//! (default 2), PROJ_BENCH_COLD (default 0).
 //!
 //! ## Run
 //! ```text
@@ -48,6 +73,7 @@
 //! # or, pointing at built tars elsewhere:
 //! PROJ_BENCH_COREUTILS_TAR=/abs/registry/software/coreutils/dist/package.tar \
 //! PROJ_BENCH_TAR_TAR=/abs/registry/software/tar/dist/package.tar \
+//! PROJ_BENCH_GIT_TAR=/abs/registry/software/git/dist/package.tar \
 //!   cargo test -p agentos-native-sidecar --release --test projection_bench -- --ignored --nocapture
 //! ```
 
@@ -60,7 +86,7 @@ use agentos_native_sidecar::package_projection::{
     build_package_leaf_mounts, read_package_manifest_from_path, DEFAULT_PACKAGE_TAR_NAME,
 };
 use vfs::package_format::pack::pack_aospkg_from_tar;
-use vfs::posix::TarFileSystem;
+use vfs::posix::{TarFileSystem, VirtualFileSystem};
 
 const SOURCE_PACKAGE_TAR_NAME: &str = "package.tar";
 
@@ -84,6 +110,15 @@ fn env_usize(key: &str, default: usize) -> usize {
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .unwrap_or(default)
+}
+
+fn env_flag(key: &str) -> bool {
+    std::env::var(key)
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
 }
 
 fn ms(d: Duration) -> f64 {
@@ -124,6 +159,7 @@ struct Sample {
     manifest: f64,
     mounts: f64,
     tar_open: f64,
+    read_all: f64,
 }
 
 struct SyntheticTargets {
@@ -134,15 +170,19 @@ struct SyntheticTargets {
     medium_pack: Duration,
 }
 
-struct RepackedTargets {
-    root: PathBuf,
-    coreutils: PathBuf,
-    tar: PathBuf,
-    coreutils_pack: Option<Duration>,
-    tar_pack: Option<Duration>,
+struct RealTarget {
+    label: &'static str,
+    dir: PathBuf,
+    source_tar: PathBuf,
+    pack: Option<Duration>,
 }
 
-impl Drop for RepackedTargets {
+struct RealTargets {
+    root: PathBuf,
+    targets: Vec<RealTarget>,
+}
+
+impl Drop for RealTargets {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.root);
     }
@@ -260,7 +300,7 @@ fn create_synthetic_targets() -> SyntheticTargets {
     }
 }
 
-fn create_repacked_real_targets(coreutils_tar: &Path, tar_tar: &Path) -> RepackedTargets {
+fn create_repacked_real_targets(sources: &[(&'static str, &Path)]) -> RealTargets {
     let unique = format!(
         "secure-exec-projection-real-{}-{}",
         std::process::id(),
@@ -270,25 +310,24 @@ fn create_repacked_real_targets(coreutils_tar: &Path, tar_tar: &Path) -> Repacke
             .as_nanos()
     );
     let root = std::env::temp_dir().join(unique);
-    let coreutils = root.join("coreutils");
-    let tar = root.join("tar");
-    fs::create_dir_all(&coreutils).expect("create repacked coreutils dir");
-    fs::create_dir_all(&tar).expect("create repacked tar dir");
-
-    let coreutils_pack = coreutils_tar.is_file().then(|| {
-        repack_package_tar_to_aospkg(coreutils_tar, &coreutils.join(DEFAULT_PACKAGE_TAR_NAME))
-    });
-    let tar_pack = tar_tar
-        .is_file()
-        .then(|| repack_package_tar_to_aospkg(tar_tar, &tar.join(DEFAULT_PACKAGE_TAR_NAME)));
-
-    RepackedTargets {
-        root,
-        coreutils,
-        tar,
-        coreutils_pack,
-        tar_pack,
-    }
+    let targets = sources
+        .iter()
+        .map(|(label, source_tar)| {
+            let dir = root.join(label);
+            fs::create_dir_all(&dir)
+                .unwrap_or_else(|e| panic!("create repacked {label} dir failed: {e}"));
+            let pack = source_tar.is_file().then(|| {
+                repack_package_tar_to_aospkg(source_tar, &dir.join(DEFAULT_PACKAGE_TAR_NAME))
+            });
+            RealTarget {
+                label,
+                dir,
+                source_tar: source_tar.to_path_buf(),
+                pack,
+            }
+        })
+        .collect();
+    RealTargets { root, targets }
 }
 
 /// Pack a source `package.tar` into a `.aospkg` via the canonical packer in
@@ -303,8 +342,63 @@ fn repack_package_tar_to_aospkg(source_tar: &Path, dest_aospkg: &Path) -> Durati
     started.elapsed()
 }
 
+/// Evict a file's pages from the OS page cache so the next access pays real
+/// disk I/O. Flushes first (a dirty page cannot be dropped), then advises
+/// DONTNEED over the whole file.
+fn evict_page_cache(path: &Path) {
+    use std::os::fd::AsRawFd;
+    let file = fs::File::open(path)
+        .unwrap_or_else(|e| panic!("open {} for cache eviction failed: {e}", path.display()));
+    file.sync_all()
+        .unwrap_or_else(|e| panic!("fsync {} before eviction failed: {e}", path.display()));
+    nix::fcntl::posix_fadvise(
+        file.as_raw_fd(),
+        0,
+        0,
+        nix::fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED,
+    )
+    .unwrap_or_else(|e| panic!("posix_fadvise(DONTNEED) on {} failed: {e}", path.display()));
+}
 
-fn project_once(dir: &str) -> (Sample, usize, usize) {
+/// Walk the mounted tar filesystem and read every regular file's full content
+/// through the VFS read path. Returns (bytes read, files read).
+fn read_all_files(fs: &mut TarFileSystem) -> (u64, usize) {
+    let mut stack = vec![String::from("/")];
+    let mut bytes = 0u64;
+    let mut files = 0usize;
+    while let Some(dir) = stack.pop() {
+        let entries = fs
+            .read_dir_with_types(&dir)
+            .unwrap_or_else(|e| panic!("readdir {dir} failed: {e:?}"));
+        for entry in entries {
+            let path = if dir == "/" {
+                format!("/{}", entry.name)
+            } else {
+                format!("{}/{}", dir, entry.name)
+            };
+            if entry.is_directory {
+                stack.push(path);
+            } else if !entry.is_symbolic_link {
+                let content = fs
+                    .read_file(&path)
+                    .unwrap_or_else(|e| panic!("read {path} failed: {e:?}"));
+                bytes += content.len() as u64;
+                files += 1;
+            }
+        }
+    }
+    (bytes, files)
+}
+
+struct ProjectOutcome {
+    sample: Sample,
+    command_count: usize,
+    mount_count: usize,
+    bytes_read: u64,
+    files_read: usize,
+}
+
+fn project_once(dir: &str) -> ProjectOutcome {
     // Step 1: read the .aospkg header + chunk1 manifest (commands included).
     // The wire carries the packed file path, so the bench does too.
     let aospkg = Path::new(dir).join(DEFAULT_PACKAGE_TAR_NAME);
@@ -329,25 +423,62 @@ fn project_once(dir: &str) -> (Sample, usize, usize) {
     // mmap the mount tar. The archive cache only holds weak refs, so dropping
     // the fs at the end of this sample makes the next sample a cold load.
     let t2 = Instant::now();
-    let fs = TarFileSystem::open(&tar_path)
+    let mut fs = TarFileSystem::open(&tar_path)
         .unwrap_or_else(|e| panic!("TarFileSystem::open({tar_path}) failed: {e:?}"));
     let tar_open_ms = ms(t2.elapsed());
+    let total_ms = ms(t0.elapsed());
+
+    // Step 4 (reported separately from FULL load): prove the mount serves
+    // real content by reading every regular file back out through the VFS.
+    let t3 = Instant::now();
+    let (bytes_read, files_read) = read_all_files(&mut fs);
+    let read_all_ms = ms(t3.elapsed());
     drop(fs);
 
-    let total_ms = ms(t0.elapsed());
-    (
-        Sample {
+    ProjectOutcome {
+        sample: Sample {
             total: total_ms,
             manifest: manifest_ms,
             mounts: mounts_ms,
             tar_open: tar_open_ms,
+            read_all: read_all_ms,
         },
         command_count,
-        mounts.len(),
-    )
+        mount_count: mounts.len(),
+        bytes_read,
+        files_read,
+    }
 }
 
-fn run_target(label: &str, dir: &Path, warmup: usize, samples: usize, pack: Option<Duration>) {
+/// In-process extraction of the source `package.tar` into a fresh directory:
+/// the minimum work an extract-style installer must do, with every advantage
+/// granted (no fork/exec, no decompression, no scripts/db, no fsync).
+/// Directory creation and removal happen outside the timed span.
+fn extract_once(source_tar: &Path, dest: &Path) -> f64 {
+    fs::create_dir_all(dest)
+        .unwrap_or_else(|e| panic!("create extraction dir {} failed: {e}", dest.display()));
+    let t0 = Instant::now();
+    let file = fs::File::open(source_tar)
+        .unwrap_or_else(|e| panic!("open {} failed: {e}", source_tar.display()));
+    let mut archive = tar::Archive::new(std::io::BufReader::new(file));
+    archive
+        .unpack(dest)
+        .unwrap_or_else(|e| panic!("unpack {} failed: {e}", source_tar.display()));
+    let elapsed = ms(t0.elapsed());
+    fs::remove_dir_all(dest)
+        .unwrap_or_else(|e| panic!("remove extraction dir {} failed: {e}", dest.display()));
+    elapsed
+}
+
+fn run_target(
+    label: &str,
+    dir: &Path,
+    source_tar: Option<&Path>,
+    warmup: usize,
+    samples: usize,
+    pack: Option<Duration>,
+    cold: bool,
+) {
     let tar = dir.join(DEFAULT_PACKAGE_TAR_NAME);
     if !tar.is_file() {
         println!(
@@ -359,35 +490,68 @@ fn run_target(label: &str, dir: &Path, warmup: usize, samples: usize, pack: Opti
     let tar_bytes = std::fs::metadata(&tar).map(|m| m.len()).unwrap_or(0);
     let dir_str = dir.to_str().expect("utf8 dir");
 
-    // Warmup (warms page cache; results discarded).
+    // Warmup (warms page cache in warm mode; results discarded).
     let mut cmd_count = 0usize;
     let mut mount_count = 0usize;
+    let mut bytes_read = 0u64;
+    let mut files_read = 0usize;
     for _ in 0..warmup {
-        let (_, c, m) = project_once(dir_str);
-        cmd_count = c;
-        mount_count = m;
+        let outcome = project_once(dir_str);
+        cmd_count = outcome.command_count;
+        mount_count = outcome.mount_count;
+        bytes_read = outcome.bytes_read;
+        files_read = outcome.files_read;
     }
 
     let mut rows: Vec<Sample> = Vec::with_capacity(samples);
     for _ in 0..samples {
-        let (sample, c, m) = project_once(dir_str);
-        cmd_count = c;
-        mount_count = m;
-        rows.push(sample);
+        if cold {
+            evict_page_cache(&tar);
+        }
+        let outcome = project_once(dir_str);
+        cmd_count = outcome.command_count;
+        mount_count = outcome.mount_count;
+        bytes_read = outcome.bytes_read;
+        files_read = outcome.files_read;
+        rows.push(outcome.sample);
     }
+
+    // Extraction baseline over the same source tar, same warmup/sample/cold
+    // treatment as the load samples.
+    let baseline = source_tar.filter(|p| p.is_file()).map(|source| {
+        let dest = dir.join("extract-baseline");
+        for _ in 0..warmup {
+            extract_once(source, &dest);
+        }
+        let mut totals: Vec<f64> = (0..samples)
+            .map(|_| {
+                if cold {
+                    evict_page_cache(source);
+                }
+                extract_once(source, &dest)
+            })
+            .collect();
+        totals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        totals
+    });
 
     let mut totals: Vec<f64> = rows.iter().map(|r| r.total).collect();
     let mut manifests: Vec<f64> = rows.iter().map(|r| r.manifest).collect();
     let mut mounts_v: Vec<f64> = rows.iter().map(|r| r.mounts).collect();
     let mut tar_opens: Vec<f64> = rows.iter().map(|r| r.tar_open).collect();
+    let mut read_alls: Vec<f64> = rows.iter().map(|r| r.read_all).collect();
+    let mut full_with_read: Vec<f64> = rows.iter().map(|r| r.total + r.read_all).collect();
     totals.sort_by(|a, b| a.partial_cmp(b).unwrap());
     manifests.sort_by(|a, b| a.partial_cmp(b).unwrap());
     mounts_v.sort_by(|a, b| a.partial_cmp(b).unwrap());
     tar_opens.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    read_alls.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    full_with_read.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     println!(
-        "\n=== {label}  ({:.1} MiB tar, {cmd_count} commands, {mount_count} leaf mounts, N={samples}, warmup={warmup}) ===",
-        tar_bytes as f64 / (1024.0 * 1024.0)
+        "\n=== {label}  ({:.1} MiB tar, {cmd_count} commands, {mount_count} leaf mounts, N={samples}, warmup={warmup}, {} cache) ===",
+        tar_bytes as f64 / (1024.0 * 1024.0),
+        if cold { "COLD page" } else { "warm page" }
     );
     if let Some(pack) = pack {
         println!(
@@ -396,8 +560,12 @@ fn run_target(label: &str, dir: &Path, warmup: usize, samples: usize, pack: Opti
         );
     }
     println!(
+        "  step4 reads back {files_read} files, {:.1} MiB, through the mounted VFS each sample",
+        bytes_read as f64 / (1024.0 * 1024.0)
+    );
+    println!(
         "  {:<28} {:>9} {:>9} {:>9} {:>9} {:>9}",
-        "load span (ms)", "min", "median", "mean", "p95", "max"
+        "span (ms)", "min", "median", "mean", "p95", "max"
     );
     // mean() is order-invariant, so the sorted slices serve every stat.
     let print_stat = |name: &str, sorted: &[f64]| {
@@ -415,7 +583,22 @@ fn run_target(label: &str, dir: &Path, warmup: usize, samples: usize, pack: Opti
     print_stat("  manifest+cmds (step1)", &manifests);
     print_stat("  leaf mounts   (step2)", &mounts_v);
     print_stat("  tar mount open (step3)", &tar_opens);
-
+    print_stat("read ALL bytes (step4)", &read_alls);
+    print_stat("load + read ALL (1..4)", &full_with_read);
+    match &baseline {
+        Some(extract) => {
+            print_stat("tar extract baseline", extract);
+            let load_median = median(&totals);
+            let full_median = median(&full_with_read);
+            let extract_median = median(extract);
+            println!(
+                "  extract/load: {:.0}x   extract/(load+read ALL): {:.1}x",
+                extract_median / load_median,
+                extract_median / full_median
+            );
+        }
+        None => println!("  tar extract baseline: [skip] no source package.tar"),
+    }
 }
 
 #[test]
@@ -423,42 +606,61 @@ fn run_target(label: &str, dir: &Path, warmup: usize, samples: usize, pack: Opti
 fn projection_bench() {
     let warmup = env_usize("PROJ_BENCH_WARMUP", 2);
     let samples = env_usize("PROJ_BENCH_SAMPLES", 30);
+    let cold = env_flag("PROJ_BENCH_COLD");
 
     let coreutils_tar = source_tar_path(
         "PROJ_BENCH_COREUTILS_TAR",
         "registry/software/coreutils/dist/package.tar",
     );
     let tar_tar = source_tar_path("PROJ_BENCH_TAR_TAR", "registry/software/tar/dist/package.tar");
+    let git_tar = source_tar_path("PROJ_BENCH_GIT_TAR", "registry/software/git/dist/package.tar");
 
     println!("\n# agentOS package load benchmark (.aospkg)");
-    println!("# timed span = manifest chunk read + leaf mounts + tar mount open (index decode + mmap)");
+    println!("# FULL load = manifest chunk read + leaf mounts + tar mount open (index decode + mmap)");
+    println!("# step4 additionally reads every regular file back through the mounted VFS");
+    println!("# baseline = in-process tar extraction of the same source package.tar");
     println!("# pack (.tar -> .aospkg) runs once in setup and is excluded from all load stats");
+    println!(
+        "# page cache: {} (set PROJ_BENCH_COLD=1 for per-sample eviction)",
+        if cold { "COLD (evicted per sample)" } else { "warm" }
+    );
     println!("# repo root = {}", repo_root().display());
 
     let synthetic = create_synthetic_targets();
     run_target(
         "synthetic-tiny",
         &synthetic.tiny,
+        Some(&synthetic.tiny.join(SOURCE_PACKAGE_TAR_NAME)),
         warmup,
         samples,
         Some(synthetic.tiny_pack),
+        cold,
     );
     run_target(
         "synthetic-medium",
         &synthetic.medium,
+        Some(&synthetic.medium.join(SOURCE_PACKAGE_TAR_NAME)),
         warmup,
         samples,
         Some(synthetic.medium_pack),
+        cold,
     );
-    let real = create_repacked_real_targets(&coreutils_tar, &tar_tar);
-    run_target(
-        "coreutils",
-        &real.coreutils,
-        warmup,
-        samples,
-        real.coreutils_pack,
-    );
-    run_target("tar (wasm binary)", &real.tar, warmup, samples, real.tar_pack);
+    let real = create_repacked_real_targets(&[
+        ("coreutils", &coreutils_tar),
+        ("tar (wasm binary)", &tar_tar),
+        ("git", &git_tar),
+    ]);
+    for target in &real.targets {
+        run_target(
+            target.label,
+            &target.dir,
+            Some(&target.source_tar),
+            warmup,
+            samples,
+            target.pack,
+            cold,
+        );
+    }
     println!();
 }
 
@@ -478,12 +680,12 @@ fn coreutils_load_budget() {
         eprintln!("skipping coreutils_load_budget: {} not built", coreutils_tar.display());
         return;
     }
-    let real = create_repacked_real_targets(&coreutils_tar, Path::new("/nonexistent"));
-    let dir = real.coreutils.to_str().expect("utf8 dir");
+    let real = create_repacked_real_targets(&[("coreutils", &coreutils_tar)]);
+    let dir = real.targets[0].dir.to_str().expect("utf8 dir");
     for _ in 0..2 {
         let _ = project_once(dir);
     }
-    let mut totals: Vec<f64> = (0..10).map(|_| project_once(dir).0.total).collect();
+    let mut totals: Vec<f64> = (0..10).map(|_| project_once(dir).sample.total).collect();
     totals.sort_by(|a, b| a.partial_cmp(b).unwrap());
     assert!(
         median(&totals) < 20.0,


### PR DESCRIPTION
- Add an in-process tar-extraction baseline over the same source package.tar to the projection bench
- Add a step-4 span that reads every regular file back through the mounted VFS to prove content is served
- Add a git registry target (PROJ_BENCH_GIT_TAR) and a PROJ_BENCH_COLD=1 mode that evicts page cache per sample via posix_fadvise(DONTNEED)
- Measured on the bench box: git package load ~12µs warm / ~130µs cold; extracting the same tar is 10–25x slower