### PR TITLE
fix(ci): repair main CI — compat check crate rename, idempotent docs-theme clone, clippy debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           components: rustfmt
       - run: |
+          rm -rf /tmp/docs-theme
           git clone https://github.com/rivet-dev/docs-theme.git /tmp/docs-theme
           git -C /tmp/docs-theme checkout 450c498555135098c6a927adfdf13458be9be22a
           rm -rf website/vendor/theme && mkdir -p website/vendor
@@ -87,6 +88,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - run: |
+          rm -rf /tmp/docs-theme
           git clone https://github.com/rivet-dev/docs-theme.git /tmp/docs-theme
           git -C /tmp/docs-theme checkout 450c498555135098c6a927adfdf13458be9be22a
           rm -rf website/vendor/theme && mkdir -p website/vendor

--- a/crates/agentos-actor-plugin/src/actions/process.rs
+++ b/crates/agentos-actor-plugin/src/actions/process.rs
@@ -29,8 +29,10 @@ pub async fn exec(
     command: &str,
     options: ExecActionOptions,
 ) -> Result<ExecResultDto> {
-    let mut base = ExecOptions::default();
-    base.env = options.env;
+    let mut base = ExecOptions {
+        env: options.env,
+        ..Default::default()
+    };
     if options.cwd.is_some() {
         base.cwd = options.cwd;
     }
@@ -60,8 +62,10 @@ pub fn spawn(
     args: Vec<String>,
     options: SpawnActionOptions,
 ) -> Result<SpawnHandle> {
-    let mut base = ExecOptions::default();
-    base.env = options.env;
+    let mut base = ExecOptions {
+        env: options.env,
+        ..Default::default()
+    };
     if options.cwd.is_some() {
         base.cwd = options.cwd;
     }

--- a/crates/agentos-sidecar-core/src/engine.rs
+++ b/crates/agentos-sidecar-core/src/engine.rs
@@ -84,7 +84,7 @@ fn resolve_agent<H: AcpHost>(
     let path = format!("/opt/agentos/pkgs/{agent_type}/current/agentos-package.json");
     let bytes = host.read_file(&path).map_err(|_| unknown())?;
     let manifest: AgentPackageManifest = serde_json::from_slice(&bytes).map_err(|_| unknown())?;
-    let agent = manifest.agent.ok_or_else(|| unknown())?;
+    let agent = manifest.agent.ok_or_else(&unknown)?;
     if agent.acp_entrypoint.is_empty() {
         return Err(unknown());
     }

--- a/crates/native-sidecar/src/execution.rs
+++ b/crates/native-sidecar/src/execution.rs
@@ -18818,10 +18818,10 @@ fn javascript_crypto_call_ecdh_session(
                 })?,
                 "ECDH private key",
             )?;
-            let ctx = BigNumContext::new().map_err(javascript_crypto_openssl_error)?;
+            let mut ctx = BigNumContext::new().map_err(javascript_crypto_openssl_error)?;
             let mut public_key = EcPoint::new(&group).map_err(javascript_crypto_openssl_error)?;
             public_key
-                .mul_generator(&group, &private_key, &ctx)
+                .mul_generator2(&group, &private_key, &mut ctx)
                 .map_err(javascript_crypto_openssl_error)?;
             session.key_pair = Some(
                 EcKey::from_private_components(&group, &private_key, &public_key)

--- a/crates/native-sidecar/tests/projection_bench.rs
+++ b/crates/native-sidecar/tests/projection_bench.rs
@@ -7,18 +7,19 @@
 //! ## What is timed
 //! Per sample, four spans are timed:
 //!   1. `read_package_manifest_from_path(<pkg>.aospkg)`
-//!        → read the 16-byte header, decode the chunk1 `PackageManifest`
-//!          (commands included)
+//!      → read the 16-byte header, decode the chunk1 `PackageManifest`
+//!      (commands included)
 //!   2. `build_package_leaf_mounts(&[descriptor], "/opt/agentos")`
-//!        → cross-package command-collision check + leaf-mount construction
+//!      → cross-package command-collision check + leaf-mount construction
 //!   3. `TarFileSystem::open` on the `.aospkg`
-//!        → decode the precomputed chunk2 mount index + mmap the mount tar
-//!          (cold each sample: the identity-keyed archive cache holds only
-//!          weak refs, so dropping the fs between samples re-loads the index)
+//!      → decode the precomputed chunk2 mount index + mmap the mount tar
+//!      (cold each sample: the identity-keyed archive cache holds only
+//!      weak refs, so dropping the fs between samples re-loads the index)
 //!   4. read every regular file in the mounted tar back out through the VFS
-//!        → recursive `read_dir_with_types` walk + `read_file` on each file,
-//!          summing bytes. This proves the mount serves real content and
-//!          bounds the total cost of "install + read everything".
+//!      → recursive `read_dir_with_types` walk + `read_file` on each file,
+//!      summing bytes. This proves the mount serves real content and
+//!      bounds the total cost of "install + read everything".
+//!
 //! `FULL load` is steps 1–3 (the honest "install" span — content reads happen
 //! later, on demand). `load + read ALL bytes` is steps 1–4 and is the
 //! conservative upper bound to quote against extraction-based installs.
@@ -59,8 +60,9 @@
 //! absent, e.g. in a clean checkout that has not built `dist/`):
 //!   - coreutils: `registry/software/coreutils/dist/package.tar` (large, many commands)
 //!   - tar:       `registry/software/tar/dist/package.tar`       (single wasm binary)
-//!   - git:       `registry/software/git/dist/package.tar`       (the package the
-//!                marketing install comparison talks about)
+//!   - git:       `registry/software/git/dist/package.tar`       (the package
+//!     the marketing install comparison talks about)
+//!
 //! Override the source tars via env:
 //!   PROJ_BENCH_COREUTILS_TAR=/abs/package.tar  PROJ_BENCH_TAR_TAR=/abs/package.tar
 //!   PROJ_BENCH_GIT_TAR=/abs/package.tar
@@ -95,7 +97,7 @@ fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .canonicalize()
-        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").into())
+        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
 }
 
 fn source_tar_path(env_key: &str, default_rel: &str) -> PathBuf {
@@ -664,10 +666,10 @@ fn projection_bench() {
     println!();
 }
 
-/// Default-suite load budget: the coreutils FULL load (manifest + leaf mounts
-/// + tar index open) must stay under 20 ms median even in a debug build (it
-/// measures ~0.15 ms in release, ~1 ms in debug — 20 ms means something is
-/// structurally wrong, e.g. a whole-archive read snuck back in). Not hidden
+/// Default-suite load budget: the coreutils FULL load (manifest, leaf mounts,
+/// tar index open) must stay under 20 ms median even in a debug build — it
+/// measures ~0.15 ms in release and ~1 ms in debug, so 20 ms means something
+/// structurally wrong (e.g. a whole-archive read snuck back in). Not hidden
 /// behind `#[ignore]` so the budget cannot silently regress; skips cleanly
 /// when the registry package is not built.
 #[test]

--- a/crates/vfs/build.rs
+++ b/crates/vfs/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, fs, path::{Path, PathBuf}};
 
 // Stage the base filesystem fixture into OUT_DIR. In-tree builds use the
 // canonical AgentOS runtime-core fixture from the current workspace; the
@@ -34,7 +34,7 @@ fn main() {
     });
 }
 
-fn stage_package_format_schema(manifest_dir: &PathBuf, out_dir: &PathBuf) {
+fn stage_package_format_schema(manifest_dir: &Path, out_dir: &Path) {
     let source_schema = manifest_dir.join("package-format").join("v1.bare");
     println!("cargo:rerun-if-changed={}", source_schema.display());
 

--- a/scripts/check-agentos-client-protocol-compat.mjs
+++ b/scripts/check-agentos-client-protocol-compat.mjs
@@ -115,8 +115,8 @@ export function checkAgentOsClientProtocolCompat(options = {}) {
 	const sidecarPath = join(root, "crates/client/src/sidecar.rs");
 	if (existsSync(sidecarPath)) {
 		const sidecarSource = readFileSync(sidecarPath, "utf8");
-		if (!sidecarSource.includes("use secure_exec_client::wire;")) {
-			errors.push("crates/client/src/sidecar.rs must import secure_exec_client::wire");
+		if (!sidecarSource.includes("use agentos_sidecar_client::wire;")) {
+			errors.push("crates/client/src/sidecar.rs must import agentos_sidecar_client::wire");
 		}
 		if (!sidecarSource.includes("protocol_version: wire::PROTOCOL_VERSION")) {
 			errors.push(


### PR DESCRIPTION
All three are pre-existing breaks from before today (reproduced locally):
- `check-agentos-client-protocol-compat.mjs` still required the pre-flip literal `use secure_exec_client::wire;`; the flip renamed the crate to `agentos_sidecar_client` (Checks job red since #1619)
- The Rust job runs on a self-hosted runner where `/tmp/docs-theme` persists, so the bare `git clone` fails on every run after the first — clone is now preceded by `rm -rf`
- `cargo clippy --workspace --all-targets -D warnings` debt: `&PathBuf` args in the vfs build script, redundant closure in sidecar-core, field-assignment-outside-initializer in the actor plugin, deprecated `mul_generator` → `mul_generator2` (sound successor, same EC_POINT_mul semantics), and bench doc-comment list formatting. Clippy is now clean workspace-wide