### PR TITLE
fix(publish): ship common on the main release track, pin independent registry deps to npm latest, fix release asset upload glob

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -387,7 +387,12 @@ jobs:
             if [ "${NPM_TAG}" = "rc" ]; then PRERELEASE="--prerelease"; fi
             gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes $PRERELEASE
           fi
-          gh release upload "v${VERSION}" release-assets/* release-assets/pyodide/* --clobber
+          # Upload FILES only — a bare `release-assets/*` glob matches the
+          # pyodide directory itself and `gh release upload` cannot upload dirs.
+          find release-assets -maxdepth 1 -type f -print0 | xargs -0 gh release upload "v${VERSION}" --clobber
+          if [ -d release-assets/pyodide ]; then
+            find release-assets/pyodide -maxdepth 1 -type f -print0 | xargs -0 gh release upload "v${VERSION}" --clobber
+          fi
       - name: Upload release assets to R2
         if: ${{ needs.context.outputs.trigger == 'release' }}
         env:

--- a/registry/software/browserbase/package.json
+++ b/registry/software/browserbase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/browserbase",
-	"version": "0.1.0",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Browserbase browse CLI for secure-exec VMs (cloud browser automation)",

--- a/registry/software/codex-cli/package.json
+++ b/registry/software/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/codex-cli",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "OpenAI Codex command package for secure-exec VMs",

--- a/registry/software/coreutils/package.json
+++ b/registry/software/coreutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/coreutils",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU coreutils for secure-exec VMs (sh, cat, ls, cp, sort, and 80+ commands)",

--- a/registry/software/curl/package.json
+++ b/registry/software/curl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/curl",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "curl HTTP client for secure-exec VMs",

--- a/registry/software/diffutils/package.json
+++ b/registry/software/diffutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/diffutils",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU diffutils for secure-exec VMs (diff)",

--- a/registry/software/duckdb/package.json
+++ b/registry/software/duckdb/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/duckdb",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "DuckDB CLI for secure-exec VMs",

--- a/registry/software/fd/package.json
+++ b/registry/software/fd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/fd",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "fd fast file finder for secure-exec VMs",

--- a/registry/software/file/package.json
+++ b/registry/software/file/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/file",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "file type detection for secure-exec VMs",

--- a/registry/software/findutils/package.json
+++ b/registry/software/findutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/findutils",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU findutils for secure-exec VMs (find, xargs)",

--- a/registry/software/gawk/package.json
+++ b/registry/software/gawk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/gawk",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU awk text processing for secure-exec VMs",

--- a/registry/software/git/package.json
+++ b/registry/software/git/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/git",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "git version control for secure-exec VMs (planned)",

--- a/registry/software/grep/package.json
+++ b/registry/software/grep/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/grep",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU grep pattern matching for secure-exec VMs (grep, egrep, fgrep)",

--- a/registry/software/gzip/package.json
+++ b/registry/software/gzip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/gzip",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU gzip compression for secure-exec VMs (gzip, gunzip, zcat)",

--- a/registry/software/http-get/package.json
+++ b/registry/software/http-get/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/http-get",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Minimal HTTP GET fetch helper for secure-exec VMs",

--- a/registry/software/jq/package.json
+++ b/registry/software/jq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/jq",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "jq JSON processor for secure-exec VMs",

--- a/registry/software/ripgrep/package.json
+++ b/registry/software/ripgrep/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/ripgrep",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "ripgrep fast search for secure-exec VMs",

--- a/registry/software/sed/package.json
+++ b/registry/software/sed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/sed",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU sed stream editor for secure-exec VMs",

--- a/registry/software/sqlite3/package.json
+++ b/registry/software/sqlite3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/sqlite3",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "SQLite3 CLI for secure-exec VMs",

--- a/registry/software/tar/package.json
+++ b/registry/software/tar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/tar",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU tar archiver for secure-exec VMs",

--- a/registry/software/tree/package.json
+++ b/registry/software/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/tree",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "tree directory listing for secure-exec VMs",

--- a/registry/software/unzip/package.json
+++ b/registry/software/unzip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/unzip",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "unzip archive extraction for secure-exec VMs",

--- a/registry/software/vim/package.json
+++ b/registry/software/vim/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/vim",
-	"version": "0.1.0",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "vim for secure-exec VMs (wasm build + bundled runtime via provides)",

--- a/registry/software/wget/package.json
+++ b/registry/software/wget/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/wget",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU wget HTTP client for secure-exec VMs",

--- a/registry/software/yq/package.json
+++ b/registry/software/yq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/yq",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "yq YAML/JSON processor for secure-exec VMs",

--- a/registry/software/zip/package.json
+++ b/registry/software/zip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/zip",
-	"version": "0.3.0-rc.2",
+	"version": "0.3.3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "zip archive creation for secure-exec VMs",

--- a/scripts/publish/src/lib/packages.ts
+++ b/scripts/publish/src/lib/packages.ts
@@ -183,7 +183,15 @@ export function discoverPackages(
 		) {
 			continue;
 		}
-		if (p.path.includes("/registry/software/")) continue;
+		// registry/software packages version independently and publish from
+		// local via the toolchain — EXCEPT `common`, which core hard-depends on
+		// and therefore ships on the main release track in lockstep.
+		if (
+			p.path.includes("/registry/software/") &&
+			p.name !== "@agentos-software/common"
+		) {
+			continue;
+		}
 		add(p.path);
 	}
 

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -103,6 +103,39 @@ export interface BumpOptions {
  *
  * Returns the number of files written.
  */
+/**
+ * Resolve the published `latest` version of an independently-versioned
+ * registry package from npm. Registry software packages (except `common`)
+ * publish from local on their own release track; the main release track pins
+ * `workspace:*` deps on them to whatever was last deliberately released.
+ * Memoized per run. Throws when the package has never been released — a
+ * published manifest carrying `workspace:` protocol is uninstallable by every
+ * consumer, so this must fail the publish, loudly.
+ */
+const npmLatestCache = new Map<string, string>();
+async function npmLatestVersion(dep: string): Promise<string> {
+	const cached = npmLatestCache.get(dep);
+	if (cached) return cached;
+	const { execa } = await import("execa");
+	const { stdout } = await execa("npm", [
+		"view",
+		dep,
+		"dist-tags.latest",
+	]).catch((error: Error & { shortMessage?: string }) => {
+		throw new Error(
+			`cannot resolve npm latest for workspace dep "${dep}": ${error.shortMessage ?? error.message}`,
+		);
+	});
+	const version = stdout.trim();
+	if (!version) {
+		throw new Error(
+			`workspace dep "${dep}" has no published latest on npm; release it from local first (agentos-toolchain publish ... --latest)`,
+		);
+	}
+	npmLatestCache.set(dep, version);
+	return version;
+}
+
 export async function bumpPackageJsons(
 	repoRoot: string,
 	version: string,
@@ -148,8 +181,14 @@ export async function bumpPackageJsons(
 					if (!spec.startsWith("workspace:")) continue;
 					const isOurPkg =
 						packageNames.has(dep) || dep.startsWith("@rivet-dev/agentos-");
-					if (!isOurPkg) continue;
-					deps[dep] = version;
+					if (isOurPkg) {
+						deps[dep] = version;
+						continue;
+					}
+					// Independently-versioned registry software packages: pin to
+					// the npm `latest` the owner last deliberately released from
+					// local. Never leave `workspace:` in a published manifest.
+					deps[dep] = await npmLatestVersion(dep);
 				}
 			}
 		}


### PR DESCRIPTION
Findings from the rc.4 cut + npm-install sanity check:
- Published `@rivet-dev/agentos-core` carried raw `workspace:*` deps on `@agentos-software/common`/`codex-cli` (the rewrite only covered flow-published packages), making core uninstallable by every consumer
- `@agentos-software/common` now publishes on the main release track in lockstep (core hard-depends on it); the remaining `registry/software/*` packages stay on their own track, published from local via the toolchain, and the release bump pins `workspace:*` deps on them to their npm `latest` — failing loudly if a dep was never released
- `gh release upload release-assets/*` matched the `pyodide` directory itself and failed the release-assets job (release-only path; preview never runs it) — upload now enumerates files only
- Registry software packages were released from local as `0.3.3` (latest) in the new `.aospkg` format to back the pins