### PR TITLE
fix(actor-plugin): reply createSession with the bare session id

### DIFF
--- a/crates/agentos-actor-plugin/src/actions/session.rs
+++ b/crates/agentos-actor-plugin/src/actions/session.rs
@@ -36,13 +36,6 @@ pub struct CreateSessionOptionsDto {
     pub additional_instructions: Option<String>,
 }
 
-/// `{ sessionId }` returned by `createSession`.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionIdDto {
-    pub session_id: String,
-}
-
 /// Result of `sendPrompt` exposed to the TS client.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -332,7 +325,7 @@ pub async fn create_session(
     vars: &mut Vars,
     agent_type: &str,
     dto: CreateSessionOptionsDto,
-) -> Result<SessionIdDto> {
+) -> Result<String> {
     let options = CreateSessionOptions {
         cwd: dto.cwd,
         env: dto.env,
@@ -374,7 +367,9 @@ pub async fn create_session(
     spawn_permission_pump(ctx, vm, vars, &session_id, &session_id);
     // Live adapter-crash notifications for connected clients (`agentCrashed`).
     spawn_exit_capture(ctx, vm, vars, &session_id, &session_id);
-    Ok(SessionIdDto { session_id })
+    // The TS mirror (`actor-actions.ts`) types this as `Promise<string>`, so the
+    // reply must be the bare session id, not a `{ sessionId }` wrapper.
+    Ok(session_id)
 }
 
 pub async fn send_prompt(


### PR DESCRIPTION
- The actor plugin replied `{sessionId}` while the TS contract, quickstart, examples, and docs all treat `createSession` as returning the id string; `sendPrompt` then failed its positional decode, breaking the client/server quickstart prompt round-trip.
- Reply with the bare id and drop the now-unused `SessionIdDto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)