### PR TITLE
feat(runtime-core): env-override the native sidecar frame timeout

### DIFF
--- a/packages/runtime-core/src/sidecar-process.ts
+++ b/packages/runtime-core/src/sidecar-process.ts
@@ -56,7 +56,27 @@ export { SidecarProcess as Sidecar };
 
 const BRIDGE_CONTRACT_VERSION = 1;
 
-export const NATIVE_SIDECAR_FRAME_TIMEOUT_MS = 120_000;
+const DEFAULT_NATIVE_SIDECAR_FRAME_TIMEOUT_MS = 120_000;
+
+// Per-frame timeout for the native sidecar protocol: how long the host waits for
+// a sidecar response frame before treating the sidecar as unresponsive. A single
+// long host request maps to one frame, so workloads with legitimately long turns
+// (an agent turn with many tool calls, media generation, etc.) can exceed the
+// default and be killed mid-turn with "timed out waiting for sidecar protocol
+// frame". The native sidecar is process-global (spawned once and multiplexed),
+// so this is an env override rather than a per-instance option.
+function resolveNativeSidecarFrameTimeoutMs(): number {
+	const raw = process.env.AGENTOS_SIDECAR_FRAME_TIMEOUT_MS;
+	if (raw !== undefined) {
+		const parsed = Number(raw);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+	return DEFAULT_NATIVE_SIDECAR_FRAME_TIMEOUT_MS;
+}
+
+export const NATIVE_SIDECAR_FRAME_TIMEOUT_MS = resolveNativeSidecarFrameTimeoutMs();
 const DEFAULT_SIDECAR_EVENT_BUFFER_CAPACITY = 4_096;
 const DEFAULT_SIDECAR_GRACEFUL_EXIT_MS = 5_000;
 const DEFAULT_SIDECAR_FORCE_EXIT_MS = 2_000;


### PR DESCRIPTION
## Summary

`NATIVE_SIDECAR_FRAME_TIMEOUT_MS` (`packages/runtime-core/src/sidecar-process.ts`) is hardcoded to `120_000` and is the value **both** native-sidecar spawn sites pass as `frameTimeoutMs` (`packages/core/src/agent-os.ts`, `packages/core/src/runtime-compat.ts`). There is currently no way to raise it without editing the source.

## Why

A single long-running host request maps to **one** sidecar protocol frame. Workloads with legitimately long turns — an agent turn with many tool calls, media/asset generation, etc. — exceed 120s and are killed mid-turn with `timed out waiting for sidecar protocol frame`, which tears down the sidecar and hangs the turn.

## Change

Resolve the const from `AGENTOS_SIDECAR_FRAME_TIMEOUT_MS` (validated finite + positive), falling back to `120_000`. Behavior is unchanged when the env var is unset.

The native sidecar is **process-global** (spawned once and multiplexed across sessions), so an env override is the correct surface — a per-`AgentOs.create` option would be ambiguous for a shared process. Happy to expose it through `AgentOsOptions` instead if you'd prefer, but env matches the shared-resource model.

## Notes

- One-line-of-behavior change; both existing spawn sites already read this const, so no call-site edits are needed.