### PR TITLE
feat(website): registry search, richer software detail pages, and icons

### DIFF
--- a/registry/software/build-essential/agentos-package.json
+++ b/registry/software/build-essential/agentos-package.json
@@ -2,6 +2,7 @@
 	"registry": {
 		"title": "Build Essential",
 		"description": "Meta-package: common + git + curl.",
+		"icon": "Hammer",
 		"priority": 100
 	}
 }

--- a/registry/software/common/agentos-package.json
+++ b/registry/software/common/agentos-package.json
@@ -2,6 +2,7 @@
 	"registry": {
 		"title": "Common",
 		"description": "Meta-package: coreutils + sed + grep + gawk + findutils + diffutils + tar + gzip.",
+		"icon": "Package",
 		"priority": 95
 	}
 }

--- a/registry/software/fd/agentos-package.json
+++ b/registry/software/fd/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "fd",
 		"description": "Fast file finder.",
+		"icon": "FileSearch",
 		"priority": 30
 	}
 }

--- a/registry/software/file/agentos-package.json
+++ b/registry/software/file/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "file",
 		"description": "Detect file types.",
+		"icon": "FileQuestion",
 		"priority": 2
 	}
 }

--- a/registry/software/http-get/agentos-package.json
+++ b/registry/software/http-get/agentos-package.json
@@ -4,6 +4,7 @@
 	],
 	"registry": {
 		"title": "http-get",
-		"description": "Minimal HTTP GET fetch helper."
+		"description": "Minimal HTTP GET fetch helper.",
+		"icon": "Download"
 	}
 }

--- a/registry/software/ripgrep/agentos-package.json
+++ b/registry/software/ripgrep/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "ripgrep",
 		"description": "Fast recursive search (rg).",
+		"icon": "Search",
 		"priority": 85
 	}
 }

--- a/registry/software/tree/agentos-package.json
+++ b/registry/software/tree/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "tree",
 		"description": "Display directory structure as a tree.",
+		"icon": "FolderTree",
 		"priority": 25
 	}
 }

--- a/registry/software/unzip/agentos-package.json
+++ b/registry/software/unzip/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "unzip",
 		"description": "Extract zip archives.",
+		"icon": "ArchiveRestore",
 		"priority": 10
 	}
 }

--- a/registry/software/vix/agentos-package.json
+++ b/registry/software/vix/agentos-package.json
@@ -5,6 +5,7 @@
 	],
 	"registry": {
 		"title": "vix",
-		"description": "Lightweight vi-style text editor."
+		"description": "Lightweight vi-style text editor.",
+		"icon": "FilePen"
 	}
 }

--- a/registry/software/yq/agentos-package.json
+++ b/registry/software/yq/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "yq",
 		"description": "YAML/JSON processor.",
+		"icon": "Braces",
 		"priority": 4
 	}
 }

--- a/registry/software/zip/agentos-package.json
+++ b/registry/software/zip/agentos-package.json
@@ -5,6 +5,7 @@
 	"registry": {
 		"title": "zip",
 		"description": "Create zip archives.",
+		"icon": "Archive",
 		"priority": 12
 	}
 }

--- a/website/scripts/gen-registry.mjs
+++ b/website/scripts/gen-registry.mjs
@@ -30,7 +30,33 @@ if (!existsSync(registryRoot)) {
 
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
 
+// Keep in sync with website/src/data/registry-icons.ts. An icon name missing
+// from REGISTRY_ICONS resolves to an undefined component and crashes the
+// registry island on hydration, so fail the build here instead.
+const KNOWN_ICONS = new Set([
+	"HardDrive",
+	"Database",
+	"Monitor",
+	"Globe",
+	"Wrench",
+	"Search",
+	"FileSearch",
+	"FolderTree",
+	"Archive",
+	"ArchiveRestore",
+	"Braces",
+	"FileQuestion",
+	"Download",
+	"FilePen",
+	"Package",
+	"Hammer",
+]);
+
 const entries = [];
+// Meta-package composition: resolved after the scan because it needs the full
+// npm-name -> slug map (a meta-package can depend on a package scanned later).
+const nameToSlug = new Map();
+const pendingIncludes = [];
 for (const type of ["agent", "software"]) {
 	const typeDir = join(registryRoot, type);
 	for (const dir of readdirSync(typeDir, { withFileTypes: true })) {
@@ -58,6 +84,16 @@ for (const type of ["agent", "software"]) {
 		if (meta.beta) entry.beta = true;
 		if (meta.icon) entry.icon = meta.icon;
 		if (meta.image) entry.image = meta.image;
+		if (Array.isArray(manifest.commands) && manifest.commands.length > 0) {
+			entry.commands = manifest.commands;
+		}
+		nameToSlug.set(pkg.name, entry.slug);
+		if (type === "software") {
+			const depNames = Object.keys(pkg.dependencies ?? {}).filter((name) =>
+				name.startsWith("@agentos-software/"),
+			);
+			if (depNames.length > 0) pendingIncludes.push({ entry, depNames });
+		}
 		if (type === "agent") {
 			// Every agent has a docs page; link it even for plain "available"
 			// entries (which keep their npm install rendering). Agents whose
@@ -73,6 +109,21 @@ for (const type of ["agent", "software"]) {
 	}
 }
 
+for (const { entry, depNames } of pendingIncludes) {
+	const includes = [];
+	for (const name of depNames) {
+		const slug = nameToSlug.get(name);
+		if (!slug) {
+			// A dep without a registry block (unlisted) shouldn't sink the whole
+			// meta-package listing.
+			console.warn(`gen-registry: ${entry.slug} depends on unlisted ${name}`);
+			continue;
+		}
+		includes.push(slug);
+	}
+	if (includes.length > 0) entry.includes = includes;
+}
+
 const seen = new Set();
 for (const entry of entries) {
 	if (seen.has(entry.slug)) {
@@ -80,6 +131,12 @@ for (const entry of entries) {
 		process.exit(1);
 	}
 	seen.add(entry.slug);
+	if (entry.icon && !KNOWN_ICONS.has(entry.icon)) {
+		console.error(
+			`gen-registry: ${entry.slug} references unknown icon "${entry.icon}" (add it to website/src/data/registry-icons.ts and KNOWN_ICONS above)`,
+		);
+		process.exit(1);
+	}
 	if (entry.image) {
 		const imagePath = join(websiteDir, "public", entry.image);
 		if (!existsSync(imagePath)) {

--- a/website/src/components/marketing/registry/RegistryPageClient.tsx
+++ b/website/src/components/marketing/registry/RegistryPageClient.tsx
@@ -2,53 +2,78 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import type { RegistryEntry } from "../../../data/registry";
+import { REQUEST_EXTENSION_URL, type RegistryEntry } from "../../../data/registry";
 import { REGISTRY_ICONS } from "../../../data/registry-icons";
 
-const CATEGORY_ORDER: { type: string; label: string; description: string }[] = [
+const CATEGORY_ORDER: {
+	type: string;
+	id: string;
+	label: string;
+	description: string;
+}[] = [
 	{
 		type: "agent",
+		id: "agents",
 		label: "Agents",
 		description:
 			"Coding agents with programmatic API access and universal transcript format (ACP).",
 	},
 	{
 		type: "file-system",
+		id: "file-systems",
 		label: "File Systems",
 		description:
 			"Mount these file systems as the root or at any sub-path inside the agent's environment.",
 	},
 	{
 		type: "browser",
+		id: "browsers",
 		label: "Browsers",
 		description:
 			"Let agents browse the web from inside the VM with cloud browser providers.",
 	},
 	{
 		type: "sandbox-extension",
+		id: "sandbox-mounting",
 		label: "Sandbox Mounting",
 		description:
 			"agentOS is a hybrid OS. Mount sandbox file systems and interact with them via tools for heavier workloads. Use agentOS natively for lightweight tasks.",
 	},
 	{
 		type: "software",
+		id: "software",
 		label: "Software",
 		description:
 			"Wasm command packages that run inside the agent's environment. Install individually or use meta-packages.",
 	},
 	{
 		type: "tool",
+		id: "bindings",
 		label: "Bindings",
 		description:
 			"Host-side tools and integrations that extend agent capabilities.",
 	},
 	{
 		type: "deploy",
+		id: "deploy",
 		label: "Deploy",
 		description:
 			"Run agentOS in production on the platform of your choice.",
 	},
 ];
+
+// Includes commands so searching "rg" surfaces ripgrep and "ls" coreutils.
+function entryHaystack(entry: RegistryEntry): string {
+	return [
+		entry.title,
+		entry.description,
+		entry.slug,
+		"package" in entry ? (entry.package ?? "") : "",
+		...(entry.commands ?? []),
+	]
+		.join(" ")
+		.toLowerCase();
+}
 
 const MAX_GRID_ITEMS = 9;
 const CAROUSEL_INTERVAL = 5000;
@@ -83,8 +108,10 @@ function EntryIcon({
 		);
 	}
 
-	if (entry.icon) {
-		const IconComponent = REGISTRY_ICONS[entry.icon];
+	// A stale committed registry.json can carry an icon name this bundle does
+	// not know; fall through to the monogram instead of rendering undefined.
+	const IconComponent = entry.icon ? REGISTRY_ICONS[entry.icon] : undefined;
+	if (IconComponent) {
 		return (
 			<IconComponent
 				style={{ width: size, height: size }}
@@ -133,8 +160,8 @@ function MonoIcon({
 		);
 	}
 
-	if (entry.icon) {
-		const IconComponent = REGISTRY_ICONS[entry.icon];
+	const IconComponent = entry.icon ? REGISTRY_ICONS[entry.icon] : undefined;
+	if (IconComponent) {
 		return (
 			<IconComponent
 				style={{ width: size, height: size }}
@@ -279,27 +306,33 @@ function FeaturedCarousel({
 }
 
 function CategorySection({
+	id,
 	label,
 	description,
 	entries,
 	theme,
 	hrefBase,
+	showAll = false,
 }: {
+	id: string;
 	label: string;
 	description: string;
 	entries: RegistryEntry[];
 	theme: RegistryTheme;
 	hrefBase: string;
+	// While searching, truncation would hide matches behind the "+N" tile.
+	showAll?: boolean;
 }) {
 	const [expanded, setExpanded] = useState(false);
-	const needsShowAll = entries.length > MAX_GRID_ITEMS;
-	const visible = expanded
+	const showEverything = expanded || showAll;
+	const needsShowAll = !showEverything && entries.length > MAX_GRID_ITEMS;
+	const visible = showEverything
 		? entries
 		: entries.slice(0, MAX_GRID_ITEMS - (needsShowAll ? 1 : 0));
 	const light = theme === "light";
 
 	return (
-		<section className="mb-12">
+		<section id={id} className="mb-12 scroll-mt-28">
 			<h2
 				className={
 					light
@@ -377,7 +410,7 @@ function CategorySection({
 					</a>
 				))}
 
-				{needsShowAll && !expanded && (
+				{needsShowAll && (
 					<button
 						onClick={() => setExpanded(true)}
 						className={
@@ -423,17 +456,56 @@ export default function RegistryPageClient({
 	const featured = entries.filter((entry) => entry.featured);
 	const light = theme === "light";
 
-	const categories = CATEGORY_ORDER.map(({ type, label, description }) => ({
+	const [query, setQuery] = useState("");
+	const search = query.trim().toLowerCase();
+	const visibleEntries = search
+		? entries.filter((entry) => entryHaystack(entry).includes(search))
+		: entries;
+
+	const categories = CATEGORY_ORDER.map(({ type, id, label, description }) => ({
+		id,
 		label,
 		description,
-		entries: entries.filter((entry) =>
+		entries: visibleEntries.filter((entry) =>
 			entry.types.includes(type as RegistryEntry["types"][number]),
 		),
 	})).filter((category) => category.entries.length > 0);
 
 	return (
 		<>
-			{featured.length > 0 && (
+			<div className="mb-10">
+				<input
+					type="search"
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
+					placeholder="Search the registry…"
+					aria-label="Search the registry"
+					className={
+						light
+							? "w-full rounded-lg border border-ink/10 bg-white/55 px-4 py-2.5 text-sm text-ink placeholder:text-ink-faint focus:border-ink/30 focus:outline-none"
+							: "w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+					}
+				/>
+				{categories.length > 1 && (
+					<div className="mt-4 flex flex-wrap justify-center gap-2">
+						{categories.map((category) => (
+							<a
+								key={category.id}
+								href={`#${category.id}`}
+								className={
+									light
+										? "rounded-full border border-ink/15 px-3 py-1 text-xs text-ink-soft no-underline transition-colors hover:border-ink/40 hover:text-ink"
+										: "rounded-full border border-white/20 px-3 py-1 text-xs text-white/60 no-underline transition-colors hover:border-white/40 hover:text-white"
+								}
+							>
+								{category.label}
+							</a>
+						))}
+					</div>
+				)}
+			</div>
+
+			{!search && featured.length > 0 && (
 				<FeaturedCarousel
 					entries={featured}
 					theme={theme}
@@ -441,14 +513,38 @@ export default function RegistryPageClient({
 				/>
 			)}
 
+			{search && categories.length === 0 && (
+				<div className="py-16 text-center">
+					<p
+						className={
+							light ? "mb-4 text-sm text-ink-soft" : "mb-4 text-sm text-white/60"
+						}
+					>
+						No matches for &ldquo;{query.trim()}&rdquo;
+					</p>
+					<button
+						onClick={() => setQuery("")}
+						className={
+							light
+								? "rounded-lg border border-ink/20 px-4 py-2 text-sm font-medium text-ink-soft transition-colors hover:border-ink/40 hover:text-ink"
+								: "rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:border-white/40 hover:text-white"
+						}
+					>
+						Clear search
+					</button>
+				</div>
+			)}
+
 			{categories.map((category) => (
 				<CategorySection
 					key={category.label}
+					id={category.id}
 					label={category.label}
 					description={category.description}
 					entries={category.entries}
 					theme={theme}
 					hrefBase={hrefBase}
+					showAll={search.length > 0}
 				/>
 			))}
 
@@ -494,7 +590,7 @@ export default function RegistryPageClient({
 						</svg>
 					</a>
 					<a
-						href="https://github.com/rivet-dev/agentos/issues"
+						href={REQUEST_EXTENSION_URL}
 						target="_blank"
 						rel="noopener noreferrer"
 						className={

--- a/website/src/data/registry-icons.ts
+++ b/website/src/data/registry-icons.ts
@@ -1,17 +1,46 @@
 import type { LucideIcon } from "lucide-react";
-import { Database, Globe, HardDrive, Monitor, Wrench } from "lucide-react";
+import {
+	Archive,
+	ArchiveRestore,
+	Braces,
+	Database,
+	Download,
+	FilePen,
+	FileQuestion,
+	FileSearch,
+	FolderTree,
+	Globe,
+	Hammer,
+	HardDrive,
+	Monitor,
+	Package,
+	Search,
+	Wrench,
+} from "lucide-react";
 
 // Registry entries reference icons by name (a serializable string) rather than
 // by component. Passing a Lucide component through the Astro `client:load`
 // island prop boundary mangles it (forwardRef objects don't survive devalue
 // serialization), which throws on hydration and blanks the page. Resolve the
 // name to a component in code on each side of the boundary instead.
+// Keep the name list in sync with KNOWN_ICONS in scripts/gen-registry.mjs.
 export type RegistryIconName =
 	| "HardDrive"
 	| "Database"
 	| "Monitor"
 	| "Globe"
-	| "Wrench";
+	| "Wrench"
+	| "Search"
+	| "FileSearch"
+	| "FolderTree"
+	| "Archive"
+	| "ArchiveRestore"
+	| "Braces"
+	| "FileQuestion"
+	| "Download"
+	| "FilePen"
+	| "Package"
+	| "Hammer";
 
 export const REGISTRY_ICONS: Record<RegistryIconName, LucideIcon> = {
 	HardDrive,
@@ -19,4 +48,15 @@ export const REGISTRY_ICONS: Record<RegistryIconName, LucideIcon> = {
 	Monitor,
 	Globe,
 	Wrench,
+	Search,
+	FileSearch,
+	FolderTree,
+	Archive,
+	ArchiveRestore,
+	Braces,
+	FileQuestion,
+	Download,
+	FilePen,
+	Package,
+	Hammer,
 };

--- a/website/src/data/registry.ts
+++ b/website/src/data/registry.ts
@@ -28,6 +28,12 @@ export interface RegistryEntryBase {
 	docsHref?: string;
 	// The session agent id, set for all generated agent entries.
 	agentId?: string;
+	// Guest commands the package links under /opt/agentos/bin (from the package
+	// manifest's `commands` list). Rendered on software detail pages and
+	// searchable on the registry index.
+	commands?: string[];
+	// Meta-packages: slugs of the registry entries this package bundles.
+	includes?: string[];
 }
 
 export interface RegistryEntryAvailable extends RegistryEntryBase {
@@ -88,6 +94,16 @@ export type RegistryEntry =
 // mounting) are curated by hand below.
 import generated from "../generated/registry.json";
 import { DEPLOY_TARGETS } from "./deploy-targets";
+
+// Prefilled new-issue URL for the "Request an Extension" CTAs (registry hero
+// and footer). No `labels=` param — GitHub silently drops it for users without
+// triage permission.
+export const REQUEST_EXTENSION_URL = `https://github.com/rivet-dev/agentos/issues/new?${new URLSearchParams(
+	{
+		title: "Registry request: ",
+		body: "**What package or extension do you need?**\n\n**What would you use it for?**\n",
+	},
+)}`;
 
 // Featured is a website decision, not package metadata: generated entries
 // with a slug in this set get the featured treatment on the registry page.

--- a/website/src/generated/registry.json
+++ b/website/src/generated/registry.json
@@ -80,7 +80,13 @@
 			],
 			"priority": 100,
 			"package": "@agentos-software/build-essential",
-			"status": "available"
+			"status": "available",
+			"icon": "Hammer",
+			"includes": [
+				"common",
+				"curl",
+				"git"
+			]
 		},
 		{
 			"slug": "common",
@@ -91,7 +97,18 @@
 			],
 			"priority": 95,
 			"package": "@agentos-software/common",
-			"status": "available"
+			"status": "available",
+			"icon": "Package",
+			"includes": [
+				"coreutils",
+				"sed",
+				"grep",
+				"gawk",
+				"findutils",
+				"diffutils",
+				"tar",
+				"gzip"
+			]
 		},
 		{
 			"slug": "git",
@@ -103,7 +120,10 @@
 			"priority": 90,
 			"package": "@agentos-software/git",
 			"status": "available",
-			"image": "/images/registry/git.svg"
+			"image": "/images/registry/git.svg",
+			"commands": [
+				"git"
+			]
 		},
 		{
 			"slug": "ripgrep",
@@ -114,7 +134,11 @@
 			],
 			"priority": 85,
 			"package": "@agentos-software/ripgrep",
-			"status": "available"
+			"status": "available",
+			"icon": "Search",
+			"commands": [
+				"rg"
+			]
 		},
 		{
 			"slug": "jq",
@@ -126,7 +150,10 @@
 			"priority": 80,
 			"package": "@agentos-software/jq",
 			"status": "available",
-			"image": "/images/registry/jq.svg"
+			"image": "/images/registry/jq.svg",
+			"commands": [
+				"jq"
+			]
 		},
 		{
 			"slug": "sqlite3",
@@ -138,7 +165,10 @@
 			"priority": 75,
 			"package": "@agentos-software/sqlite3",
 			"status": "available",
-			"image": "/images/registry/sqlite3.svg"
+			"image": "/images/registry/sqlite3.svg",
+			"commands": [
+				"sqlite3"
+			]
 		},
 		{
 			"slug": "duckdb",
@@ -150,7 +180,10 @@
 			"priority": 70,
 			"package": "@agentos-software/duckdb",
 			"status": "available",
-			"image": "/images/registry/duckdb.svg"
+			"image": "/images/registry/duckdb.svg",
+			"commands": [
+				"duckdb"
+			]
 		},
 		{
 			"slug": "vim",
@@ -162,7 +195,10 @@
 			"priority": 65,
 			"package": "@agentos-software/vim",
 			"status": "available",
-			"image": "/images/registry/vim.svg"
+			"image": "/images/registry/vim.svg",
+			"commands": [
+				"vim"
+			]
 		},
 		{
 			"slug": "tar",
@@ -174,7 +210,10 @@
 			"priority": 60,
 			"package": "@agentos-software/tar",
 			"status": "available",
-			"image": "/images/registry/tar.svg"
+			"image": "/images/registry/tar.svg",
+			"commands": [
+				"tar"
+			]
 		},
 		{
 			"slug": "wget",
@@ -186,7 +225,10 @@
 			"priority": 55,
 			"package": "@agentos-software/wget",
 			"status": "available",
-			"image": "/images/registry/wget.svg"
+			"image": "/images/registry/wget.svg",
+			"commands": [
+				"wget"
+			]
 		},
 		{
 			"slug": "curl",
@@ -198,7 +240,10 @@
 			"priority": 50,
 			"package": "@agentos-software/curl",
 			"status": "available",
-			"image": "/images/registry/curl.svg"
+			"image": "/images/registry/curl.svg",
+			"commands": [
+				"curl"
+			]
 		},
 		{
 			"slug": "coreutils",
@@ -210,7 +255,96 @@
 			"priority": 45,
 			"package": "@agentos-software/coreutils",
 			"status": "available",
-			"image": "/images/registry/coreutils.svg"
+			"image": "/images/registry/coreutils.svg",
+			"commands": [
+				"sh",
+				"arch",
+				"b2sum",
+				"base32",
+				"base64",
+				"basename",
+				"basenc",
+				"cat",
+				"chmod",
+				"cksum",
+				"column",
+				"comm",
+				"cp",
+				"cut",
+				"date",
+				"dd",
+				"dircolors",
+				"dirname",
+				"du",
+				"echo",
+				"env",
+				"expand",
+				"expr",
+				"factor",
+				"false",
+				"fmt",
+				"fold",
+				"head",
+				"join",
+				"link",
+				"ln",
+				"logname",
+				"ls",
+				"md5sum",
+				"mkdir",
+				"mktemp",
+				"mv",
+				"nice",
+				"nl",
+				"nohup",
+				"nproc",
+				"numfmt",
+				"od",
+				"paste",
+				"pathchk",
+				"printenv",
+				"printf",
+				"ptx",
+				"pwd",
+				"readlink",
+				"realpath",
+				"rev",
+				"rm",
+				"rmdir",
+				"seq",
+				"sha1sum",
+				"sha224sum",
+				"sha256sum",
+				"sha384sum",
+				"sha512sum",
+				"shred",
+				"shuf",
+				"sleep",
+				"sort",
+				"split",
+				"stat",
+				"stdbuf",
+				"strings",
+				"sum",
+				"tac",
+				"tail",
+				"tee",
+				"test",
+				"timeout",
+				"touch",
+				"tr",
+				"true",
+				"truncate",
+				"tsort",
+				"uname",
+				"unexpand",
+				"uniq",
+				"unlink",
+				"wc",
+				"which",
+				"whoami",
+				"yes"
+			]
 		},
 		{
 			"slug": "grep",
@@ -222,7 +356,10 @@
 			"priority": 40,
 			"package": "@agentos-software/grep",
 			"status": "available",
-			"image": "/images/registry/grep.svg"
+			"image": "/images/registry/grep.svg",
+			"commands": [
+				"grep"
+			]
 		},
 		{
 			"slug": "sed",
@@ -234,7 +371,10 @@
 			"priority": 35,
 			"package": "@agentos-software/sed",
 			"status": "available",
-			"image": "/images/registry/sed.svg"
+			"image": "/images/registry/sed.svg",
+			"commands": [
+				"sed"
+			]
 		},
 		{
 			"slug": "fd",
@@ -245,7 +385,11 @@
 			],
 			"priority": 30,
 			"package": "@agentos-software/fd",
-			"status": "available"
+			"status": "available",
+			"icon": "FileSearch",
+			"commands": [
+				"fd"
+			]
 		},
 		{
 			"slug": "tree",
@@ -256,7 +400,11 @@
 			],
 			"priority": 25,
 			"package": "@agentos-software/tree",
-			"status": "available"
+			"status": "available",
+			"icon": "FolderTree",
+			"commands": [
+				"tree"
+			]
 		},
 		{
 			"slug": "gawk",
@@ -268,7 +416,10 @@
 			"priority": 20,
 			"package": "@agentos-software/gawk",
 			"status": "available",
-			"image": "/images/registry/gawk.svg"
+			"image": "/images/registry/gawk.svg",
+			"commands": [
+				"awk"
+			]
 		},
 		{
 			"slug": "findutils",
@@ -280,7 +431,11 @@
 			"priority": 15,
 			"package": "@agentos-software/findutils",
 			"status": "available",
-			"image": "/images/registry/findutils.svg"
+			"image": "/images/registry/findutils.svg",
+			"commands": [
+				"find",
+				"xargs"
+			]
 		},
 		{
 			"slug": "zip",
@@ -291,7 +446,11 @@
 			],
 			"priority": 12,
 			"package": "@agentos-software/zip",
-			"status": "available"
+			"status": "available",
+			"icon": "Archive",
+			"commands": [
+				"zip"
+			]
 		},
 		{
 			"slug": "unzip",
@@ -302,7 +461,11 @@
 			],
 			"priority": 10,
 			"package": "@agentos-software/unzip",
-			"status": "available"
+			"status": "available",
+			"icon": "ArchiveRestore",
+			"commands": [
+				"unzip"
+			]
 		},
 		{
 			"slug": "gzip",
@@ -314,7 +477,10 @@
 			"priority": 8,
 			"package": "@agentos-software/gzip",
 			"status": "available",
-			"image": "/images/registry/gzip.svg"
+			"image": "/images/registry/gzip.svg",
+			"commands": [
+				"gzip"
+			]
 		},
 		{
 			"slug": "diffutils",
@@ -326,7 +492,10 @@
 			"priority": 6,
 			"package": "@agentos-software/diffutils",
 			"status": "available",
-			"image": "/images/registry/diffutils.svg"
+			"image": "/images/registry/diffutils.svg",
+			"commands": [
+				"diff"
+			]
 		},
 		{
 			"slug": "yq",
@@ -337,7 +506,11 @@
 			],
 			"priority": 4,
 			"package": "@agentos-software/yq",
-			"status": "available"
+			"status": "available",
+			"icon": "Braces",
+			"commands": [
+				"yq"
+			]
 		},
 		{
 			"slug": "file",
@@ -348,7 +521,11 @@
 			],
 			"priority": 2,
 			"package": "@agentos-software/file",
-			"status": "available"
+			"status": "available",
+			"icon": "FileQuestion",
+			"commands": [
+				"file"
+			]
 		},
 		{
 			"slug": "codex-cli",
@@ -360,7 +537,11 @@
 			"priority": 0,
 			"package": "@agentos-software/codex-cli",
 			"status": "available",
-			"image": "/images/registry/codex.svg"
+			"image": "/images/registry/codex.svg",
+			"commands": [
+				"codex",
+				"codex-exec"
+			]
 		},
 		{
 			"slug": "http-get",
@@ -371,7 +552,11 @@
 			],
 			"priority": 0,
 			"package": "@agentos-software/http-get",
-			"status": "available"
+			"status": "available",
+			"icon": "Download",
+			"commands": [
+				"http_get"
+			]
 		},
 		{
 			"slug": "vix",
@@ -382,7 +567,11 @@
 			],
 			"priority": 0,
 			"package": "@agentos-software/vix",
-			"status": "available"
+			"status": "available",
+			"icon": "FilePen",
+			"commands": [
+				"vix"
+			]
 		}
 	]
 }

--- a/website/src/pages/registry/[slug].astro
+++ b/website/src/pages/registry/[slug].astro
@@ -145,6 +145,73 @@ const exampleHtml = exampleSource
 	? await highlightCodeHtml(exampleSource, "ts")
 	: null;
 
+// The registry ships in-repo WASM builds and most do not implement `--help`
+// (the fallback), so each override below is verified against its source under
+// registry/native. `null` means the command has no clean non-interactive demo
+// (needs a live server, an existing archive, network egress, or a TTY) — the
+// run section is skipped for those.
+const RUN_COMMAND_OVERRIDES: Record<string, string | null> = {
+	coreutils: "ls /home/agentos",
+	diffutils: null,
+	duckdb: "duckdb -c 'select 42;'",
+	file: "echo hello | file -",
+	findutils: "find /home/agentos -type d",
+	gawk: "echo 'hello world' | gawk '{print $2}'",
+	git: "git init",
+	grep: "echo agentos | grep agent",
+	"http-get": null,
+	jq: "echo 1 | jq '. + 1'",
+	ripgrep: "rg --files-with-matches TODO /home/agentos",
+	sed: "echo hello | sed s/hello/world/",
+	sqlite3: "sqlite3 :memory: 'select 1+1;'",
+	tree: "tree /home/agentos",
+	unzip: null,
+	vix: null,
+	wget: null,
+	yq: "echo 'name: agentos' | yq .name",
+	zip: "echo hello > hello.txt && zip demo.zip hello.txt",
+};
+
+const commandList = isSoftware ? (entry.commands ?? []) : [];
+const runCommand = commandList.length
+	? entry.slug in RUN_COMMAND_OVERRIDES
+		? RUN_COMMAND_OVERRIDES[entry.slug]
+		: `${commandList[0]} --help`
+	: null;
+// The command the snippet showcases: the first token of the invocation that
+// is one of the package's own commands (overrides may pipe through `echo`).
+const runShowcased = runCommand
+	? (runCommand.split(/\s+/).find((token) => commandList.includes(token)) ??
+		commandList[0])
+	: null;
+const runSource = runCommand
+	? `import { createClient } from "@rivet-dev/agentos/client";
+import type { registry } from "./server";
+
+const client = createClient<typeof registry>({
+  endpoint: "http://localhost:6420",
+});
+const agent = client.vm.getOrCreate("my-agent");
+
+// \`${runShowcased}\` is now available inside the VM.
+const result = await agent.exec("${runCommand}");
+console.log(result.stdout);`
+	: null;
+const runHtml = runSource ? await highlightCodeHtml(runSource, "ts") : null;
+
+// Command chips: coreutils ships 87 commands, so cap the always-visible list
+// and tuck the rest behind a native <details> (this page is static, no island).
+const COMMAND_CHIP_CAP = 24;
+const visibleCommands = commandList.slice(0, COMMAND_CHIP_CAP);
+const hiddenCommands = commandList.slice(COMMAND_CHIP_CAP);
+const commandChipClass =
+	"rounded border border-ink/10 bg-white/55 px-2 py-1 font-mono text-[12px] text-ink-soft";
+
+// Meta-packages: resolve bundled slugs to live entries for title + link.
+const includedEntries = (isSoftware ? (entry.includes ?? []) : [])
+	.map((slug) => registry.find((candidate) => candidate.slug === slug))
+	.filter((candidate) => candidate !== undefined);
+
 // Plain npm install is only shown for entries that aren't software or
 // sandbox-mounting (those show a registration example instead).
 const installCmd =
@@ -288,6 +355,68 @@ const EntryIcon = entry.icon ? REGISTRY_ICONS[entry.icon] : undefined;
 							<div class="overflow-x-auto px-5 py-4 font-mono text-[13px] leading-relaxed" set:html={exampleHtml} />
 						</InkPanel>
 					</section>
+
+					{runHtml && (
+						<section>
+							<h2 class="mb-3 text-xl font-medium text-ink">3. Run a command</h2>
+							<p class="mb-4 text-sm text-ink-soft">
+								Its commands are on the VM's{" "}
+								<code class="rounded bg-ink/5 px-1.5 py-0.5 font-mono text-[13px] text-ink">$PATH</code>{" "}
+								— run them from your client with{" "}
+								<code class="rounded bg-ink/5 px-1.5 py-0.5 font-mono text-[13px] text-ink">exec</code>.
+							</p>
+							<InkPanel className="mb-8">
+								<div class="overflow-x-auto px-5 py-4 font-mono text-[13px] leading-relaxed" set:html={runHtml} />
+							</InkPanel>
+						</section>
+					)}
+
+					{visibleCommands.length > 0 && (
+						<section class="mb-8">
+							<h2 class="mb-3 text-xl font-medium text-ink">Commands</h2>
+							<p class="mb-4 text-sm text-ink-soft">
+								Linked under{" "}
+								<code class="rounded bg-ink/5 px-1.5 py-0.5 font-mono text-[13px] text-ink">/opt/agentos/bin</code>{" "}
+								inside the VM:
+							</p>
+							<div class="flex flex-wrap gap-2">
+								{visibleCommands.map((cmd) => (
+									<code class={commandChipClass}>{cmd}</code>
+								))}
+							</div>
+							{hiddenCommands.length > 0 && (
+								<details class="mt-3">
+									<summary class="cursor-pointer text-sm text-ink-faint transition-colors hover:text-ink">
+										Show {hiddenCommands.length} more
+									</summary>
+									<div class="mt-3 flex flex-wrap gap-2">
+										{hiddenCommands.map((cmd) => (
+											<code class={commandChipClass}>{cmd}</code>
+										))}
+									</div>
+								</details>
+							)}
+						</section>
+					)}
+
+					{includedEntries.length > 0 && (
+						<section class="mb-8">
+							<h2 class="mb-3 text-xl font-medium text-ink">Includes</h2>
+							<p class="mb-4 text-sm text-ink-soft">
+								Registering this meta-package brings in these packages:
+							</p>
+							<div class="flex flex-wrap gap-2">
+								{includedEntries.map((included) => (
+									<a
+										href={`/registry/${included.slug}`}
+										class="rounded-lg border border-ink/20 px-3 py-1.5 font-mono text-sm text-ink-soft no-underline transition-colors hover:border-ink/40 hover:text-ink"
+									>
+										{included.title}
+									</a>
+								))}
+							</div>
+						</section>
+					)}
 
 					<div class="flex flex-wrap gap-3">
 						<a

--- a/website/src/pages/registry/index.astro
+++ b/website/src/pages/registry/index.astro
@@ -3,13 +3,13 @@ import Layout from "../../layouts/Layout.astro";
 import { Navigation } from "../../components/Navigation";
 import { Footer } from "../../components/Footer";
 import RegistryPageClient from "../../components/marketing/registry/RegistryPageClient";
-import { registry } from "../../data/registry";
+import { registry, REQUEST_EXTENSION_URL } from "../../data/registry";
 import { HERO_H1_CLASS } from "../../components/marketing/typography";
 ---
 
 <Layout
   title="agentOS Registry"
-  description="Browse agents, tools, file systems, and sandbox mounting for agentOS."
+  description="Browse agents, software packages, file systems, browsers, sandbox mounting, and deploy targets for agentOS."
 >
   <Navigation client:load />
   <main class="paper-grain min-h-screen w-full font-sans text-ink-soft" style="overflow-x: clip;">
@@ -19,7 +19,7 @@ import { HERO_H1_CLASS } from "../../components/marketing/typography";
           agentOS Registry
         </h1>
         <p class="mx-auto mt-6 max-w-3xl text-lg leading-relaxed text-ink-soft md:text-xl">
-          Browse agents, tools, file systems, and sandbox mounting for agentOS.
+          Browse agents, software packages, file systems, browsers, sandbox mounting, and deploy targets for agentOS.
         </p>
         <div class="mt-8 flex items-center justify-center gap-3">
           <a
@@ -32,7 +32,7 @@ import { HERO_H1_CLASS } from "../../components/marketing/typography";
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
           </a>
           <a
-            href="https://github.com/rivet-dev/agentos/issues"
+            href={REQUEST_EXTENSION_URL}
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 rounded-lg border border-ink/20 px-5 py-2.5 text-sm font-medium text-ink-soft no-underline transition-colors hover:border-ink/40 hover:text-ink"


### PR DESCRIPTION
Updates the `/registry` page to keep up with the now auto-generated catalog.

- **Browse UX**: client-side search box (matches title, description, package name, and provided commands) plus a category jump-nav; hero copy now names all current categories.
- **Detail pages**: software entries show their provided commands (coreutils' 87 collapse behind a `<details>`), meta-packages list what they bundle with links, and each gets a runnable `exec` example verified against the in-repo WASM builds.
- **Polish**: the 11 previously icon-less entries get Lucide icons; both "Request an Extension" CTAs open a prefilled new-issue form.
- Generator passes `commands`/`includes` through and fails the build on an unknown icon name; `registry.json` regenerated.