### PR TITLE
fix(execution): stop presuming stdio is a TTY under kernel-stdio sync RPC

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -790,7 +790,13 @@ const stdioTtyCache = new Map();
 function stdioFdIsKernelTty(fd) {
   const descriptor = Number(fd) >>> 0;
   if (descriptor > 2) return false;
-  if (KERNEL_STDIO_SYNC_RPC) return true;
+  // Even in kernel-stdio sync-RPC mode the answer must come from the kernel:
+  // that mode is on for EVERY sidecar wasm execution, including piped
+  // vm.exec() runs whose stdio is NOT a PTY. Hardcoding true here made
+  // non-interactive shells think they had a terminal (fd_fdstat_get reported
+  // CHARACTER_DEVICE, host_tty.isatty said 1), so they enabled raw mode and
+  // the kernel's truthful "not a PTY end" refusal trapped the guest with
+  // exit 1 after otherwise-successful commands.
   if (stdioTtyCache.has(descriptor)) return stdioTtyCache.get(descriptor);
   let isTty = false;
   try {

--- a/packages/core/tests/brush-interactive.test.ts
+++ b/packages/core/tests/brush-interactive.test.ts
@@ -121,7 +121,7 @@ describe.skipIf(REGISTRY_SH === undefined)("brush interactive PTY repaint", () =
 		const { AgentOs } = await import("../src/index.js");
 		term = new Terminal({ cols: 80, rows: 14, allowProposedApi: true });
 		vm = await AgentOs.create({
-			software: [{ packageDir: fixtureDir }],
+			software: [{ packagePath: fixtureDir }],
 		});
 
 		({ shellId } = vm.openShell({
@@ -178,7 +178,7 @@ describe.skipIf(REGISTRY_SH === undefined)("brush interactive PTY repaint", () =
 		const { AgentOs } = await import("../src/index.js");
 		term = new Terminal({ cols: 80, rows: 14, allowProposedApi: true });
 		vm = await AgentOs.create({
-			software: [{ packageDir: fixtureDir }],
+			software: [{ packagePath: fixtureDir }],
 		});
 		await vm.writeFile("/tmp/marker.txt", "child-once-marker\n");
 

--- a/packages/core/tests/helpers/projected-agent-package.ts
+++ b/packages/core/tests/helpers/projected-agent-package.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import {
 	chmodSync,
 	mkdirSync,
@@ -61,21 +60,10 @@ export function createProjectedAgentPackage(
 	writeFileSync(binPath, `#!/usr/bin/env node\n${options.adapterScript}\n`);
 	chmodSync(binPath, 0o755);
 
-	// The sidecar mounts packages from `<dir>/package.tar` (directory projection is
-	// not supported); tar the built tree and hand back the dir that contains it.
-	const packDir = join(root, "packed");
-	mkdirSync(packDir, { recursive: true });
-	execFileSync("tar", [
-		"-cf",
-		join(packDir, "package.tar"),
-		"-C",
-		packageDir,
-		".",
-	]);
-
 	return {
 		packageDir,
-		software: { packageDir: packDir },
+		// `packagePath` accepts a transition package dir for local fixtures.
+		software: { packagePath: packageDir },
 		binPath,
 		cleanup: () => rmSync(root, { recursive: true, force: true }),
 	};

--- a/packages/core/tests/helpers/registry-commands.ts
+++ b/packages/core/tests/helpers/registry-commands.ts
@@ -1,11 +1,16 @@
 /**
  * Registry software packages for tests — STRICT, no silent skips.
  *
- * Every `@agentos-software/*` package exports `{ packageDir }` pointing at its
- * registry-built runtime dir (`dist/package/`). Importing this helper THROWS
- * with build instructions when a standard package is not built, instead of
- * letting suites silently skip: with the committed file-linked deps, "not
- * built" always means the sibling secure-exec registry needs building.
+ * Every `@agentos-software/*` package exports `{ packagePath }` pointing at its
+ * packed `.aospkg` (`dist/package.aospkg`). Importing this helper THROWS with
+ * build instructions when a standard package is not built, instead of letting
+ * suites silently skip: with the committed file-linked deps, "not built"
+ * always means the sibling registry needs building.
+ *
+ * Built-ness is checked against the `.aospkg` itself (present, non-trivial,
+ * correct magic) plus the sibling `dist/package/` transition dir's bin map
+ * when it exists (local registry builds produce both), so a stale or empty
+ * command set still fails loudly.
  *
  * The only sanctioned exception is the C-sysroot package set (duckdb,
  * http-get, sqlite3, wget, zip, unzip): those need the patched wasi C sysroot
@@ -17,11 +22,15 @@ import {
 	copyFileSync,
 	existsSync,
 	mkdirSync,
-	readFileSync,
+	openSync,
+	readdirSync,
+	readSync,
+	closeSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import codex from "@agentos-software/codex-cli";
 import coreutils from "@agentos-software/coreutils";
 import curl from "@agentos-software/curl";
@@ -40,57 +49,104 @@ import tree from "@agentos-software/tree";
 import yq from "@agentos-software/yq";
 
 export interface RegistryPackageRef {
-	packageDir: string;
+	packagePath: string;
 }
 
 const BUILD_INSTRUCTIONS =
-	"Build the registry in the sibling secure-exec checkout:\n" +
+	"Build the registry:\n" +
 	"  just registry-native   # native wasm binaries, once per checkout (slow)\n" +
-	"  just registry-build    # stage bin/ + assemble every dist/package\n" +
-	"See secure-exec registry/README.md.";
+	"  just registry-build    # stage bin/ + pack every dist/package.aospkg\n" +
+	"See registry/README.md.";
 
-/** Read a built package's `dist/package/package.json` bin map, or null. */
-function readBinMap(dir: string): Record<string, string> | null {
-	const manifestPath = join(dir, "package.json");
-	if (!existsSync(manifestPath)) return null;
+/** `.aospkg` container magic (crates/vfs/package-format/v1.bare). */
+const AOSPKG_MAGIC = Buffer.from([0x89, 0x41, 0x4f, 0x53]);
+
+/** True when the path is a plausible packed `.aospkg` (magic + header size). */
+function isPackedAospkg(path: string): boolean {
 	try {
-		const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
-			bin?: Record<string, string>;
-		};
-		return manifest.bin ?? {};
+		if (statSync(path).size <= 16) return false;
+		const fd = openSync(path, "r");
+		try {
+			const head = Buffer.alloc(4);
+			readSync(fd, head, 0, 4, 0);
+			return head.equals(AOSPKG_MAGIC);
+		} finally {
+			closeSync(fd);
+		}
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The unpacked manifest dir for a ref, when one is locally available: the
+ * transition dir itself, or the `dist/package/` sibling of a packed
+ * `dist/package.aospkg` (registry builds stage both).
+ */
+function manifestDir(pkg: RegistryPackageRef): string | null {
+	const path = pkg.packagePath;
+	const dir = path.endsWith(".aospkg")
+		? join(dirname(path), "package")
+		: path;
+	return existsSync(dir) ? dir : null;
+}
+
+/**
+ * A built package's staged commands, from its `bin/` directory listing (the
+ * transition dir carries only `agentos-package.json` + `bin/`; the command
+ * set is the packed `bin/` contents). Maps name -> package-relative path.
+ */
+function readBinMap(dir: string): Record<string, string> | null {
+	const binDir = join(dir, "bin");
+	if (!existsSync(binDir)) return null;
+	try {
+		const bin: Record<string, string> = {};
+		for (const entry of readdirSync(binDir)) {
+			bin[entry] = `bin/${entry}`;
+		}
+		return bin;
 	} catch {
 		return null;
 	}
 }
 
 function builtState(pkg: RegistryPackageRef): {
+	built: boolean;
 	bin: Record<string, string> | null;
 	missing: string[];
 } {
-	const bin = readBinMap(pkg.packageDir);
-	if (bin === null) return { bin, missing: [] };
-	const missing = Object.entries(bin)
-		.filter(([, rel]) => !existsSync(join(pkg.packageDir, rel)))
-		.map(([cmd]) => cmd);
-	return { bin, missing };
+	const packed = pkg.packagePath.endsWith(".aospkg");
+	const built = packed
+		? isPackedAospkg(pkg.packagePath)
+		: existsSync(join(pkg.packagePath, "agentos-package.json"));
+	const dir = manifestDir(pkg);
+	const bin = dir ? readBinMap(dir) : null;
+	const missing =
+		dir && bin
+			? Object.entries(bin)
+					.filter(([, rel]) => !existsSync(join(dir, rel)))
+					.map(([cmd]) => cmd)
+			: [];
+	return { built, bin, missing };
 }
 
 /**
- * Assert a registry package is built (assembled `dist/package` with a
- * non-empty, fully-present command set) and return it. Throws with build
- * instructions otherwise.
+ * Assert a registry package is built (a real packed `.aospkg`, with a
+ * non-empty, fully-present command set when the staged transition dir is
+ * available to inspect) and return it. Throws with build instructions
+ * otherwise.
  */
 export function requireBuilt<T extends RegistryPackageRef>(
 	pkg: T,
 	name: string,
 ): T {
-	const { bin, missing } = builtState(pkg);
-	if (bin === null) {
+	const { built, bin, missing } = builtState(pkg);
+	if (!built) {
 		throw new Error(
-			`registry package ${name} is NOT BUILT (no ${pkg.packageDir}/package.json).\n${BUILD_INSTRUCTIONS}`,
+			`registry package ${name} is NOT BUILT (no valid ${pkg.packagePath}).\n${BUILD_INSTRUCTIONS}`,
 		);
 	}
-	if (Object.keys(bin).length === 0) {
+	if (bin !== null && Object.keys(bin).length === 0) {
 		throw new Error(
 			`registry package ${name} is an EMPTY placeholder (no commands staged into bin/).\n${BUILD_INSTRUCTIONS}`,
 		);
@@ -106,22 +162,66 @@ export function requireBuilt<T extends RegistryPackageRef>(
 /**
  * Skip reason for the C-sysroot package set ONLY (duckdb, http-get, sqlite3,
  * wget, zip, unzip). These need the patched wasi C sysroot
- * (`make -C registry/native/c` in secure-exec), which most checkouts don't
- * build — a missing artifact is an environment limitation, not a forgotten
- * build, so suites may skip with this reason instead of throwing.
+ * (`make -C registry/native/c`), which most checkouts don't build — a missing
+ * artifact is an environment limitation, not a forgotten build, so suites may
+ * skip with this reason instead of throwing.
  */
 export function cSysrootPackageSkipReason(
 	...packages: Array<{ pkg: RegistryPackageRef; name: string }>
 ): string | false {
 	const unbuilt = packages.filter(({ pkg }) => {
-		const { bin, missing } = builtState(pkg);
-		return bin === null || Object.keys(bin).length === 0 || missing.length > 0;
+		const { built, bin, missing } = builtState(pkg);
+		return (
+			!built ||
+			(bin !== null && Object.keys(bin).length === 0) ||
+			missing.length > 0
+		);
 	});
 	if (unbuilt.length === 0) return false;
 	return (
 		`C-sysroot registry packages not built: ${unbuilt.map(({ name }) => name).join(", ")} ` +
-		"(needs the patched wasi C sysroot: `make -C registry/native/c` in secure-exec, then `just registry-build`)"
+		"(needs the patched wasi C sysroot: `make -C registry/native/c`, then `just registry-build`)"
 	);
+}
+
+/** True when a built package stages the named command (via its bin map). */
+export function packageCommandExists(
+	pkg: RegistryPackageRef,
+	command: string,
+): boolean {
+	const dir = manifestDir(pkg);
+	if (!dir) return false;
+	const bin = readBinMap(dir);
+	const rel = bin?.[command];
+	return typeof rel === "string" && existsSync(join(dir, rel));
+}
+
+/**
+ * The staged command dir (`<manifest dir>/bin`) of a built package — for
+ * harnesses that consume raw command dirs (e.g. `createWasmVmRuntime`).
+ * Throws when the staged transition dir is unavailable.
+ */
+export function packageCommandsDir(pkg: RegistryPackageRef): string {
+	const dir = manifestDir(pkg);
+	if (!dir) {
+		throw new Error(
+			`registry package has no staged transition dir next to ${pkg.packagePath}.\n${BUILD_INSTRUCTIONS}`,
+		);
+	}
+	return join(dir, "bin");
+}
+
+/** First REGISTRY_SOFTWARE package that stages the named command. Throws if none. */
+export function findPackageWithCommand(command: string): RegistryPackageRef {
+	const pkg = REGISTRY_SOFTWARE.find((candidate) =>
+		packageCommandExists(candidate, command),
+	);
+	if (!pkg) {
+		throw new Error(
+			`registry software does not provide "${command}".\n${BUILD_INSTRUCTIONS}`,
+		);
+	}
+	return pkg;
 }
 
 /** All standard registry software packages — throws at import if any is unbuilt. */
@@ -148,19 +248,20 @@ export const REGISTRY_SOFTWARE = (
 
 /**
  * Test-only commands (e.g. `xu`, a registry VM-test binary) ship in NO
- * software package — they exist only in the native build output of the linked
- * secure-exec checkout. Synthesize a minimal package around them so suites can
- * project them like any other software. Throws when the native build output is
- * absent (same build instructions as everything else).
+ * software package — they exist only in the native build output of the
+ * registry. Synthesize a minimal transition-dir package around them so suites
+ * can project them like any other software (`packagePath` accepts a package
+ * dir for local fixtures). Throws when the native build output is absent
+ * (same build instructions as everything else).
  */
 export function testOnlyCommandSoftware(
 	commands: string[] = ["xu"],
 ): RegistryPackageRef {
-	// registry/software/<pkg>/dist/package -> registry/native/.../commands, so
-	// this follows whichever secure-exec checkout the deps are linked to.
+	// registry/software/<pkg>/dist/package.aospkg -> registry/native/... — this
+	// follows whichever registry checkout the deps are linked to.
 	const nativeCommandsDir = join(
-		coreutils.packageDir,
-		"../../../..",
+		dirname(coreutils.packagePath),
+		"../../..",
 		"native/target/wasm32-wasip1/release/commands",
 	);
 	const dir = join(tmpdir(), `agentos-test-cmds-${process.pid}`);
@@ -186,5 +287,5 @@ export function testOnlyCommandSoftware(
 		join(dir, "agentos-package.json"),
 		`${JSON.stringify({ name: "agentos-test-commands" }, null, 2)}\n`,
 	);
-	return { packageDir: dir };
+	return { packagePath: dir };
 }

--- a/packages/core/tests/native-sidecar-process.test.ts
+++ b/packages/core/tests/native-sidecar-process.test.ts
@@ -36,19 +36,16 @@ import {
 } from "../src/sidecar/rpc-client.js";
 import { findCargoBinary, resolveCargoBinary } from "../src/sidecar/cargo.js";
 import { serializePermissionsForSidecar } from "../src/sidecar/permissions.js";
-import { REGISTRY_SOFTWARE } from "./helpers/registry-commands.js";
+import {
+	findPackageWithCommand,
+	packageCommandsDir,
+} from "./helpers/registry-commands.js";
 
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 const SIDECAR_BINARY = join(REPO_ROOT, "target/debug/agentos-sidecar");
-const REGISTRY_COMMANDS_DIR = (() => {
-	const commandPackage = REGISTRY_SOFTWARE.find((pkg) =>
-		pkg.commands?.some((command) => command.name === "sh"),
-	);
-	if (!commandPackage) {
-		throw new Error("registry software does not provide sh");
-	}
-	return commandPackage.commandDir;
-})();
+const REGISTRY_COMMANDS_DIR = packageCommandsDir(
+	findPackageWithCommand("sh"),
+);
 const SIGNAL_STATE_CONTROL_PREFIX = "__AGENT_OS_SIGNAL_STATE__:";
 const ALLOW_ALL_VM_PERMISSIONS = {
 	fs: "allow",

--- a/packages/core/tests/pty-line-discipline.test.ts
+++ b/packages/core/tests/pty-line-discipline.test.ts
@@ -688,7 +688,7 @@ describe("PTY line discipline matrix", () => {
 
 		const { AgentOs } = await import("../src/index.js");
 		vm = await AgentOs.create({
-			software: [{ packageDir }],
+			software: [{ packagePath: packageDir }],
 		});
 		await vm.writeFile(NODE_PROBE_GUEST_PATH, readFileSync(NODE_PROBE_SOURCE));
 	}, 180_000);

--- a/packages/core/tests/vim-interactive.test.ts
+++ b/packages/core/tests/vim-interactive.test.ts
@@ -61,7 +61,7 @@ function assertVimAvailable() {
 // sidecar projects it into `/opt/agentos/bin/vim` and registers the command, so
 // `openShell({ command: "vim" })` resolves it. Mirrors packages/shell/src/main.ts
 // and tests/pty-protocol.test.ts's package materialization.
-function materializeVimPackage(): { packageDir: string } {
+function materializeVimPackage(): { packagePath: string } {
 	const packageDir = mkdtempSync(join(tmpdir(), "agentos-vim-pkg-"));
 	const binDir = join(packageDir, "bin");
 	mkdirSync(binDir);
@@ -74,7 +74,7 @@ function materializeVimPackage(): { packageDir: string } {
 		join(packageDir, "agentos-package.json"),
 		JSON.stringify({ name: "vim" }),
 	);
-	return { packageDir };
+	return { packagePath: packageDir };
 }
 
 function screen(term: InstanceType<typeof Terminal>): string {

--- a/packages/core/tests/vim-provides.test.ts
+++ b/packages/core/tests/vim-provides.test.ts
@@ -88,7 +88,7 @@ function assertVimAvailable() {
 // package-relative path; without it, ship only the `bin/vim` command so bare vim
 // cannot source defaults.vim (the control case).
 function materializeLocalEditorsPackage(withProvides: boolean): {
-	packageDir: string;
+	packagePath: string;
 } {
 	const packageDir = mkdtempSync(join(tmpdir(), "agentos-local-editors-"));
 	const binDir = join(packageDir, "bin");
@@ -124,7 +124,7 @@ function materializeLocalEditorsPackage(withProvides: boolean): {
 			...(provides ? { provides } : {}),
 		}),
 	);
-	return { packageDir };
+	return { packagePath: packageDir };
 }
 
 function screen(term: InstanceType<typeof Terminal>): string {

--- a/packages/core/tests/vim-render.test.ts
+++ b/packages/core/tests/vim-render.test.ts
@@ -71,7 +71,7 @@ describe.skipIf(!existsSync(VIM_BINARY))("vim full-screen rendering (strict)", (
 				JSON.stringify({ name: "vim", version: "0.0.0", bin: { vim: "bin/vim" } }),
 			);
 			writeFileSync(join(dir, "agentos-package.json"), JSON.stringify({ name: "vim" }));
-			vimPkg = { packageDir: dir };
+			vimPkg = { packagePath: dir };
 		} else {
 			vimPkg = (await import("@agentos-software/vim")).default;
 		}

--- a/packages/core/tests/wasm-commands.test.ts
+++ b/packages/core/tests/wasm-commands.test.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 import curlPackage from "@agentos-software/curl";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { AgentOs } from "../src/index.js";
-import { REGISTRY_SOFTWARE } from "./helpers/registry-commands.js";
+import {
+	packageCommandExists,
+	REGISTRY_SOFTWARE,
+} from "./helpers/registry-commands.js";
 
 vi.setConfig({ testTimeout: 45_000 });
 
@@ -656,7 +659,7 @@ EOF`);
 	describe("curl", () => {
 		useDescribeVm();
 
-		const hasCurl = existsSync(join(curlPackage.commandDir, "curl"));
+		const hasCurl = packageCommandExists(curlPackage, "curl");
 
 		const CURL_SCRIPT = `
 const net = require("net");


### PR DESCRIPTION
- The wasm runner hardcoded "stdio is a kernel PTY" whenever AGENTOS_WASI_STDIO_SYNC_RPC=1 — which is now every sidecar wasm execution — so non-interactive execs saw isatty=true, shells enabled raw mode, and the kernel's truthful "not a PTY end" refusal trapped guests with exit 1 (`pwd` printed `/` but exited 1; every shell-routed wasm-commands test failed).
- Ask the kernel via __kernel_isatty instead of hardcoding true.
- Port packages/core test fixtures off removed packageDir/commandDir refs to packagePath (.aospkg), un-breaking the wasm-commands/filesystem suites at setup and converting them to the packed format users install. wasm-commands: 36 failures -> 5 (remaining are separate deletion-propagation and curl bugs, tracked in the goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)