### PR TITLE
fix(ci): pin linux glibc floor for published binaries

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,8 @@ env:
   R2_ENDPOINT: https://2a94c6a0ced8d35ea63cddc86c2681e7.r2.cloudflarestorage.com
   SIDECAR_PLATFORMS: "linux-x64-gnu linux-arm64-gnu darwin-x64 darwin-arm64"
   PUBLISH_INCLUDE_REGISTRY_PACKAGES: "1"
+  LINUX_GNU_LLVM_VERSION: "22"
+  LINUX_GNU_SYSROOT_TAG: "sysroot-20250207"
 
 jobs:
   context:
@@ -103,7 +105,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
-          key: ${{ matrix.target }}-${{ needs.context.outputs.trigger }}
+          key: ${{ matrix.target }}-${{ env.LINUX_GNU_SYSROOT_TAG }}-llvm-${{ env.LINUX_GNU_LLVM_VERSION }}-${{ needs.context.outputs.trigger }}
       - uses: actions/cache@v4
         with:
           path: ~/.cargo/.rusty_v8
@@ -111,6 +113,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-rusty-v8-
       - run: pnpm install --frozen-lockfile --filter='!@agentos/website'
+      - name: Set up Linux GNU sysroot
+        run: scripts/ci/setup-linux-gnu-sysroot.sh
       - name: Build sidecar binaries
         id: build
         run: |
@@ -128,6 +132,16 @@ jobs:
           cp "target/${{ matrix.target }}/${profile}/agentos-sidecar" "$out/agentos-sidecar"
           cp "target/${{ matrix.target }}/${profile}/agentos-native-sidecar" "$out/agentos-native-sidecar"
           echo "dir=$out" >> "$GITHUB_OUTPUT"
+      - name: Check glibc floor
+        run: |
+          scripts/ci/check-linux-glibc-floor.sh \
+            "${{ steps.build.outputs.dir }}/agentos-sidecar" \
+            "${{ steps.build.outputs.dir }}/agentos-native-sidecar"
+      - name: Smoke-run in old Linux containers
+        run: |
+          scripts/ci/smoke-linux-artifacts.sh binary \
+            "${{ steps.build.outputs.dir }}/agentos-sidecar" \
+            "${{ steps.build.outputs.dir }}/agentos-native-sidecar"
       - uses: actions/upload-artifact@v4
         with:
           name: sidecar-${{ matrix.platform }}
@@ -162,7 +176,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
-          key: plugin-${{ matrix.target }}-${{ needs.context.outputs.trigger }}
+          key: plugin-${{ matrix.target }}-${{ env.LINUX_GNU_SYSROOT_TAG }}-llvm-${{ env.LINUX_GNU_LLVM_VERSION }}-${{ needs.context.outputs.trigger }}
       - uses: actions/cache@v4
         with:
           path: ~/.cargo/.rusty_v8
@@ -170,6 +184,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-rusty-v8-
       - run: pnpm install --frozen-lockfile --filter='!@agentos/website'
+      - name: Set up Linux GNU sysroot
+        run: scripts/ci/setup-linux-gnu-sysroot.sh
       - name: Build plugin cdylib
         id: build
         run: |
@@ -186,6 +202,14 @@ jobs:
           cp "target/${{ matrix.target }}/${profile}/libagentos_actor_plugin.so" \
             "$out/libagentos_actor_plugin.so"
           echo "dir=$out" >> "$GITHUB_OUTPUT"
+      - name: Check glibc floor
+        run: |
+          scripts/ci/check-linux-glibc-floor.sh \
+            "${{ steps.build.outputs.dir }}/libagentos_actor_plugin.so"
+      - name: Smoke-run in old Linux containers
+        run: |
+          scripts/ci/smoke-linux-artifacts.sh shared-library \
+            "${{ steps.build.outputs.dir }}/libagentos_actor_plugin.so"
       - uses: actions/upload-artifact@v4
         with:
           name: plugin-${{ matrix.platform }}

--- a/scripts/ci/agentos-gettid-shim.c
+++ b/scripts/ci/agentos-gettid-shim.c
@@ -1,0 +1,24 @@
+#define _GNU_SOURCE
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef SYS_gettid
+#  if defined(__x86_64__)
+#    define SYS_gettid 186
+#  elif defined(__aarch64__)
+#    define SYS_gettid 178
+#  elif defined(__arm__)
+#    define SYS_gettid 224
+#  elif defined(__i386__)
+#    define SYS_gettid 224
+#  elif defined(__powerpc64__)
+#    define SYS_gettid 207
+#  else
+#    error "gettid syscall number unknown for this architecture"
+#  endif
+#endif
+
+pid_t gettid(void) {
+  return (pid_t)syscall(SYS_gettid);
+}

--- a/scripts/ci/check-linux-glibc-floor.sh
+++ b/scripts/ci/check-linux-glibc-floor.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+floor_minor=27
+regression_minor=32
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <elf>..." >&2
+  exit 2
+fi
+
+for artifact in "$@"; do
+  echo "Checking glibc symbol floor for ${artifact}"
+  versions="$(objdump -T "${artifact}" | grep -oE 'GLIBC_2\.[0-9]+' | sort -Vu || true)"
+
+  if [ -z "${versions}" ]; then
+    echo "No GLIBC_2.x symbols found in ${artifact}."
+    continue
+  fi
+
+  echo "${versions}"
+
+  while IFS= read -r version; do
+    minor="${version#GLIBC_2.}"
+    if [ "${minor}" -ge "${regression_minor}" ]; then
+      echo "${artifact} references ${version}; this is at or above the hard regression tripwire GLIBC_2.${regression_minor}." >&2
+      exit 1
+    fi
+    if [ "${minor}" -gt "${floor_minor}" ]; then
+      echo "${artifact} references ${version}; expected GLIBC_2.${floor_minor} or older." >&2
+      exit 1
+    fi
+  done <<< "${versions}"
+done

--- a/scripts/ci/deno-memfd-create-shim.c
+++ b/scripts/ci/deno-memfd-create-shim.c
@@ -1,0 +1,26 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_memfd_create
+#  if defined(__x86_64__)
+#    define SYS_memfd_create 319
+#  elif defined(__aarch64__)
+#    define SYS_memfd_create 279
+#  elif defined(__arm__)
+#    define SYS_memfd_create 385
+#  elif defined(__i386__)
+#    define SYS_memfd_create 356
+#  elif defined(__powerpc64__)
+#    define SYS_memfd_create 360
+#  else
+#    error "memfd_create syscall number unknown for this architecture"
+#  endif
+#endif
+
+int memfd_create(const char *name, unsigned int flags) {
+  return syscall(SYS_memfd_create, name, flags);
+}

--- a/scripts/ci/setup-linux-gnu-sysroot.sh
+++ b/scripts/ci/setup-linux-gnu-sysroot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+llvm_version="${LINUX_GNU_LLVM_VERSION:-22}"
+sysroot_tag="${LINUX_GNU_SYSROOT_TAG:-sysroot-20250207}"
+github_env="${GITHUB_ENV:?GITHUB_ENV must be set by GitHub Actions}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+. /etc/os-release
+codename="${VERSION_CODENAME:?missing VERSION_CODENAME in /etc/os-release}"
+apt_list="/etc/apt/sources.list.d/llvm-toolchain-${codename}-${llvm_version}.list"
+
+echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${llvm_version} main" \
+  | sudo dd "of=${apt_list}" > /dev/null
+curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | gpg --dearmor \
+  | sudo dd "of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg" > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  binutils \
+  "clang-${llvm_version}" \
+  "lld-${llvm_version}" \
+  xz-utils
+
+"clang-${llvm_version}" -c -o /tmp/agentos_memfd_create_shim.o \
+  scripts/ci/deno-memfd-create-shim.c -fPIC
+"clang-${llvm_version}" -c -o /tmp/agentos_gettid_shim.o \
+  scripts/ci/agentos-gettid-shim.c -fPIC
+
+sysroot_arch="$(uname -m)"
+sysroot_url="https://github.com/denoland/deno_sysroot_build/releases/download/${sysroot_tag}/sysroot-${sysroot_arch}.tar.xz"
+
+curl -fsSL "${sysroot_url}" -o /tmp/agentos-sysroot.tar.xz
+sudo rm -rf /sysroot
+cd /
+xzcat /tmp/agentos-sysroot.tar.xz | sudo tar -x
+cd "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set by GitHub Actions}"
+
+. /sysroot/.env
+
+rustflags_extra="-C linker-plugin-lto=true \
+-C linker=clang-${llvm_version} \
+-C link-arg=-fuse-ld=lld-${llvm_version} \
+-C link-arg=-ldl \
+-C link-arg=-Wl,--allow-shlib-undefined \
+-C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache \
+-C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m \
+-C link-arg=/tmp/agentos_memfd_create_shim.o \
+-C link-arg=/tmp/agentos_gettid_shim.o \
+${RUSTFLAGS:-}"
+
+{
+  echo "CC=/usr/bin/clang-${llvm_version}"
+  echo "CFLAGS=${CFLAGS:-}"
+  echo "RUSTFLAGS<<__AGENTOS_SYSROOT_RUSTFLAGS"
+  echo "${rustflags_extra}"
+  echo "__AGENTOS_SYSROOT_RUSTFLAGS"
+} >> "${github_env}"
+
+echo "Configured ${sysroot_tag} (${sysroot_arch}) with LLVM ${llvm_version}."

--- a/scripts/ci/smoke-linux-artifacts.sh
+++ b/scripts/ci/smoke-linux-artifacts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kind="${1:-}"
+shift || true
+
+if [ -z "${kind}" ] || [ "$#" -eq 0 ]; then
+  echo "usage: $0 <binary|shared-library> <artifact>..." >&2
+  exit 2
+fi
+
+case "${kind}" in
+  binary | shared-library) ;;
+  *)
+    echo "unsupported artifact kind: ${kind}" >&2
+    exit 2
+    ;;
+esac
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+if command -v docker >/dev/null 2>&1; then
+  container_runtime=docker
+elif command -v podman >/dev/null 2>&1; then
+  container_runtime=podman
+else
+  if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y podman
+  fi
+
+  if command -v podman >/dev/null 2>&1; then
+    container_runtime=podman
+  else
+    echo "docker or podman is required for Linux compatibility smoke tests" >&2
+    exit 127
+  fi
+fi
+
+run_container() {
+  "${container_runtime}" run --rm -v "${tmpdir}:/artifacts:ro" "$@"
+}
+
+for artifact in "$@"; do
+  cp "${artifact}" "${tmpdir}/$(basename "${artifact}")"
+  chmod +x "${tmpdir}/$(basename "${artifact}")"
+done
+
+for image in docker.io/library/debian:11 docker.io/library/ubuntu:20.04; do
+  for artifact in "$@"; do
+    name="$(basename "${artifact}")"
+    echo "Smoke-checking ${name} in ${image}"
+    if [ "${kind}" = "binary" ]; then
+      run_container "${image}" /bin/sh -ceu '
+        status=0
+        timeout 5s "/artifacts/$1" --version > /tmp/agentos-smoke.out 2> /tmp/agentos-smoke.err || status=$?
+        cat /tmp/agentos-smoke.out
+        cat /tmp/agentos-smoke.err >&2
+        if grep -E "GLIBC_2\\.[0-9]+.*not found|version .*GLIBC_2\\.[0-9]+" /tmp/agentos-smoke.err >&2; then
+          exit 1
+        fi
+        if [ "${status}" -eq 126 ] || [ "${status}" -eq 127 ]; then
+          exit "${status}"
+        fi
+        exit 0
+      ' sh "${name}"
+    else
+      run_container "${image}" /bin/sh -ceu '
+        ldd "/artifacts/$1"
+      ' sh "${name}"
+    fi
+  done
+done


### PR DESCRIPTION
## Summary

- Pins linux-gnu published artifacts to Deno's bionic sysroot at link time instead of inheriting the runner glibc floor.
- Adds glibc symbol-floor guards and old-container smoke checks for sidecar, runtime-sidecar, and plugin Linux artifacts.
- Adds the syscall shims required by the sysroot link path.

## Validation

- `cargo check --workspace`
- `pnpm build`
- `pnpm check-types`
- `pnpm --filter publish test`
- `pnpm --filter publish check-types`
- `node scripts/verify-fixed-versions.mjs`
- Lean preview publish: https://github.com/rivet-dev/agentos/actions/runs/28841480113
- Local npm smoke: `@rivet-dev/agentos@glibc` / `0.0.0-glibc.928bc3a` installed and verified in Debian 11 and Ubuntu 20.04 containers
