### PR TITLE
feat(pi-acp): opt-in persistent sessions via PI_SESSION_DIR

### DIFF
--- a/registry/agent/pi/src/adapter.ts
+++ b/registry/agent/pi/src/adapter.ts
@@ -103,7 +103,31 @@ Object.defineProperty(process, "stdin", {
 
 type SessionManagerLike = {
 	inMemory(cwd?: string): unknown;
+	continueRecent(cwd: string, sessionDir: string): unknown;
 };
+
+/**
+ * Choose the Pi `SessionManager` for a new session.
+ *
+ * By default sessions are in-memory (nothing is written to disk), so a
+ * conversation is lost when the adapter process restarts. When the embedder
+ * provides a session directory via the `PI_SESSION_DIR` env var, use pi's
+ * `continueRecent` instead: it persists the session's `.jsonl` under that
+ * directory and resumes the most recent one, so conversations survive an adapter
+ * restart. No behavior change unless `PI_SESSION_DIR` is set.
+ *
+ * Exported for unit testing (the real `newSession` path needs the Pi SDK).
+ */
+export function resolveSessionManager(
+	SessionManager: SessionManagerLike,
+	cwd: string,
+	env: Record<string, string | undefined> = process.env,
+): unknown {
+	const sessionDir = env.PI_SESSION_DIR?.trim();
+	return sessionDir
+		? SessionManager.continueRecent(cwd, sessionDir)
+		: SessionManager.inMemory(cwd);
+}
 
 type ModelLike = {
 	id: string;
@@ -873,7 +897,7 @@ export class PiSdkAgent implements Agent {
 		const { session } = await __trace.span("createAgentSession", () =>
 			createAgentSession({
 				cwd: params.cwd,
-				sessionManager: SessionManager.inMemory(params.cwd),
+				sessionManager: resolveSessionManager(SessionManager, params.cwd),
 				resourceLoader,
 				tools: this.wrapTools(
 					createCodingTools(params.cwd, {

--- a/registry/agent/pi/tests/session-manager.test.mjs
+++ b/registry/agent/pi/tests/session-manager.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve as resolvePath } from "node:path";
+
+// Unit tests for resolveSessionManager. The real newSession path needs the Pi
+// SDK, so we test the SessionManager selection directly with a fake.
+const packageDir = resolvePath(import.meta.dirname, "..");
+const { resolveSessionManager } = await import(
+	resolvePath(packageDir, "dist", "adapter.js")
+);
+
+function fakeSessionManager() {
+	const calls = [];
+	return {
+		calls,
+		inMemory(cwd) {
+			calls.push(["inMemory", cwd]);
+			return { kind: "inMemory", cwd };
+		},
+		continueRecent(cwd, dir) {
+			calls.push(["continueRecent", cwd, dir]);
+			return { kind: "continueRecent", cwd, dir };
+		},
+	};
+}
+
+test("PI_SESSION_DIR persists + resumes via continueRecent", () => {
+	const sm = fakeSessionManager();
+	const result = resolveSessionManager(sm, "/workspace", {
+		PI_SESSION_DIR: "/sessions/a/main",
+	});
+	assert.deepEqual(sm.calls, [["continueRecent", "/workspace", "/sessions/a/main"]]);
+	assert.equal(result.kind, "continueRecent");
+});
+
+test("no PI_SESSION_DIR falls back to in-memory (default, unchanged)", () => {
+	const sm = fakeSessionManager();
+	const result = resolveSessionManager(sm, "/workspace", {});
+	assert.deepEqual(sm.calls, [["inMemory", "/workspace"]]);
+	assert.equal(result.kind, "inMemory");
+});
+
+test("blank/whitespace PI_SESSION_DIR is ignored", () => {
+	const sm = fakeSessionManager();
+	resolveSessionManager(sm, "/workspace", { PI_SESSION_DIR: "   " });
+	assert.deepEqual(sm.calls, [["inMemory", "/workspace"]]);
+});


### PR DESCRIPTION
## feat(pi-acp): opt-in persistent sessions via `PI_SESSION_DIR`

### Problem
`registry/agent/pi/src/adapter.ts` hardcodes `SessionManager.inMemory(params.cwd)`
for every new session. In-memory means pi never writes the session `.jsonl`, so the
entire conversation is lost the moment the adapter process restarts (actor
sleep/eviction, crash, redeploy). There is no way for an embedder to get persistent,
resumable sessions short of patching the adapter.

Pi already provides the other half — `SessionManager.continueRecent(cwd, sessionDir)`
persists the session under `sessionDir` and resumes the most recent one. It just
isn't reachable from the ACP adapter.

### Change
Add `resolveSessionManager(SessionManager, cwd, env)`: if `PI_SESSION_DIR` is set in
the session env, use `continueRecent(cwd, PI_SESSION_DIR)`; otherwise `inMemory(cwd)`.
Wire the `newSession` call site to it.

- **Additive & non-breaking** — default stays in-memory; behavior only changes when
  the embedder sets `PI_SESSION_DIR`.
- **Env-driven**, matching the accepted `SECURE_EXEC_FRAME_TIMEOUT_MS` override (#1641).
- **Tested** — `resolveSessionManager` is exported and unit-tested with a fake
  SessionManager (persist branch, default branch, blank-value guard); the real
  `newSession` path needs the Pi SDK so the selection logic is tested directly.

### Verification
`resolveSessionManager` logic verified for all three branches; `check-types` + the
`tests/*.test.mjs` node:test suite run in CI.
