### PR TITLE
fix(ci): retain coreutils stub source

### DIFF
--- a/packages/runtime-core/scripts/copy-wasm-commands.mjs
+++ b/packages/runtime-core/scripts/copy-wasm-commands.mjs
@@ -74,7 +74,7 @@ export function requiredSoftwareCommandNames(softwareRoot = SOFTWARE_ROOT) {
 	return [...required].sort();
 }
 
-export function requiredPackageCommandNames(
+export function requiredPackageArtifactNames(
 	softwareRoot = SOFTWARE_ROOT,
 	packageNames = [],
 ) {
@@ -91,6 +91,9 @@ export function requiredPackageCommandNames(
 		const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 		for (const name of commandNames(manifest, manifestPath)) {
 			required.add(name);
+		}
+		if ((manifest.stubs ?? []).length > 0) {
+			required.add("_stubs");
 		}
 	}
 	return [...required].sort();
@@ -169,7 +172,7 @@ export function copyWasmCommands({
 } = {}) {
 	const required = requireCommands
 		? requiredPackageNames.length > 0
-			? requiredPackageCommandNames(softwareRoot, requiredPackageNames)
+			? requiredPackageArtifactNames(softwareRoot, requiredPackageNames)
 			: requiredSoftwareCommandNames(softwareRoot)
 		: [];
 

--- a/packages/runtime-core/tests/copy-wasm-commands.test.ts
+++ b/packages/runtime-core/tests/copy-wasm-commands.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	copyWasmCommands,
-	requiredPackageCommandNames,
+	requiredPackageArtifactNames,
 	requiredSoftwareCommandNames,
 } from "../scripts/copy-wasm-commands.mjs";
 
@@ -81,13 +81,13 @@ describe("copy WASM commands", () => {
 	it("derives a required command contract for selected packages", () => {
 		const { softwareRoot } = fixture();
 		expect(
-			requiredPackageCommandNames(softwareRoot, ["default-tools"]),
-		).toEqual(["alpha", "alpha-alias", "legacy"]);
+			requiredPackageArtifactNames(softwareRoot, ["default-tools"]),
+		).toEqual(["_stubs", "alpha", "alpha-alias", "legacy"]);
 	});
 
 	it("validates a selected package without requiring the full registry", () => {
 		const { sourceDir, destDir, softwareRoot } = fixture();
-		for (const name of ["alpha", "alpha-alias", "legacy"]) {
+		for (const name of ["_stubs", "alpha", "alpha-alias", "legacy"]) {
 			writeFileSync(join(sourceDir, name), name);
 		}
 		writeFileSync(join(sourceDir, "unselected-extra"), "extra");
@@ -102,6 +102,7 @@ describe("copy WASM commands", () => {
 		});
 
 		expect(readdirSync(destDir).sort()).toEqual([
+			"_stubs",
 			"alpha",
 			"alpha-alias",
 			"legacy",
@@ -166,5 +167,24 @@ describe("copy WASM commands", () => {
 			}),
 		).toThrow(/missing required default WASM commands.*alpha-alias, legacy/);
 		expect(existsSync(join(destDir, "alpha"))).toBe(true);
+	});
+
+	it("rejects a selected package artifact without its internal stub source", () => {
+		const { root, destDir, softwareRoot } = fixture();
+		const sourceDir = join(root, "missing-source");
+		for (const name of ["alpha", "alpha-alias", "legacy"]) {
+			writeFileSync(join(destDir, name), name);
+		}
+
+		expect(() =>
+			copyWasmCommands({
+				sourceDir,
+				destDir,
+				softwareRoot,
+				requireCommands: true,
+				requiredPackageNames: ["default-tools"],
+				log: () => {},
+			}),
+		).toThrow(/missing required default WASM commands.*_stubs/);
 	});
 });


### PR DESCRIPTION
- Preserve the internal `_stubs` binary in filtered coreutils artifacts.
- Validate downloaded selected-package artifacts against the restaging contract.
- Cover the missing-stub regression and successful filtered copy.