### PR TITLE
test: move sed actor replay to nightly

### DIFF
--- a/packages/agentos/package.json
+++ b/packages/agentos/package.json
@@ -51,7 +51,8 @@
 		"build:actor": "tsup src/index.ts src/client.ts src/react.ts",
 		"build:tabs": "vite build --config vite.tabs.config.ts",
 		"check-types": "tsc --noEmit",
-		"test": "vitest run",
+		"test": "vitest run --exclude '**/*.nightly.test.ts'",
+		"test:nightly": "AGENTOS_ACTOR_E2E=1 vitest run tests/*.nightly.test.ts --fileParallelism=false --passWithNoTests",
 		"test:e2e": "cargo build --manifest-path ../../Cargo.toml -p agentos-sidecar && pnpm --filter @rivet-dev/agentos-runtime-core build && pnpm --filter @agentos-software/manifest build && pnpm --filter @agentos-software/common... build && pnpm --filter @agentos-software/coreutils build:runtime && pnpm --filter @rivet-dev/agentos-test-harness build && pnpm --filter @rivet-dev/agentos-core build && pnpm build && pnpm test:e2e:run",
 		"test:e2e:run": "AGENTOS_ACTOR_E2E=1 vitest run tests/actor.e2e.test.ts tests/agent-os-conformance.e2e.test.ts --fileParallelism=false"
 	},

--- a/packages/agentos/tests/actor-software-replay.nightly.test.ts
+++ b/packages/agentos/tests/actor-software-replay.nightly.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sed } from "@agentos-software/common";
+import { describe, expect, test } from "vitest";
+import {
+	actorBytes,
+	actorHandle,
+	startActorRuntime,
+} from "./helpers/actor-runtime.js";
+
+const RUN_E2E = process.env.AGENTOS_ACTOR_E2E === "1";
+
+describe.skipIf(!RUN_E2E)("AgentOS real Rivet actor nightly software replay", () => {
+	test("replays dynamic mounts and linked software after actor sleep", async () => {
+		const storagePath = mkdtempSync(join(tmpdir(), "agentos-replay-e2e-"));
+		let runtime: Awaited<ReturnType<typeof startActorRuntime>> | undefined;
+		try {
+			runtime = await startActorRuntime(storagePath);
+			const handle = actorHandle(runtime.endpoint, `replay-${Date.now()}`);
+			const mountPath = "/durable-dynamic-mount";
+			await handle.mountFs({
+				path: mountPath,
+				plugin: {
+					id: "chunked_actor_sqlite",
+					config: {
+						namespace: "dynamic-replay",
+						chunkSize: 512 * 1024,
+						inlineThreshold: 64 * 1024,
+					},
+				},
+			});
+			await handle.writeFile(`${mountPath}/message.txt`, "mounted-before-sleep");
+			await handle.linkSoftware({ path: sed.packagePath });
+			expect(
+				(await handle.listSoftware()).some((entry: { commands: string[] }) =>
+					entry.commands.includes("sed"),
+				),
+			).toBe(true);
+
+			await handle.sleepActor();
+			await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+			expect(await handle.listMounts()).toContainEqual(
+				expect.objectContaining({ path: mountPath, readOnly: false }),
+			);
+			expect(
+				new TextDecoder().decode(
+					actorBytes(await handle.readFile(`${mountPath}/message.txt`)),
+				),
+			).toBe("mounted-before-sleep");
+			expect(
+				(await handle.listSoftware()).some((entry: { commands: string[] }) =>
+					entry.commands.includes("sed"),
+				),
+			).toBe(true);
+		} finally {
+			await runtime?.stop();
+			rmSync(storagePath, { recursive: true, force: true });
+		}
+	}, 180_000);
+});

--- a/packages/agentos/tests/actor.e2e.test.ts
+++ b/packages/agentos/tests/actor.e2e.test.ts
@@ -1,7 +1,6 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sed } from "@agentos-software/common";
 import { CONFORMANCE_AGENT_NAME } from "@rivet-dev/agentos-test-harness/agent-os-conformance-fixture";
 import { describe, expect, test } from "vitest";
 import {
@@ -226,54 +225,6 @@ describe.skipIf(!RUN_E2E)("AgentOS real Rivet actor", () => {
 				large,
 			);
 			expect(await handle.getWakeCount()).toBe(3);
-		} finally {
-			await runtime?.stop();
-			rmSync(storagePath, { recursive: true, force: true });
-		}
-	}, 180_000);
-
-	test("replays dynamic mounts and linked software after actor sleep", async () => {
-		const storagePath = mkdtempSync(join(tmpdir(), "agentos-replay-e2e-"));
-		let runtime: Awaited<ReturnType<typeof startActorRuntime>> | undefined;
-		try {
-			runtime = await startActorRuntime(storagePath);
-			const handle = actorHandle(runtime.endpoint, `replay-${Date.now()}`);
-			const mountPath = "/durable-dynamic-mount";
-			await handle.mountFs({
-				path: mountPath,
-				plugin: {
-					id: "chunked_actor_sqlite",
-					config: {
-						namespace: "dynamic-replay",
-						chunkSize: 512 * 1024,
-						inlineThreshold: 64 * 1024,
-					},
-				},
-			});
-			await handle.writeFile(`${mountPath}/message.txt`, "mounted-before-sleep");
-			await handle.linkSoftware({ path: sed.packagePath });
-			expect(
-				(await handle.listSoftware()).some((entry: { commands: string[] }) =>
-					entry.commands.includes("sed"),
-				),
-			).toBe(true);
-
-			await handle.sleepActor();
-			await new Promise((resolve) => setTimeout(resolve, 1_000));
-
-			expect(await handle.listMounts()).toContainEqual(
-				expect.objectContaining({ path: mountPath, readOnly: false }),
-			);
-			expect(
-				new TextDecoder().decode(
-					actorBytes(await handle.readFile(`${mountPath}/message.txt`)),
-				),
-			).toBe("mounted-before-sleep");
-			expect(
-				(await handle.listSoftware()).some((entry: { commands: string[] }) =>
-					entry.commands.includes("sed"),
-				),
-			).toBe(true);
 		} finally {
 			await runtime?.stop();
 			rmSync(storagePath, { recursive: true, force: true });


### PR DESCRIPTION
- Keep core actor and AgentOS conformance coverage in the PR lane.
- Move the actor replay case that links the non-core sed package to nightly.
- Add explicit normal/nightly Vitest scripts for the AgentOS package.