### PR TITLE
fix(ci): install nightly cmake prerequisite

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -22,6 +22,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-wasip1
+      - name: Install toolchain build prerequisites
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --yes cmake
+          fi
       - run: pnpm install --frozen-lockfile
       - run: node --test scripts/generate-secure-exec-mirror.test.mjs
       - run: make -C toolchain commands


### PR DESCRIPTION
- install CMake on the self-hosted nightly runner when absent
- unblock the full WASM command and DuckDB validation path