### PR TITLE
fix(ci): restore fast PR coverage and Rust setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
       - run: node --test scripts/check-rustfmt.test.mjs
       - run: node scripts/check-rustfmt.mjs
       - run: pnpm check-types
+      - name: Run fast package unit tests
+        run: |
+          pnpm --parallel --aggregate-output \
+            --filter '@rivet-dev/agentos-build-tools' \
+            --filter '@rivet-dev/agentos-toolchain' \
+            --filter '@rivet-dev/agentos-runtime-sidecar' \
+            --filter 'secure-exec' \
+            test
       - run: pnpm lint
         continue-on-error: true
       - name: Pack JavaScript build outputs
@@ -125,12 +133,20 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: '0'
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           key: native-pr-${{ hashFiles('Cargo.lock') }}
+      - name: Install V8 bridge build dependencies
+        run: pnpm install --frozen-lockfile --filter '@rivet-dev/agentos-build-tools...'
       - name: Verify generated VM config bindings
         run: |
           cargo test -p agentos-vm-config --quiet
@@ -139,7 +155,22 @@ jobs:
         run: cargo build -p agentos-sidecar -p agentos-native-sidecar
       - run: cargo clippy --workspace --exclude agentos-sidecar-browser --exclude agentos-native-sidecar-browser --all-targets -- -D warnings
       - run: cargo test -p agentos-protocol -p agentos-sidecar -- --test-threads=1
-      - run: cargo test -p agentos-client --lib -- --test-threads=1
+      - name: Test Rust client contracts
+        env:
+          AGENTOS_SIDECAR_BIN: ${{ github.workspace }}/target/debug/agentos-sidecar
+        run: |
+          cargo test -p agentos-client \
+            --lib \
+            --test scaffold \
+            --test session_event_types \
+            --test e2e_smoke \
+            --test fs_e2e \
+            --test lifecycle_e2e \
+            --test mount_e2e \
+            --test sidecar_pool_e2e \
+            --test cron_e2e \
+            --test cron_grammar_e2e \
+            -- --test-threads=1
       - name: Stage stripped sidecar artifacts
         run: |
           mkdir -p ci-artifacts/agentos-sidecar ci-artifacts/agentos-native-sidecar
@@ -175,7 +206,7 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --filter '@rivet-dev/agentos-core...'
       - uses: actions/download-artifact@v4
         with:
           name: js-dist
@@ -207,7 +238,7 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --filter '@rivet-dev/agentos-runtime-core...'
       - uses: actions/download-artifact@v4
         with:
           name: js-dist
@@ -244,7 +275,7 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --filter '@rivet-dev/agentos...'
       - uses: actions/download-artifact@v4
         with:
           name: js-dist

--- a/packages/agentos/package.json
+++ b/packages/agentos/package.json
@@ -52,7 +52,7 @@
 		"build:tabs": "vite build --config vite.tabs.config.ts",
 		"check-types": "tsc --noEmit",
 		"test": "vitest run --exclude '**/*.nightly.test.ts'",
-		"test:pr": "AGENTOS_ACTOR_E2E=1 vitest run tests/agent-os-conformance.e2e.test.ts --fileParallelism=false",
+		"test:pr": "AGENTOS_ACTOR_E2E=1 vitest run tests/actor.test.ts tests/client.test.ts tests/agent-os-conformance.e2e.test.ts --fileParallelism=false",
 		"test:nightly": "AGENTOS_ACTOR_E2E=1 vitest run tests/*.nightly.test.ts tests/agent-os-conformance.e2e.test.ts --fileParallelism=false --passWithNoTests",
 		"test:e2e": "cargo build --manifest-path ../../Cargo.toml -p agentos-sidecar && pnpm --filter @rivet-dev/agentos-runtime-core build && pnpm --filter @agentos-software/manifest build && pnpm --filter @agentos-software/common... build && pnpm --filter @agentos-software/coreutils build:runtime && pnpm --filter @rivet-dev/agentos-test-harness build && pnpm --filter @rivet-dev/agentos-core build && pnpm build && pnpm test:e2e:run",
 		"test:e2e:run": "AGENTOS_ACTOR_E2E=1 vitest run tests/actor-lifecycle.nightly.test.ts tests/agent-os-conformance.e2e.test.ts --fileParallelism=false"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,8 @@
 		"build:agentos-protocol": "node ./scripts/compile-agentos-protocol.mjs",
 		"build:protocols": "pnpm run build:agentos-protocol",
 		"test": "vitest run --exclude '**/*.nightly.test.ts' --reporter=verbose",
-		"test:pr": "vitest run tests/migration-parity.test.ts --fileParallelism=false --reporter=verbose",
+		"test:unit": "vitest run tests/agent-exit-event.test.ts tests/agentos-package.test.ts tests/agentos-protocol.test.ts tests/allowed-node-builtins.test.ts tests/bindings-zod.test.ts tests/bindings.test.ts tests/cron-manager.test.ts tests/cron-timer-driver.test.ts tests/generated-protocol.test.ts tests/leak-agent-os-processes.test.ts tests/leak-rpc-client.test.ts tests/mount-descriptors.test.ts tests/mount-reconfigure.test.ts tests/options-schema.test.ts tests/public-api-exports.test.ts tests/root-filesystem-descriptors.test.ts tests/runtime-compat-mount.test.ts tests/session-event-ordering.test.ts tests/session-permission-surface.test.ts tests/sidecar-client.test.ts tests/sidecar-permission-descriptors.test.ts tests/wasm-permission-tiers.test.ts --fileParallelism=false",
+		"test:pr": "pnpm test:unit && vitest run tests/migration-parity.test.ts --fileParallelism=false --reporter=verbose",
 		"test:nightly": "vitest run tests/*.nightly.test.ts --reporter=verbose --passWithNoTests"
 	},
 	"dependencies": {

--- a/packages/core/src/agentos-package.ts
+++ b/packages/core/src/agentos-package.ts
@@ -33,7 +33,7 @@ export interface PackageDescriptor {
 	path: string;
 }
 
-/** Discriminate the dir-only package reference. */
+/** Discriminate the path-only package reference. */
 export function isPackageDescriptor(
 	value: unknown,
 ): value is PackageDescriptor {

--- a/packages/core/tests/agentos-package.test.ts
+++ b/packages/core/tests/agentos-package.test.ts
@@ -7,8 +7,9 @@ import { isPackageDescriptor } from "../src/agentos-package.js";
 // + inode-sharing assertions. The only thing left client-side is the descriptor
 // surface, so this is a thin discriminator test.
 describe("agentos-package descriptor surface", () => {
-	it("discriminates the dir-only package descriptor", () => {
-		expect(isPackageDescriptor("/x")).toBe(true);
+	it("discriminates the path-only package descriptor", () => {
+		expect(isPackageDescriptor({ path: "/x" })).toBe(true);
+		expect(isPackageDescriptor("/x")).toBe(false);
 		expect(isPackageDescriptor({ name: "p", dir: "/x" })).toBe(false);
 		expect(isPackageDescriptor({ dir: "/x" })).toBe(false);
 		expect(isPackageDescriptor(null)).toBe(false);


### PR DESCRIPTION
- install the V8 bridge dependencies inside the parallel Rust producer and restore fast Rust client integration coverage
- restore curated Core, Actor, and package unit tests without returning heavyweight VM/software matrices to PR CI
- narrow consumer dependency installs while preserving the full nightly and release paths