### PR TITLE
fix(agentos): support RivetKit 2.3.5 actor runtime socket

### DIFF
--- a/crates/actor-uds-client/protocol/v1.bare
+++ b/crates/actor-uds-client/protocol/v1.bare
@@ -1,23 +1,16 @@
-# This schema is the client-side copy of Rivet's actor UDS protocol v1.
-# The actor and sidecar intentionally ship in lockstep with no compatibility shim.
+# Client-side copy of RivetKit 2.3.5's Actor Runtime Socket protocol v1.
+# AgentOS and RivetKit intentionally ship this boundary in lockstep.
 
-type ClientHello struct {
-	token: str
-}
+type ClientHello void
 
 type HelloOk struct {
 	maxFrameBytes: u32
 }
 
-type HelloRejectUnauthorized void
-type HelloRejectUnsupportedVersion struct {
-	minVersion: u16
-	maxVersion: u16
-}
+type HelloRejectUnsupportedVersion void
 
 type ServerHello union {
 	HelloOk |
-	HelloRejectUnauthorized |
 	HelloRejectUnsupportedVersion
 }
 
@@ -46,9 +39,25 @@ type SqliteQuery struct {
 	params: list<SqlValue>
 }
 
+type SqliteBegin struct {
+	leaseKey: str
+	timeoutMs: optional<u64>
+}
+
+type SqliteCommit struct {
+	leaseKey: str
+}
+
+type SqliteRollback struct {
+	leaseKey: str
+}
+
 type RequestPayload union {
 	SqliteExec |
-	SqliteQuery
+	SqliteQuery |
+	SqliteBegin |
+	SqliteCommit |
+	SqliteRollback
 }
 
 type Request struct {
@@ -62,6 +71,10 @@ type ClientFrame union {
 }
 
 type SqliteExecOk void
+type SqliteBeginOk void
+type SqliteCommitOk void
+type SqliteRollbackOk void
+
 type SqliteQueryOk struct {
 	columns: list<str>
 	rows: list<SqlRow>
@@ -76,22 +89,33 @@ type SqlError struct {
 }
 
 type EndpointClosed void
+
 type QueueFull struct {
 	limit: str
 	capacity: u32
 }
 
-type TxnOpenAtEnd void
-type LeaseExpired void
+type InvalidLeaseKey struct {
+	message: str
+}
+
+type LeaseExpired struct {
+	timeoutMs: u64
+	message: str
+}
+
 type ResponseTooLarge void
 
 type ResponsePayload union {
 	SqliteExecOk |
 	SqliteQueryOk |
+	SqliteBeginOk |
+	SqliteCommitOk |
+	SqliteRollbackOk |
 	SqlError |
 	EndpointClosed |
 	QueueFull |
-	TxnOpenAtEnd |
+	InvalidLeaseKey |
 	LeaseExpired |
 	ResponseTooLarge
 }
@@ -103,6 +127,7 @@ type Response struct {
 
 type FrameTooLarge void
 type MalformedFrame void
+
 type GoAwayReason union {
 	FrameTooLarge |
 	MalformedFrame

--- a/crates/actor-uds-client/src/lib.rs
+++ b/crates/actor-uds-client/src/lib.rs
@@ -36,18 +36,16 @@ pub enum ActorUdsError {
     Io(#[from] io::Error),
     #[error("actor SQLite UDS protocol failed: {0}")]
     Protocol(String),
-    #[error("actor SQLite UDS authentication failed")]
-    Unauthorized,
-    #[error("actor SQLite UDS version mismatch (server {min_version}..={max_version}, client {PROTOCOL_VERSION})")]
-    VersionMismatch { min_version: u16, max_version: u16 },
+    #[error("actor SQLite UDS protocol version is unsupported")]
+    VersionMismatch,
     #[error("actor SQLite UDS endpoint closed")]
     EndpointClosed,
     #[error("actor SQLite UDS queue limit {limit} reached (capacity {capacity})")]
     QueueFull { limit: String, capacity: u32 },
-    #[error("actor SQLite UDS request left a transaction open without a lease")]
-    TransactionOpen,
-    #[error("actor SQLite UDS transaction lease expired")]
-    LeaseExpired,
+    #[error("actor SQLite UDS transaction lease is invalid: {message}")]
+    InvalidLeaseKey { message: String },
+    #[error("actor SQLite UDS transaction lease expired after {timeout_ms}ms: {message}")]
+    LeaseExpired { timeout_ms: u64, message: String },
     #[error("actor SQLite UDS response exceeded the negotiated frame limit")]
     ResponseTooLarge,
     #[error("actor SQLite error {code} at statement {statement_index}: {message}")]
@@ -78,7 +76,6 @@ pub struct ActorUdsClient {
 
 struct Inner {
     path: PathBuf,
-    token: String,
     request_timeout: Duration,
     next_request_id: AtomicU32,
     connection: Mutex<Option<Connection>>,
@@ -90,19 +87,14 @@ struct Connection {
 }
 
 impl ActorUdsClient {
-    pub fn new(path: impl Into<PathBuf>, token: impl Into<String>) -> Self {
-        Self::with_request_timeout(path, token, DEFAULT_REQUEST_TIMEOUT)
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self::with_request_timeout(path, DEFAULT_REQUEST_TIMEOUT)
     }
 
-    pub fn with_request_timeout(
-        path: impl Into<PathBuf>,
-        token: impl Into<String>,
-        request_timeout: Duration,
-    ) -> Self {
+    pub fn with_request_timeout(path: impl Into<PathBuf>, request_timeout: Duration) -> Self {
         Self {
             inner: Arc::new(Inner {
                 path: path.into(),
-                token: token.into(),
                 request_timeout,
                 next_request_id: AtomicU32::new(1),
                 connection: Mutex::new(None),
@@ -159,6 +151,56 @@ impl ActorUdsClient {
         }
     }
 
+    pub async fn begin(
+        &self,
+        lease_key: impl Into<String>,
+        timeout_ms: Option<u64>,
+    ) -> Result<(), ActorUdsError> {
+        match self
+            .request(
+                wire::RequestPayload::SqliteBegin(wire::SqliteBegin {
+                    lease_key: lease_key.into(),
+                    timeout_ms,
+                }),
+                None,
+            )
+            .await?
+        {
+            wire::ResponsePayload::SqliteBeginOk => Ok(()),
+            other => Err(unexpected_response("begin", &other)),
+        }
+    }
+
+    pub async fn commit(&self, lease_key: impl Into<String>) -> Result<(), ActorUdsError> {
+        match self
+            .request(
+                wire::RequestPayload::SqliteCommit(wire::SqliteCommit {
+                    lease_key: lease_key.into(),
+                }),
+                None,
+            )
+            .await?
+        {
+            wire::ResponsePayload::SqliteCommitOk => Ok(()),
+            other => Err(unexpected_response("commit", &other)),
+        }
+    }
+
+    pub async fn rollback(&self, lease_key: impl Into<String>) -> Result<(), ActorUdsError> {
+        match self
+            .request(
+                wire::RequestPayload::SqliteRollback(wire::SqliteRollback {
+                    lease_key: lease_key.into(),
+                }),
+                None,
+            )
+            .await?
+        {
+            wire::ResponsePayload::SqliteRollbackOk => Ok(()),
+            other => Err(unexpected_response("rollback", &other)),
+        }
+    }
+
     async fn request(
         &self,
         payload: wire::RequestPayload,
@@ -186,7 +228,7 @@ impl ActorUdsClient {
     ) -> Result<wire::ResponsePayload, ActorUdsError> {
         let mut slot = self.inner.connection.lock().await;
         if slot.is_none() {
-            *slot = Some(connect(&self.inner.path, &self.inner.token).await?);
+            *slot = Some(connect(&self.inner.path).await?);
         }
         let connection = slot.as_mut().expect("connection initialized");
         let request_id = self.inner.next_request_id.fetch_add(1, Ordering::Relaxed);
@@ -242,18 +284,16 @@ impl ActorUdsClient {
     }
 }
 
-async fn connect(path: &Path, token_value: &str) -> Result<Connection, ActorUdsError> {
+async fn connect(path: &Path) -> Result<Connection, ActorUdsError> {
     let mut stream = timeout(DEFAULT_CONNECT_TIMEOUT, UnixStream::connect(path))
         .await
         .map_err(|_| ActorUdsError::Timeout {
             operation: "connect",
             timeout_ms: DEFAULT_CONNECT_TIMEOUT.as_millis() as u64,
         })??;
-    let hello = versioned::ClientHello::wrap_latest(wire::ClientHello {
-        token: token_value.to_owned(),
-    })
-    .serialize_with_embedded_version(PROTOCOL_VERSION)
-    .map_err(|error| ActorUdsError::Protocol(error.to_string()))?;
+    let hello = versioned::ClientHello::wrap_latest(())
+        .serialize_with_embedded_version(PROTOCOL_VERSION)
+        .map_err(|error| ActorUdsError::Protocol(error.to_string()))?;
     write_frame(&mut stream, &hello).await?;
     let response = read_frame(&mut stream, MAX_FRAME_BYTES).await?;
     match versioned::ServerHello::deserialize_with_embedded_version(&response)
@@ -263,13 +303,7 @@ async fn connect(path: &Path, token_value: &str) -> Result<Connection, ActorUdsE
             stream,
             max_frame_bytes: ok.max_frame_bytes.min(MAX_FRAME_BYTES),
         }),
-        wire::ServerHello::HelloRejectUnauthorized => Err(ActorUdsError::Unauthorized),
-        wire::ServerHello::HelloRejectUnsupportedVersion(version) => {
-            Err(ActorUdsError::VersionMismatch {
-                min_version: version.min_version,
-                max_version: version.max_version,
-            })
-        }
+        wire::ServerHello::HelloRejectUnsupportedVersion => Err(ActorUdsError::VersionMismatch),
     }
 }
 
@@ -309,8 +343,13 @@ fn map_response(payload: wire::ResponsePayload) -> Result<wire::ResponsePayload,
             limit: error.limit,
             capacity: error.capacity,
         }),
-        wire::ResponsePayload::TxnOpenAtEnd => Err(ActorUdsError::TransactionOpen),
-        wire::ResponsePayload::LeaseExpired => Err(ActorUdsError::LeaseExpired),
+        wire::ResponsePayload::InvalidLeaseKey(error) => Err(ActorUdsError::InvalidLeaseKey {
+            message: error.message,
+        }),
+        wire::ResponsePayload::LeaseExpired(error) => Err(ActorUdsError::LeaseExpired {
+            timeout_ms: error.timeout_ms,
+            message: error.message,
+        }),
         wire::ResponsePayload::ResponseTooLarge => Err(ActorUdsError::ResponseTooLarge),
         response => Ok(response),
     }

--- a/crates/actor-uds-client/tests/client.rs
+++ b/crates/actor-uds-client/tests/client.rs
@@ -21,17 +21,16 @@ async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> io::Result<()> 
 }
 
 #[tokio::test]
-async fn authenticates_and_reuses_a_connection_for_query_and_exec() {
+async fn handshakes_and_reuses_a_connection_for_query_and_exec() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("actor.sock");
     let listener = UnixListener::bind(&path).unwrap();
     let server = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
-        let hello = wire::versioned::ClientHello::deserialize_with_embedded_version(
+        wire::versioned::ClientHello::deserialize_with_embedded_version(
             &read_frame(&mut stream).await.unwrap(),
         )
         .unwrap();
-        assert_eq!(hello.token, "secret");
         let response =
             wire::versioned::ServerHello::wrap_latest(wire::ServerHello::HelloOk(wire::HelloOk {
                 max_frame_bytes: 32 * 1024 * 1024,
@@ -84,7 +83,7 @@ async fn authenticates_and_reuses_a_connection_for_query_and_exec() {
         write_frame(&mut stream, &response).await.unwrap();
     });
 
-    let client = ActorUdsClient::new(&path, "secret");
+    let client = ActorUdsClient::new(&path);
     let result = client
         .query("SELECT ?", vec![SqlValue::SqlInteger(42)])
         .await
@@ -96,24 +95,25 @@ async fn authenticates_and_reuses_a_connection_for_query_and_exec() {
 }
 
 #[tokio::test]
-async fn reports_authentication_rejection_as_a_typed_error() {
+async fn reports_version_rejection_as_a_typed_error() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("actor.sock");
     let listener = UnixListener::bind(&path).unwrap();
     let server = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
         read_frame(&mut stream).await.unwrap();
-        let response =
-            wire::versioned::ServerHello::wrap_latest(wire::ServerHello::HelloRejectUnauthorized)
-                .serialize_with_embedded_version(1)
-                .unwrap();
+        let response = wire::versioned::ServerHello::wrap_latest(
+            wire::ServerHello::HelloRejectUnsupportedVersion,
+        )
+        .serialize_with_embedded_version(1)
+        .unwrap();
         write_frame(&mut stream, &response).await.unwrap();
     });
 
-    let error = ActorUdsClient::new(&path, "wrong")
+    let error = ActorUdsClient::new(&path)
         .query("SELECT 1", Vec::new())
         .await
         .unwrap_err();
-    assert!(matches!(error, ActorUdsError::Unauthorized));
+    assert!(matches!(error, ActorUdsError::VersionMismatch));
     server.await.unwrap();
 }

--- a/crates/agentos-sidecar/src/session_store/performance_tests.rs
+++ b/crates/agentos-sidecar/src/session_store/performance_tests.rs
@@ -89,7 +89,6 @@ impl ActorUdsFixture {
         agentos_native_sidecar::vm_sqlite::resolve_vm_sqlite(
             &VmSqliteDescriptor::ActorUds {
                 path: self.path.clone(),
-                token: "secret".to_owned(),
             },
             runtime().context(),
             DEFAULT_SQLITE_MAX_RESULT_BYTES,
@@ -195,9 +194,8 @@ async fn serve_actor_connection(
     let Ok(hello_frame) = read_frame(&mut stream).await else {
         return;
     };
-    let hello = wire::versioned::ClientHello::deserialize_with_embedded_version(&hello_frame)
+    wire::versioned::ClientHello::deserialize_with_embedded_version(&hello_frame)
         .expect("actor client hello");
-    assert_eq!(hello.token, "secret");
     let response =
         wire::versioned::ServerHello::wrap_latest(wire::ServerHello::HelloOk(wire::HelloOk {
             max_frame_bytes: 32 * 1024 * 1024,
@@ -228,6 +226,24 @@ async fn serve_actor_connection(
                 wire::RequestPayload::SqliteQuery(query) => {
                     metrics.query_count.fetch_add(1, Ordering::Relaxed);
                     execute_query(&mut connection, query)
+                }
+                wire::RequestPayload::SqliteBegin(_) => {
+                    connection
+                        .execute_batch("BEGIN IMMEDIATE")
+                        .expect("begin actor transaction");
+                    wire::ResponsePayload::SqliteBeginOk
+                }
+                wire::RequestPayload::SqliteCommit(_) => {
+                    connection
+                        .execute_batch("COMMIT")
+                        .expect("commit actor transaction");
+                    wire::ResponsePayload::SqliteCommitOk
+                }
+                wire::RequestPayload::SqliteRollback(_) => {
+                    connection
+                        .execute_batch("ROLLBACK")
+                        .expect("rollback actor transaction");
+                    wire::ResponsePayload::SqliteRollbackOk
                 }
             }
         };
@@ -482,8 +498,8 @@ async fn exercise_near_limit_append(
     if let Some(metrics) = wire_metrics {
         let (query_count, response_bytes) = metrics.snapshot();
         assert_eq!(
-            query_count, 7,
-            "actor append must be BEGIN + four statements + COMMIT + one retention read"
+            query_count, 5,
+            "actor append must be four statements plus one retention read; transaction control uses dedicated frames"
         );
         assert!(
             response_bytes <= APPEND_WIRE_BYTE_LIMIT,

--- a/crates/native-sidecar/src/vm_sqlite.rs
+++ b/crates/native-sidecar/src/vm_sqlite.rs
@@ -114,8 +114,8 @@ pub async fn resolve_vm_sqlite(
     max_result_bytes: usize,
 ) -> Result<SharedVmSqliteDatabase, VmSqliteError> {
     match descriptor {
-        VmSqliteDescriptor::ActorUds { path, token } => Ok(Arc::new(
-            ActorUdsVmSqliteDatabase::open(path.clone(), token.clone(), max_result_bytes).await?,
+        VmSqliteDescriptor::ActorUds { path } => Ok(Arc::new(
+            ActorUdsVmSqliteDatabase::open(path.clone(), max_result_bytes).await?,
         )),
         VmSqliteDescriptor::SqliteFile { path } => Ok(Arc::new(
             LocalVmSqliteDatabase::open(PathBuf::from(path), runtime, max_result_bytes).await?,
@@ -130,13 +130,9 @@ struct ActorUdsVmSqliteDatabase {
 }
 
 impl ActorUdsVmSqliteDatabase {
-    async fn open(
-        path: String,
-        token: String,
-        max_result_bytes: usize,
-    ) -> Result<Self, VmSqliteError> {
+    async fn open(path: String, max_result_bytes: usize) -> Result<Self, VmSqliteError> {
         let database = Self {
-            client: ActorUdsClient::new(path, token),
+            client: ActorUdsClient::new(path),
             max_result_bytes,
         };
         database.enable_and_verify_foreign_keys().await?;
@@ -165,9 +161,7 @@ impl VmSqliteDatabase for ActorUdsVmSqliteDatabase {
         statements: Vec<SqlStatement>,
     ) -> Result<Vec<QueryResult>, VmSqliteError> {
         let key = Uuid::new_v4().to_string();
-        self.client
-            .query_with_lease("BEGIN IMMEDIATE", Vec::new(), Some(&key))
-            .await?;
+        self.client.begin(&key, None).await?;
         let mut results = Vec::with_capacity(statements.len());
         for statement in statements {
             let expected_changes = statement.expected_changes;
@@ -178,11 +172,7 @@ impl VmSqliteDatabase for ActorUdsVmSqliteDatabase {
             {
                 Ok(result) => {
                     if let Err(error) = validate_expected_changes(expected_changes, &result) {
-                        if let Err(rollback_error) = self
-                            .client
-                            .query_with_lease("ROLLBACK", Vec::new(), Some(&key))
-                            .await
-                        {
+                        if let Err(rollback_error) = self.client.rollback(&key).await {
                             eprintln!(
                                 "ERR_AGENTOS_SQLITE_ROLLBACK: actor transaction {key} rollback failed after {error}: {rollback_error}"
                             );
@@ -190,11 +180,7 @@ impl VmSqliteDatabase for ActorUdsVmSqliteDatabase {
                         return Err(error);
                     }
                     if let Err(error) = validate_result_size(&result, self.max_result_bytes) {
-                        if let Err(rollback_error) = self
-                            .client
-                            .query_with_lease("ROLLBACK", Vec::new(), Some(&key))
-                            .await
-                        {
+                        if let Err(rollback_error) = self.client.rollback(&key).await {
                             eprintln!(
                                 "ERR_AGENTOS_SQLITE_ROLLBACK: actor transaction {key} rollback failed after {error}: {rollback_error}"
                             );
@@ -204,11 +190,7 @@ impl VmSqliteDatabase for ActorUdsVmSqliteDatabase {
                     results.push(result)
                 }
                 Err(error) => {
-                    if let Err(rollback_error) = self
-                        .client
-                        .query_with_lease("ROLLBACK", Vec::new(), Some(&key))
-                        .await
-                    {
+                    if let Err(rollback_error) = self.client.rollback(&key).await {
                         eprintln!(
                             "ERR_AGENTOS_SQLITE_ROLLBACK: actor transaction {key} rollback failed after {error}: {rollback_error}"
                         );
@@ -217,16 +199,8 @@ impl VmSqliteDatabase for ActorUdsVmSqliteDatabase {
                 }
             }
         }
-        if let Err(error) = self
-            .client
-            .query_with_lease("COMMIT", Vec::new(), Some(&key))
-            .await
-        {
-            if let Err(rollback_error) = self
-                .client
-                .query_with_lease("ROLLBACK", Vec::new(), Some(&key))
-                .await
-            {
+        if let Err(error) = self.client.commit(&key).await {
+            if let Err(rollback_error) = self.client.rollback(&key).await {
                 eprintln!(
                     "ERR_AGENTOS_SQLITE_ROLLBACK: actor transaction {key} rollback failed after commit error {error}: {rollback_error}"
                 );

--- a/crates/native-sidecar/tests/chunked_actor_sqlite.rs
+++ b/crates/native-sidecar/tests/chunked_actor_sqlite.rs
@@ -189,11 +189,8 @@ fn execute_query(connection: &mut Connection, request: wire::SqliteQuery) -> wir
 }
 
 async fn serve_connection(mut stream: UnixStream, database: Arc<Mutex<Connection>>) {
-    let hello = wire::versioned::ClientHello::deserialize_with_embedded_version(
-        &read_frame(&mut stream).await,
-    )
-    .unwrap();
-    assert_eq!(hello.token, "secret");
+    wire::versioned::ClientHello::deserialize_with_embedded_version(&read_frame(&mut stream).await)
+        .unwrap();
     let response =
         wire::versioned::ServerHello::wrap_latest(wire::ServerHello::HelloOk(wire::HelloOk {
             max_frame_bytes: 32 * 1024 * 1024,
@@ -221,6 +218,18 @@ async fn serve_connection(mut stream: UnixStream, database: Arc<Mutex<Connection
                     wire::ResponsePayload::SqliteExecOk
                 }
                 wire::RequestPayload::SqliteQuery(query) => execute_query(&mut connection, query),
+                wire::RequestPayload::SqliteBegin(_) => {
+                    connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+                    wire::ResponsePayload::SqliteBeginOk
+                }
+                wire::RequestPayload::SqliteCommit(_) => {
+                    connection.execute_batch("COMMIT").unwrap();
+                    wire::ResponsePayload::SqliteCommitOk
+                }
+                wire::RequestPayload::SqliteRollback(_) => {
+                    connection.execute_batch("ROLLBACK").unwrap();
+                    wire::ResponsePayload::SqliteRollbackOk
+                }
             }
         };
         let response = wire::versioned::ServerFrame::wrap_latest(wire::ServerFrame::Response(
@@ -255,7 +264,6 @@ async fn metadata_and_blocks_persist_directly_over_actor_sqlite_uds() {
     let client = vm_sqlite::resolve_vm_sqlite(
         &agentos_vm_config::VmSqliteDescriptor::ActorUds {
             path: path.display().to_string(),
-            token: "secret".to_owned(),
         },
         runtime.context(),
         128 * 1024 * 1024,
@@ -304,7 +312,6 @@ async fn migrations_are_independent_strict_and_atomic_over_actor_sqlite_uds() {
     let client = vm_sqlite::resolve_vm_sqlite(
         &agentos_vm_config::VmSqliteDescriptor::ActorUds {
             path: path.display().to_string(),
-            token: "secret".to_owned(),
         },
         runtime.context(),
         128 * 1024 * 1024,

--- a/crates/vm-config/src/lib.rs
+++ b/crates/vm-config/src/lib.rs
@@ -108,8 +108,8 @@ impl CreateVmConfig {
 #[ts(tag = "type", rename_all = "snake_case")]
 #[ts(export, export_to = "../../../packages/runtime-core/src/generated/")]
 pub enum VmSqliteDescriptor {
-    /// Rivet actor SQLite reached through the actor's authenticated UDS.
-    ActorUds { path: String, token: String },
+    /// Rivet actor SQLite reached through the actor's local runtime socket.
+    ActorUds { path: String },
     /// A SQLite database file owned by the native sidecar host.
     SqliteFile { path: String },
 }
@@ -117,13 +117,8 @@ pub enum VmSqliteDescriptor {
 impl VmSqliteDescriptor {
     fn validate(&self) -> Result<(), VmConfigError> {
         match self {
-            Self::ActorUds { path, token } => {
+            Self::ActorUds { path } => {
                 validate_absolute_host_path("database.path", path)?;
-                if token.is_empty() || token.len() > 4096 {
-                    return Err(VmConfigError::new(
-                        "database.token must contain 1..=4096 bytes",
-                    ));
-                }
             }
             Self::SqliteFile { path } => validate_absolute_host_path("database.path", path)?,
         }

--- a/packages/agentos/src/actor.ts
+++ b/packages/agentos/src/actor.ts
@@ -125,17 +125,17 @@ async function ensureVm(
 
 	const startedAt = Date.now();
 	runtime.vm = (async () => {
-		const actorUds = (
+		const actorRuntimeSocket = (
 			c as AnyContext & {
-				actorUds(): Promise<{ path: string; token: string }>;
+				actorRuntimeSocket(): Promise<{ path: string }>;
 			}
-		).actorUds;
-		if (typeof actorUds !== "function") {
+		).actorRuntimeSocket;
+		if (typeof actorRuntimeSocket !== "function") {
 			throw new Error(
-				"AgentOS actors require a RivetKit runtime with experimental actor UDS support",
+				"AgentOS actors require a RivetKit runtime with Actor Runtime Socket support",
 			);
 		}
-		const { path, token } = await actorUds.call(c);
+		const { path } = await actorRuntimeSocket.call(c);
 		const mountRows = await c.db.execute<{ descriptor_json: string }>(
 			"SELECT descriptor_json FROM agentos_actor_dynamic_mounts ORDER BY path",
 		);
@@ -144,7 +144,7 @@ async function ensureVm(
 		);
 		const vm = await AgentOs.create({
 			...options,
-			database: { type: "actor_uds", path, token },
+			database: { type: "actor_uds", path },
 			onAgentExit: (event) => {
 				c.log.error({
 					msg: "agent-os agent adapter exited unexpectedly",
@@ -203,6 +203,11 @@ async function ensureVm(
 		return await runtime.vm;
 	} catch (error) {
 		runtime.vm = null;
+		c.log.error({
+			msg: "agent-os vm bootstrap failed",
+			actorId: c.actorId,
+			error,
+		});
 		throw error;
 	}
 }
@@ -1159,6 +1164,7 @@ export function createAgentOS<
 			actionTimeout: DEFAULT_ACTION_TIMEOUT_MS,
 			sleepGracePeriod: DEFAULT_SLEEP_GRACE_PERIOD_MS,
 			...actorConfig.options,
+			enableActorRuntimeSocket: true,
 		},
 		db: db({ onMigrate: migrateAgentOsActorTables }),
 		events: { ...(actorConfig.events ?? {}), ...builtInEvents },

--- a/packages/agentos/tests/actor.test.ts
+++ b/packages/agentos/tests/actor.test.ts
@@ -437,9 +437,8 @@ describe("agentOS actor", () => {
 		const pending: Promise<unknown>[] = [];
 		const context = {
 			actorId: "hook-test",
-			actorUds: vi.fn(async () => ({
+			actorRuntimeSocket: vi.fn(async () => ({
 				path: "/tmp/actor.sock",
-				token: "token",
 			})),
 			broadcast: vi.fn(),
 			db: { execute: vi.fn(async () => []) },
@@ -518,9 +517,8 @@ describe("agentOS actor", () => {
 		const keepAwake = vi.fn(<T>(hold: Promise<T>) => hold);
 		const context = {
 			actorId: "prompt-keep-awake-test",
-			actorUds: vi.fn(async () => ({
+			actorRuntimeSocket: vi.fn(async () => ({
 				path: "/tmp/actor.sock",
-				token: "token",
 			})),
 			broadcast: vi.fn(),
 			db: { execute: vi.fn(async () => []) },
@@ -553,9 +551,8 @@ describe("agentOS actor", () => {
 		const log = { info: vi.fn(), error: vi.fn() };
 		const context = {
 			actorId: "prompt-error-test",
-			actorUds: vi.fn(async () => ({
+			actorRuntimeSocket: vi.fn(async () => ({
 				path: "/tmp/actor.sock",
-				token: "token",
 			})),
 			broadcast: vi.fn(),
 			db: { execute: vi.fn(async () => []) },
@@ -609,9 +606,8 @@ describe("agentOS actor", () => {
 		const log = { info: vi.fn(), error: vi.fn() };
 		const context = {
 			actorId: "terminal-exit-test",
-			actorUds: vi.fn(async () => ({
+			actorRuntimeSocket: vi.fn(async () => ({
 				path: "/tmp/actor.sock",
-				token: "token",
 			})),
 			broadcast: vi.fn(),
 			db: { execute: vi.fn(async () => []) },

--- a/packages/agentos/tests/fixtures/actor-runtime-server.mjs
+++ b/packages/agentos/tests/fixtures/actor-runtime-server.mjs
@@ -1,11 +1,3 @@
-Warning: Refused to snapshot some files:
-  registry/agent/pi/.cache/pi-acp-rust-target/wasm32-wasip1/release/deps/libagent_client_protocol_schema-a8b47b6b940f80a1.rlib: 18.9MiB (19837300 bytes); the maximum size allowed is 16.0MiB (16777216 bytes)
-Hint: This is to prevent large files from being added by accident. To fix this:
-  * Add the file(s) to `.gitignore`
-  * Run `jj config set --repo snapshot.max-new-file-size 19837300`
-    This will increase the maximum file size allowed for new files, in this repository only.
-  * Run `jj --config snapshot.max-new-file-size=19837300 status`
-    This will increase the maximum file size allowed for new files, for this command only.
 import { agentOS, setup } from "../../dist/index.js";
 import { allowAll } from "@rivet-dev/agentos-core/internal/runtime-compat";
 import {

--- a/packages/core/src/agent-os.ts
+++ b/packages/core/src/agent-os.ts
@@ -539,7 +539,7 @@ export type RootFilesystemConfig =
 
 /** VM-scoped SQLite storage shared by VFS and AgentOS durable state. */
 export type VmSqliteConfig =
-	| { type: "actor_uds"; path: string; token: string }
+	| { type: "actor_uds"; path: string }
 	| { type: "sqlite_file"; path: string };
 
 /**

--- a/packages/core/src/options-schema.ts
+++ b/packages/core/src/options-schema.ts
@@ -379,7 +379,6 @@ export const agentOsOptionFieldSchemas = {
 				.object({
 					type: z.literal("actor_uds"),
 					path: z.string().min(1),
-					token: z.string().min(1).max(4096),
 				})
 				.strict(),
 			z

--- a/packages/core/tests/options-schema.test.ts
+++ b/packages/core/tests/options-schema.test.ts
@@ -6,6 +6,17 @@ import {
 } from "../src/sandbox.js";
 
 describe("AgentOsOptions validation", () => {
+	test("accepts the path-only actor runtime socket descriptor", () => {
+		expect(
+			agentOsOptionsSchema.safeParse({
+				database: {
+					type: "actor_uds",
+					path: "/tmp/actor-runtime.sock",
+				},
+			}).success,
+		).toBe(true);
+	});
+
 	test("accepts a declarative sidecar-native root", () => {
 		expect(
 			agentOsOptionsSchema.safeParse({

--- a/packages/core/tests/pi-headless.test.ts
+++ b/packages/core/tests/pi-headless.test.ts
@@ -155,8 +155,8 @@ describe("full openSession({ agent: 'pi' }) inside the VM", () => {
 			});
 
 			const agentInfo = await vm.getSessionAgentInfo({ sessionId });
-			expect(agentInfo.name).toBe("pi-sdk-acp");
-			expect(agentInfo.title).toBe("Pi SDK ACP adapter");
+			expect(agentInfo.name).toBe("pi-acp");
+			expect(agentInfo.title).toBe("pi ACP adapter");
 			expect(agentInfo.version).toBeTruthy();
 
 			const capabilities = await vm.getSessionCapabilities({ sessionId });

--- a/packages/runtime-core/src/generated/VmSqliteDescriptor.ts
+++ b/packages/runtime-core/src/generated/VmSqliteDescriptor.ts
@@ -3,4 +3,4 @@
 /**
  * Transport used by the VM-scoped SQLite substrate.
  */
-export type VmSqliteDescriptor = { "type": "actor_uds", path: string, token: string, } | { "type": "sqlite_file", path: string, };
+export type VmSqliteDescriptor = { "type": "actor_uds", path: string, } | { "type": "sqlite_file", path: string, };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   rivetkit:
     '@rivetkit/react':
-      specifier: 0.0.0-sqlite-uds.4e59a38
-      version: 0.0.0-sqlite-uds.4e59a38
+      specifier: 2.3.5
+      version: 2.3.5
     rivetkit:
-      specifier: 0.0.0-sqlite-uds.4e59a38
-      version: 0.0.0-sqlite-uds.4e59a38
+      specifier: 2.3.5
+      version: 2.3.5
 
 overrides:
   '@rivet-dev/agentos-core': workspace:*
@@ -115,7 +115,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -143,7 +143,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -183,7 +183,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -232,7 +232,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -281,7 +281,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -324,7 +324,7 @@ importers:
         version: link:../../packages/agentos
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -339,7 +339,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/react':
         specifier: ^19.0.0
@@ -379,7 +379,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -422,7 +422,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -471,7 +471,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -520,7 +520,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -569,7 +569,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -618,7 +618,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -667,7 +667,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -716,7 +716,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -765,7 +765,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -814,7 +814,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -863,7 +863,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -912,7 +912,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -961,7 +961,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1010,7 +1010,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1059,7 +1059,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1108,7 +1108,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1157,7 +1157,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1206,7 +1206,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1255,7 +1255,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1310,7 +1310,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1362,7 +1362,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1411,7 +1411,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1479,7 +1479,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1528,7 +1528,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1577,7 +1577,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1626,7 +1626,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1675,7 +1675,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1724,7 +1724,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1773,7 +1773,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1822,7 +1822,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1871,7 +1871,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1920,7 +1920,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1969,7 +1969,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2018,7 +2018,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2067,7 +2067,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2125,7 +2125,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2177,7 +2177,7 @@ importers:
         version: 4.12.9
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2226,7 +2226,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2272,7 +2272,7 @@ importers:
         version: 9.14.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -2306,10 +2306,10 @@ importers:
         version: link:../core
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -2938,7 +2938,7 @@ importers:
         version: 14.0.3
       rivetkit:
         specifier: catalog:rivetkit
-        version: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.19.3
@@ -5873,102 +5873,114 @@ packages:
     resolution: {integrity: sha512-3qndQUQXLdwafMEqfhz24hUtDPcsf1Bu3q52Kb8MqeH8JUh3h6R4HYW3ZJXiQsLcyYyFM68PuIwlLRlg1xDEpg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@rivetkit/engine-cli-darwin-arm64@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-ZT+wqmQzLznezyYVTzRHckWbp7F4yOG3ZCCON+ErdnWd84A4mwJMYXZPIObGD2OVSxmNhWqXO1ocNTKwDsIllw==}
+  '@rivetkit/engine-cli-darwin-arm64@2.3.5':
+    resolution: {integrity: sha512-u2xAkC9vJOvzfNVlw1OA/VTgqX0+gX6TNhHyGOevOfYY+wl5WS5EIoY9Hi/SYQMEAUnQcHadIlZRlxvCE6XscA==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-darwin-x64@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-PgiKyvhciN17C7RjyB9J9ApVkCTJmdyaRZnsSmy0xdbNY12uKrhH2mNcaQAPV+7/QB4HB4TjVgD1wT+PCCGiQg==}
+  '@rivetkit/engine-cli-darwin-x64@2.3.5':
+    resolution: {integrity: sha512-RjTl9/d2h0B+WiJND/XVoWHVrKHIzJUhugTamwwM/DWLFTJBuEnVBoEOXHhpkqhowwpd3rSdTlbgfURK3rSE6g==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-2FZhrpzYfNIId3Tn0wpz1klcoKZjf2NBzGkmdxGQKY0kh7XynBsZxUnqyHJVFAkfLSSW+1t8E6PLTMSfPHIKXQ==}
+  '@rivetkit/engine-cli-linux-arm64-musl@2.3.5':
+    resolution: {integrity: sha512-V18tiHM5eNH31RQe/dRgZW1BuBlptHgMeesyKV8teRMvpVhXfxoe+9rQKA49nCKCsiLSktQwNhswkN18PGd3uQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-iw3v07nBtc1+qiQxl/g3HPT9UPOJUidvOYixPpxtydaRqh465/6pYy8cTzQOhEKBodBD3drsaB+6GJwDLy8CMA==}
+  '@rivetkit/engine-cli-linux-x64-musl@2.3.5':
+    resolution: {integrity: sha512-/yJPsQbfe3lIsgPKq5BEvHXQRYurQ4gy3HNrkI4OIG7rQnTdOgbOkZyaKaY7yUqyqq4EyWijSsUAtrvjQvxx7Q==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/engine-cli@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-5WYBHyO4Yudb2RuVbbp2srb/XDbEAdTihxUj/aUerahalR3KiNDo5zpUZpfhhoAQrjPQTVTN9Nan/RVloVpFRg==}
+  '@rivetkit/engine-cli-win32-x64@2.3.5':
+    resolution: {integrity: sha512-TVD9KhRhieypbj6fO3MdrbeontM4yQTuiHaGqOfjd+2ynj4GbUIya6hDQjfRXCUM12OFmvlKLAOfLDCNpkBQ7Q==}
+    engines: {node: '>= 20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rivetkit/engine-cli@2.3.5':
+    resolution: {integrity: sha512-A/gIO6sNcOgkKjYBIFwTIm7rD7GquxUWBkh2t07Aju/elFp4bxEnUVvESyDWZPunDOoBHlT454gbpbWtVLiuhA==}
     engines: {node: '>= 20.0.0'}
 
-  '@rivetkit/engine-envoy-protocol@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-asUWA8E+fyD1RLQ5wH6KhCTNZ3laAqqS2bZQkcMQS8mQn/9BVl+sfCm/yM3hLK7lH7WT616sJhcP86EktZCLsA==}
+  '@rivetkit/engine-envoy-protocol@2.3.5':
+    resolution: {integrity: sha512-GSoI2hJ5XnXIufZvvpeCYJCjEd2AUtaSJWmP/3X250mp3W06C7PnBmalziOcBCLQeROu9EG6gii2eBG8RylaCQ==}
 
-  '@rivetkit/framework-base@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-s4yFjZZbcPXA++VfS5n1FgEohSG2gJec/svlmV2zko3Q4iqMip7g4/6DIU+5wsD1EkCwKE2dmuYdn0ML9sTtbQ==}
+  '@rivetkit/framework-base@2.3.5':
+    resolution: {integrity: sha512-B8y6Smjw2MU44hOmWJjD8beCDErCGq89Lb0QjvxBjyDnBewG8je1ajy3adVLho9Yf2KTVUa+cNizq7amm05quQ==}
 
   '@rivetkit/on-change@6.0.1':
     resolution: {integrity: sha512-QBN/KRBXLJdCgN4gBTL3XAc/zKm58atSnieXWMOyFSPmo6F1/yIVV/LTRdvAktfCttrGx7W6c32i/lwqCHWnsQ==}
     engines: {node: '>=20'}
 
-  '@rivetkit/react@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-O2DWeQ7RvisfhVV0s5BOy/+BSSRrthS8ntVqFcDAhSiXKex6iUQSflhA4mkfcVW4/XWOzLmf2tNYPxEul/hKhw==}
+  '@rivetkit/react@2.3.5':
+    resolution: {integrity: sha512-wKjVxja+Zu+2GeQqg1u4jsICZRTbO6biqh80hcwcT0X2jtt/A5IWgaRjsL0J3wLZ+qsLuZkqH7Ry54Dlxr+kNw==}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-sH/wB5IvlDQ7lktL7lk/1h5K8/Rxm/UYyY8GKGOdPzgIhBK7RNE194vhlLLgjWCU2P5eTo/uG8U5n7Shw1VoBA==}
+  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.5':
+    resolution: {integrity: sha512-WQw784r/qZj20c2n/gFqHSbxIuXciHc0+nSMGNB/Hg+8Io1+ubS+HwNoYP1fdLdFVZMlEmv+LtNwq6e9nKne6g==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-E8Lt44QIOjzNnrFDWALpIFn3p593l57Y7z5mmY4oK0xScJlw8hL6jn0ISvCA1BRd0wPTy5/fwCUxGAivhhVJAg==}
+  '@rivetkit/rivetkit-napi-darwin-x64@2.3.5':
+    resolution: {integrity: sha512-csmbh7OOhkHqOYV8xpBInrV4kj2OtSqEzThoVWfIWBhi0034tV62jiV+5cQeGhZe3K61rYPCa3KTS27jZOhSvw==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-xdFAuc0s8tj6p63zeY/IoS0JKtnmTh6RyOauy+8cptTzGDUXcQnuzQU28YjPJ535je7aGIlJYfSXhL/rd4kmZA==}
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.5':
+    resolution: {integrity: sha512-R6BLMzCnI6eG42QYpgVHMk6zDAtvCiBR60UhWVPv4tWtOYFzTKtADP1VdEFGR8xcLUNewAysace711bnH7dSLQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-W6gTRHX1Sx9Oi2KoPpEN1fENEkF/dqvpc5OqNJErCcW8M2WCB/0BU/c7nHsP54ZLzS0kcZtaQov6qw0Nt2eaWA==}
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.5':
+    resolution: {integrity: sha512-rwfFzHwt7QjCK8lF/ttIHxojE90JDhVfyDr9jnnDJskehP4lNCZtdfewUQM869dtgcr1Dz2BV8mY6UM5JoLhVQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-BY8SZke/5iHh35rFrkJ+GkmMelezHaIrClxjpZ6a3Yfu4owAfOUCOSTHZttYAoba4EdnCpB8aTQ2SimtvNN77g==}
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.5':
+    resolution: {integrity: sha512-KZxr4zTFEG5UokI7foz+X+lBvzyUh+D1LccPSjNS9By8RJgh+PdROfEimlwUIOr9SAf5RQHXuTccYLzUWgdCBQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-rxtzRH2hpaz8hx6F1GIIM7f0FpDzyBKNtmusDQswmYajkm/Hfxl9ha2bleHg6EFtNVAr8gQ9cHAZcAv583bAJw==}
+  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.5':
+    resolution: {integrity: sha512-2qHwi49thBgAGNDGGKy7o2GODl/h215cDC/cOanfkTLtwbSJPkuric+ITA0i6oCUPePMmaJf6DIPf+tOQzO2LA==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-0SibmwqUugIfgRdwuG45+SvjMLzk5Bim/cViOtnt2FrucNB1E/YeC7QD4MxMi/Z+z+M/A33dljUst70C2f5uVA==}
+  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.5':
+    resolution: {integrity: sha512-cOt2wkC7HY+KBaRijBzqlkK7dhv4qZHRhdsTZWwCuOOeJPT426F/92nBYYCz30+211VrFK2Ic6Q1hDUl7mBoaQ==}
+    engines: {node: '>= 20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rivetkit/rivetkit-napi@2.3.5':
+    resolution: {integrity: sha512-H7SctWpugmKLk0Ebx6fIq4/svPIIyG7M8IEPa9f4SqVRg8eqQCLNpWheygl+FdD4VrrUMJJfm8IDZ5At5+x99g==}
     engines: {node: '>= 20.0.0'}
 
   '@rivetkit/rivetkit-wasm@2.3.2':
     resolution: {integrity: sha512-HNBzh6uQFi4ZYL0tHAZ6nrYKoGCfa+kObLCwdS+/ZzGePV7WGUl20Do1bHjBtnVgp9UwzQu+lka8kFwKfqm6WA==}
 
-  '@rivetkit/traces@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-4d9Kodk7H0frBHNTmzJBXkOGKGgn5eU+A9XTmOTsoHIpPqK5AUrbJ35P2mQHQmzoU+WoHUumvey0Ze8UOKIy/Q==}
+  '@rivetkit/traces@2.3.5':
+    resolution: {integrity: sha512-aU/5hm83dB5P3v/EWruwHbtu5Tc02YNuJHprIaj7FZNOf4AAW9ropdb9OafzPykEtuwIwSoCAT4qtuMkY+7CrQ==}
     engines: {node: '>=18.0.0'}
 
-  '@rivetkit/virtual-websocket@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-U6C9jSf4VaQGEZTROFZHLsfCUci8No4ofBV6muzqmAKTiq6NN7mLE5V0muc0LTUx5dFpcX9hATJW1FSZVpnbYw==}
+  '@rivetkit/virtual-websocket@2.3.5':
+    resolution: {integrity: sha512-LPXssVv22e//7zZLzJ5Lw62fWWDiBKE091tRxrYi0R9W/uqtSWCC82DGpyOMim03bVwhixuiNvVXLNVo9Gngow==}
 
-  '@rivetkit/workflow-engine@0.0.0-sqlite-uds.4e59a38':
-    resolution: {integrity: sha512-TUe2ZEg2D8yCNZTr+F6eeMp2uK2VAybYHhMj1IQUOuWwSyamBD8o5UFkqO12nYcE+52a7NwfHwhHEov8riVb1w==}
+  '@rivetkit/workflow-engine@2.3.5':
+    resolution: {integrity: sha512-T6xh8tLfU1bODFtHJHCvRkML2Ahy9C653mIZ2bsMnryEKBQE4uG5I4WczHSgdkSpUZk7+ZoKwiR52PFdqJYEyQ==}
     engines: {node: '>=18.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
@@ -9013,8 +9025,8 @@ packages:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
     engines: {node: '>= 0.8'}
 
-  rivetkit@0.0.0-sqlite-uds.4e59a38:
-    resolution: {integrity: sha512-cZnF3JMeMFirZISiYtZHGrpBPuFXN52A0ctEoM5zON2g7g17x4N3z+sNJOqaUenPL9f73Sv8YPU97UMdeDiZWQ==}
+  rivetkit@2.3.5:
+    resolution: {integrity: sha512-RgRlK2Qj3eeqZtebBslj0XM6bMDv1hvBsJg/M/LRHg//1dx67dWS15hSYgkcZz1LQxCoAdc84fhaBvgKJtUQbA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       drizzle-kit: ^0.31.2
@@ -12307,34 +12319,38 @@ snapshots:
 
   '@rivetkit/bare-ts@0.6.2': {}
 
-  '@rivetkit/engine-cli-darwin-arm64@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-cli-darwin-arm64@2.3.5':
     optional: true
 
-  '@rivetkit/engine-cli-darwin-x64@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-cli-darwin-x64@2.3.5':
     optional: true
 
-  '@rivetkit/engine-cli-linux-arm64-musl@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-cli-linux-arm64-musl@2.3.5':
     optional: true
 
-  '@rivetkit/engine-cli-linux-x64-musl@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-cli-linux-x64-musl@2.3.5':
     optional: true
 
-  '@rivetkit/engine-cli@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-cli-win32-x64@2.3.5':
+    optional: true
+
+  '@rivetkit/engine-cli@2.3.5':
     optionalDependencies:
-      '@rivetkit/engine-cli-darwin-arm64': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/engine-cli-darwin-x64': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/engine-cli-linux-arm64-musl': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/engine-cli-linux-x64-musl': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/engine-cli-darwin-arm64': 2.3.5
+      '@rivetkit/engine-cli-darwin-x64': 2.3.5
+      '@rivetkit/engine-cli-linux-arm64-musl': 2.3.5
+      '@rivetkit/engine-cli-linux-x64-musl': 2.3.5
+      '@rivetkit/engine-cli-win32-x64': 2.3.5
 
-  '@rivetkit/engine-envoy-protocol@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/engine-envoy-protocol@2.3.5':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
 
-  '@rivetkit/framework-base@0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/framework-base@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@tanstack/store': 0.7.7
       fast-deep-equal: 3.1.3
-      rivetkit: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -12372,13 +12388,13 @@ snapshots:
 
   '@rivetkit/on-change@6.0.1': {}
 
-  '@rivetkit/react@0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/react@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
-      '@rivetkit/framework-base': 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      '@rivetkit/framework-base': 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       '@tanstack/react-store': 0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      rivetkit: 0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -12414,48 +12430,52 @@ snapshots:
       - sqlite3
       - ws
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi-darwin-x64@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-darwin-x64@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.5':
     optional: true
 
-  '@rivetkit/rivetkit-napi@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.5':
+    optional: true
+
+  '@rivetkit/rivetkit-napi@2.3.5':
     dependencies:
       '@napi-rs/cli': 2.18.4
-      '@rivetkit/engine-envoy-protocol': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/engine-envoy-protocol': 2.3.5
     optionalDependencies:
-      '@rivetkit/rivetkit-napi-darwin-arm64': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/rivetkit-napi-darwin-x64': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/rivetkit-napi-linux-arm64-musl': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/rivetkit-napi-linux-x64-gnu': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/rivetkit-napi-linux-x64-musl': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/rivetkit-napi-darwin-arm64': 2.3.5
+      '@rivetkit/rivetkit-napi-darwin-x64': 2.3.5
+      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 2.3.5
+      '@rivetkit/rivetkit-napi-linux-arm64-musl': 2.3.5
+      '@rivetkit/rivetkit-napi-linux-x64-gnu': 2.3.5
+      '@rivetkit/rivetkit-napi-linux-x64-musl': 2.3.5
+      '@rivetkit/rivetkit-napi-win32-x64-msvc': 2.3.5
 
   '@rivetkit/rivetkit-wasm@2.3.2': {}
 
-  '@rivetkit/traces@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/traces@2.3.5':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
       fdb-tuple: 1.0.0
       vbare: 0.0.4
 
-  '@rivetkit/virtual-websocket@0.0.0-sqlite-uds.4e59a38': {}
+  '@rivetkit/virtual-websocket@2.3.5': {}
 
-  '@rivetkit/workflow-engine@0.0.0-sqlite-uds.4e59a38':
+  '@rivetkit/workflow-engine@2.3.5':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
@@ -15724,19 +15744,19 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rivetkit@0.0.0-sqlite-uds.4e59a38(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
+  rivetkit@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.9)(zod@4.3.6)
       '@rivet-dev/agent-os-core': 0.1.1(pyodide@0.28.3(bufferutil@4.1.0))
       '@rivetkit/bare-ts': 0.6.2
-      '@rivetkit/engine-cli': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/engine-envoy-protocol': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/engine-cli': 2.3.5
+      '@rivetkit/engine-envoy-protocol': 2.3.5
       '@rivetkit/on-change': 6.0.1
-      '@rivetkit/rivetkit-napi': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/rivetkit-napi': 2.3.5
       '@rivetkit/rivetkit-wasm': 2.3.2
-      '@rivetkit/traces': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/virtual-websocket': 0.0.0-sqlite-uds.4e59a38
-      '@rivetkit/workflow-engine': 0.0.0-sqlite-uds.4e59a38
+      '@rivetkit/traces': 2.3.5
+      '@rivetkit/virtual-websocket': 2.3.5
+      '@rivetkit/workflow-engine': 2.3.5
       cbor-x: 1.6.4
       drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)
       hono: 4.12.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,9 +57,9 @@ onlyBuiltDependencies:
 # pinned once here and referenced everywhere via `catalog:rivetkit`.
 catalogs:
   rivetkit:
-    rivetkit: 0.0.0-sqlite-uds.4e59a38
-    '@rivetkit/react': 0.0.0-sqlite-uds.4e59a38
+    rivetkit: 2.3.5
+    '@rivetkit/react': 2.3.5
 
 overrides:
-  '@rivetkit/rivetkit-wasm': 2.3.2
+  '@rivetkit/rivetkit-wasm': 2.3.5
   web-streams-polyfill: 3.3.3


### PR DESCRIPTION
## Summary
- upgrade the RivetKit dependency family from the custom sqlite-uds build to stable 2.3.5
- migrate AgentOS actor persistence to RivetKit Actor Runtime Socket v1, including explicit transaction leases
- update path-only configuration validation and adapter metadata assertions

## Local validation
- full workspace build
- Rust actor socket, native sidecar, sidecar session-store, and VM-config tests
- AgentOS test:pr: 33/33 passed, including real Rivet actor conformance
- credentialed real Pi prompt + shell tool + file write + durable history E2E