### PR TITLE
fix(software): republish default commands with executable metadata

### DIFF
--- a/software/coreutils/package.json
+++ b/software/coreutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/coreutils",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU coreutils for secure-exec VMs (sh, cat, ls, cp, sort, and 80+ commands)",

--- a/software/diffutils/package.json
+++ b/software/diffutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/diffutils",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU diffutils for secure-exec VMs (diff)",

--- a/software/findutils/package.json
+++ b/software/findutils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/findutils",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU findutils for secure-exec VMs (find, xargs)",

--- a/software/gawk/package.json
+++ b/software/gawk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/gawk",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU awk text processing for secure-exec VMs",

--- a/software/grep/package.json
+++ b/software/grep/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/grep",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU grep pattern matching for secure-exec VMs (grep, egrep, fgrep)",

--- a/software/gzip/package.json
+++ b/software/gzip/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/gzip",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU gzip compression for secure-exec VMs (gzip, gunzip, zcat)",

--- a/software/sed/package.json
+++ b/software/sed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/sed",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU sed stream editor for secure-exec VMs",

--- a/software/tar/package.json
+++ b/software/tar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentos-software/tar",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "GNU tar archiver for secure-exec VMs",


### PR DESCRIPTION
## Summary
- bump the eight default command bundles to 0.3.4
- republish rebuilt `.aospkg` archives carrying current executable metadata
- allow the next AgentOS `common` release to pin compatible command artifacts

## Validation
- all eight 0.3.4 packages are published and resolve as npm latest
- credentialed local AgentOS + real Pi shell-tool/file-write E2E passes with the rebuilt bundles