### PR TITLE
fix(publish): exclude website from package build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -300,6 +300,7 @@ jobs:
           # Browser support is retained in-tree but intentionally disabled until
           # it has a reactor/security design independent of the native sidecar.
           npx turbo build \
+            --filter='!@rivet-dev/agentos-website' \
             --filter='!@rivet-dev/agentos-browser' \
             --filter='!@rivet-dev/agentos-runtime-browser' \
             --filter='!@rivet-dev/agentos-playground' \


### PR DESCRIPTION
- Exclude the website from the npm publish Turbo build, matching the filtered dependency install.
- Prevent release builds from failing on unavailable website-only tooling.