### PR TITLE
fix(eve): align Vercel Eve release dependencies

### DIFF
--- a/examples/vercel-eve/agent/agent.ts
+++ b/examples/vercel-eve/agent/agent.ts
@@ -14,6 +14,6 @@ export default defineAgent({
 		],
 	},
 	experimental: {
-		workflow: { world: "./world.ts" },
+		workflow: { world: "#world" },
 	},
 });

--- a/examples/vercel-eve/package.json
+++ b/examples/vercel-eve/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.1",
 	"private": true,
 	"type": "module",
+	"imports": {
+		"#world": "./world.ts"
+	},
 	"scripts": {
 		"build": "eve build",
 		"dev": "eve dev",
@@ -13,6 +16,7 @@
 		"@rivet-dev/agentos": "workspace:*",
 		"@rivet-dev/agentos-core": "workspace:*",
 		"@rivet-dev/agentos-eve": "workspace:*",
+		"@rivet-dev/vercel-world": "2.3.7",
 		"@vercel/connect": "0.4.0",
 		"ai": "7.0.26",
 		"eve": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"@rivetkit/rivetkit-wasm": "2.3.2",
+			"@rivetkit/rivetkit-wasm": "2.3.7",
 			"@mariozechner/pi-tui": "0.60.0",
 			"@mariozechner/pi-agent-core": "0.60.0"
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,15 @@ settings:
 catalogs:
   rivetkit:
     '@rivetkit/react':
-      specifier: 2.3.5
-      version: 2.3.5
+      specifier: 2.3.7
+      version: 2.3.7
     rivetkit:
-      specifier: 2.3.5
-      version: 2.3.5
+      specifier: 2.3.7
+      version: 2.3.7
 
 overrides:
   '@rivet-dev/agentos-core': workspace:*
-  '@rivetkit/rivetkit-wasm': 2.3.2
+  '@rivetkit/rivetkit-wasm': 2.3.7
   '@mariozechner/pi-tui': 0.60.0
   '@mariozechner/pi-agent-core': 0.60.0
 
@@ -115,7 +115,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -143,7 +143,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -183,7 +183,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -232,7 +232,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -281,7 +281,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -324,7 +324,7 @@ importers:
         version: link:../../packages/agentos
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -339,7 +339,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/react':
         specifier: ^19.0.0
@@ -379,7 +379,7 @@ importers:
         version: link:../../packages/agentos
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -422,7 +422,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -471,7 +471,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -520,7 +520,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -569,7 +569,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -618,7 +618,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -667,7 +667,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -716,7 +716,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -765,7 +765,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -814,7 +814,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -863,7 +863,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -912,7 +912,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -961,7 +961,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1010,7 +1010,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1059,7 +1059,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1108,7 +1108,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1157,7 +1157,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1206,7 +1206,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1255,7 +1255,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1310,7 +1310,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1362,7 +1362,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1411,7 +1411,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1479,7 +1479,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1528,7 +1528,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1577,7 +1577,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1626,7 +1626,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1675,7 +1675,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1724,7 +1724,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1773,7 +1773,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1822,7 +1822,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1871,7 +1871,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1920,7 +1920,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -1969,7 +1969,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2018,7 +2018,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2067,7 +2067,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2125,7 +2125,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2154,6 +2154,9 @@ importers:
       '@rivet-dev/agentos-eve':
         specifier: workspace:*
         version: link:../../packages/eve
+      '@rivet-dev/vercel-world':
+        specifier: 2.3.7
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.21.0(bufferutil@4.1.0))
       '@vercel/connect':
         specifier: 0.4.0
         version: 0.4.0(ai@7.0.26(zod@4.3.6))(eve@0.27.0(@opentelemetry/api@1.9.0)(ai@7.0.26(zod@4.3.6))(aws4fetch@1.0.20)(better-sqlite3@12.8.0)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0))(jiti@2.7.0)(lru-cache@11.2.7))
@@ -2208,7 +2211,7 @@ importers:
         version: 4.12.9
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2257,7 +2260,7 @@ importers:
         version: 7.2.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       sandbox-agent:
         specifier: ^0.4.2
         version: 0.4.2(@vercel/sandbox@2.8.0)(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6)
@@ -2303,7 +2306,7 @@ importers:
         version: 9.14.0
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -2337,10 +2340,10 @@ importers:
         version: link:../core
       '@rivetkit/react':
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -2993,7 +2996,7 @@ importers:
         version: 14.0.3
       rivetkit:
         specifier: catalog:rivetkit
-        version: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+        version: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     devDependencies:
       '@types/node':
         specifier: ^22.19.3
@@ -7294,6 +7297,10 @@ packages:
       pyodide:
         optional: true
 
+  '@rivet-dev/vercel-world@2.3.7':
+    resolution: {integrity: sha512-abtMmQUwNGgjXYcbS3WWZV6ahUAvV/bo4wENrwCBs7fi33bV8oR0+LS22A2tu9T7Syu0f+LyLNgjPMO96HLiiw==}
+    engines: {node: '>=22.0.0'}
+
   '@rivet-gg/components@file:website/vendor/theme/vendor/components':
     resolution: {directory: website/vendor/theme/vendor/components, type: directory}
     peerDependencies:
@@ -7320,114 +7327,114 @@ packages:
     resolution: {integrity: sha512-3qndQUQXLdwafMEqfhz24hUtDPcsf1Bu3q52Kb8MqeH8JUh3h6R4HYW3ZJXiQsLcyYyFM68PuIwlLRlg1xDEpg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@rivetkit/engine-cli-darwin-arm64@2.3.5':
-    resolution: {integrity: sha512-u2xAkC9vJOvzfNVlw1OA/VTgqX0+gX6TNhHyGOevOfYY+wl5WS5EIoY9Hi/SYQMEAUnQcHadIlZRlxvCE6XscA==}
+  '@rivetkit/engine-cli-darwin-arm64@2.3.7':
+    resolution: {integrity: sha512-F3yGSDIaW94BZzuAm3erQRT/Ki55wHJ/b6tOaE7d9tRmTAZw/XqHmjNdUYjOvFUQKLb+SSsOittM4dINrAANQQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-darwin-x64@2.3.5':
-    resolution: {integrity: sha512-RjTl9/d2h0B+WiJND/XVoWHVrKHIzJUhugTamwwM/DWLFTJBuEnVBoEOXHhpkqhowwpd3rSdTlbgfURK3rSE6g==}
+  '@rivetkit/engine-cli-darwin-x64@2.3.7':
+    resolution: {integrity: sha512-P8BbQsamIvv8U/cEoJUFr+uAzwjjl9cG+ZZxjDX9OJxbuD11ESpHvDLgge54ijynO3IjoP8cIzjIXat6mr2Gkw==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/engine-cli-linux-arm64-musl@2.3.5':
-    resolution: {integrity: sha512-V18tiHM5eNH31RQe/dRgZW1BuBlptHgMeesyKV8teRMvpVhXfxoe+9rQKA49nCKCsiLSktQwNhswkN18PGd3uQ==}
+  '@rivetkit/engine-cli-linux-arm64-musl@2.3.7':
+    resolution: {integrity: sha512-G3s76BHfIs6R9rm6JYI13sOjPLy08+C8WvVoFwSdMqsibEaqlfo36wVkp/x1g0sEZUek/dBxVrKqMMR7c4/gug==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/engine-cli-linux-x64-musl@2.3.5':
-    resolution: {integrity: sha512-/yJPsQbfe3lIsgPKq5BEvHXQRYurQ4gy3HNrkI4OIG7rQnTdOgbOkZyaKaY7yUqyqq4EyWijSsUAtrvjQvxx7Q==}
+  '@rivetkit/engine-cli-linux-x64-musl@2.3.7':
+    resolution: {integrity: sha512-LWhrUVzULcsZ4ufCLsx23YfrdMW2INd9g0ANBac9+PzGwL8qYfVIXnDpR3587lapu68EbSEPZcconf1tBlvJxQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/engine-cli-win32-x64@2.3.5':
-    resolution: {integrity: sha512-TVD9KhRhieypbj6fO3MdrbeontM4yQTuiHaGqOfjd+2ynj4GbUIya6hDQjfRXCUM12OFmvlKLAOfLDCNpkBQ7Q==}
+  '@rivetkit/engine-cli-win32-x64@2.3.7':
+    resolution: {integrity: sha512-jyA5PlHivHXyyq2ehnuXwxd5TUSbB4emomnph9EovsJo7qIdmSNaaCO13NYBT483fd0uXiNI0MK/lkJa9ePY5A==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@rivetkit/engine-cli@2.3.5':
-    resolution: {integrity: sha512-A/gIO6sNcOgkKjYBIFwTIm7rD7GquxUWBkh2t07Aju/elFp4bxEnUVvESyDWZPunDOoBHlT454gbpbWtVLiuhA==}
+  '@rivetkit/engine-cli@2.3.7':
+    resolution: {integrity: sha512-CezLwJ0B7dWDbA7qM6Aq04mwnrJAdrDActRrrcb4NBa20h7wO9KPAYBwyJz/dRnKm9EUUNcFZ6hrSDpp6T3+Rg==}
     engines: {node: '>= 20.0.0'}
 
-  '@rivetkit/engine-envoy-protocol@2.3.5':
-    resolution: {integrity: sha512-GSoI2hJ5XnXIufZvvpeCYJCjEd2AUtaSJWmP/3X250mp3W06C7PnBmalziOcBCLQeROu9EG6gii2eBG8RylaCQ==}
+  '@rivetkit/engine-envoy-protocol@2.3.7':
+    resolution: {integrity: sha512-lsJM3ERwozQCebaOMKJzqIQlcLbbN3LXurRB0+7LsM6FUUL2l6hMoq5I2De/G35DJ6OWDva9AmzfvzI+5f1GPg==}
 
-  '@rivetkit/framework-base@2.3.5':
-    resolution: {integrity: sha512-B8y6Smjw2MU44hOmWJjD8beCDErCGq89Lb0QjvxBjyDnBewG8je1ajy3adVLho9Yf2KTVUa+cNizq7amm05quQ==}
+  '@rivetkit/framework-base@2.3.7':
+    resolution: {integrity: sha512-zxmdAzFogA3PeT3ZgFIoYlEAJVi3iCwbPBXczZKf2x2QMCl2cTZ2jswFCAgHUUMQWj+AWiX65usxq73a9Ls/qQ==}
 
   '@rivetkit/on-change@6.0.1':
     resolution: {integrity: sha512-QBN/KRBXLJdCgN4gBTL3XAc/zKm58atSnieXWMOyFSPmo6F1/yIVV/LTRdvAktfCttrGx7W6c32i/lwqCHWnsQ==}
     engines: {node: '>=20'}
 
-  '@rivetkit/react@2.3.5':
-    resolution: {integrity: sha512-wKjVxja+Zu+2GeQqg1u4jsICZRTbO6biqh80hcwcT0X2jtt/A5IWgaRjsL0J3wLZ+qsLuZkqH7Ry54Dlxr+kNw==}
+  '@rivetkit/react@2.3.7':
+    resolution: {integrity: sha512-Y3UoUYhkLKDQrJdloCmYK+fhJMlPw5BPHbRb5VutFh5L8csIRZLoCoMitzV7mjNUxuDE1+k10iGuUHYPZUP4aA==}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.5':
-    resolution: {integrity: sha512-WQw784r/qZj20c2n/gFqHSbxIuXciHc0+nSMGNB/Hg+8Io1+ubS+HwNoYP1fdLdFVZMlEmv+LtNwq6e9nKne6g==}
+  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.7':
+    resolution: {integrity: sha512-gI1wMe6z85VDeR4K/wnzevVakXTg5UCfvjlDOp1+23nyU3NlInhN156dEWO8EsfRMrs+1bYoGdc4rcoN+4PUrw==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-darwin-x64@2.3.5':
-    resolution: {integrity: sha512-csmbh7OOhkHqOYV8xpBInrV4kj2OtSqEzThoVWfIWBhi0034tV62jiV+5cQeGhZe3K61rYPCa3KTS27jZOhSvw==}
+  '@rivetkit/rivetkit-napi-darwin-x64@2.3.7':
+    resolution: {integrity: sha512-H5tUwvCbKwTIBiyQG01ikK5mdc9ISg+bv8gPUw41mYOKq8rb9nBLkcl2TKcreFHac8KaGxtnBZzYcjbUV3NcwQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.5':
-    resolution: {integrity: sha512-R6BLMzCnI6eG42QYpgVHMk6zDAtvCiBR60UhWVPv4tWtOYFzTKtADP1VdEFGR8xcLUNewAysace711bnH7dSLQ==}
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.7':
+    resolution: {integrity: sha512-MpOeiO5M737e93hM/FjcH+zv8xBEX1tgBd/59K/Uw7qlRbWW7JGz8WGjavdxv211LRqxsn8EUlGRxcADDsXnBA==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.5':
-    resolution: {integrity: sha512-rwfFzHwt7QjCK8lF/ttIHxojE90JDhVfyDr9jnnDJskehP4lNCZtdfewUQM869dtgcr1Dz2BV8mY6UM5JoLhVQ==}
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.7':
+    resolution: {integrity: sha512-0GsUgd/HHvIq6v92kp0H175mGm2Exvs4krBLih0MIpVAkqJk8EIcKI6wJhCwY04Fr0MS8sHkUhjuHXa7QcmlYA==}
     engines: {node: '>= 20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.5':
-    resolution: {integrity: sha512-KZxr4zTFEG5UokI7foz+X+lBvzyUh+D1LccPSjNS9By8RJgh+PdROfEimlwUIOr9SAf5RQHXuTccYLzUWgdCBQ==}
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.7':
+    resolution: {integrity: sha512-8wCD1FuDpM+yiKRG8ro1K8ILVpJXzCNKViJ1axq1b4Nyqgod/nyEvvKDaT4qhA5+Om+W5i6YRO1uddjC6QjJSQ==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.5':
-    resolution: {integrity: sha512-2qHwi49thBgAGNDGGKy7o2GODl/h215cDC/cOanfkTLtwbSJPkuric+ITA0i6oCUPePMmaJf6DIPf+tOQzO2LA==}
+  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.7':
+    resolution: {integrity: sha512-8RGzXD33GH1/DWufFzCZRI+npF5IL/9z7Ja3pthsuYgrL+axGG0iqfAjbwj5HHnB/ceUGQVT+uCKzoLnG+odtw==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.5':
-    resolution: {integrity: sha512-cOt2wkC7HY+KBaRijBzqlkK7dhv4qZHRhdsTZWwCuOOeJPT426F/92nBYYCz30+211VrFK2Ic6Q1hDUl7mBoaQ==}
+  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.7':
+    resolution: {integrity: sha512-n1by/coKxWOb2FZDGLM2qmULxcLSqx8hxJuk7Hsb1gl4uNHGviUzYr+r7WAiOzonK/Dgy477u3OKf5yBie743A==}
     engines: {node: '>= 20.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@rivetkit/rivetkit-napi@2.3.5':
-    resolution: {integrity: sha512-H7SctWpugmKLk0Ebx6fIq4/svPIIyG7M8IEPa9f4SqVRg8eqQCLNpWheygl+FdD4VrrUMJJfm8IDZ5At5+x99g==}
+  '@rivetkit/rivetkit-napi@2.3.7':
+    resolution: {integrity: sha512-1d3HtNKzJwdkznWDWSpCwg1rBn+nVwUfcKrApINTfiEhfDyVeznwbVFkfHWqOBHsjU17vvWFfjjTtf8QsjLwUQ==}
     engines: {node: '>= 20.0.0'}
 
-  '@rivetkit/rivetkit-wasm@2.3.2':
-    resolution: {integrity: sha512-HNBzh6uQFi4ZYL0tHAZ6nrYKoGCfa+kObLCwdS+/ZzGePV7WGUl20Do1bHjBtnVgp9UwzQu+lka8kFwKfqm6WA==}
+  '@rivetkit/rivetkit-wasm@2.3.7':
+    resolution: {integrity: sha512-o7QBtFOJrajyPVBIDQ32k8sDNFsUc8v2ETfNpr+Ch374ydmZMzCv3XKJU9vubc9bZa7WpCHSzf5ztc8b8i/Xpg==}
 
-  '@rivetkit/traces@2.3.5':
-    resolution: {integrity: sha512-aU/5hm83dB5P3v/EWruwHbtu5Tc02YNuJHprIaj7FZNOf4AAW9ropdb9OafzPykEtuwIwSoCAT4qtuMkY+7CrQ==}
+  '@rivetkit/traces@2.3.7':
+    resolution: {integrity: sha512-B7QYjFP2HPxyfPsVjfcNIV7FPLWgGWGypmlT/dZM1i1Cf1WRdeuBumPLffgs3YceiY7Pm4D/gZZVt5p0m4Cx+A==}
     engines: {node: '>=18.0.0'}
 
-  '@rivetkit/virtual-websocket@2.3.5':
-    resolution: {integrity: sha512-LPXssVv22e//7zZLzJ5Lw62fWWDiBKE091tRxrYi0R9W/uqtSWCC82DGpyOMim03bVwhixuiNvVXLNVo9Gngow==}
+  '@rivetkit/virtual-websocket@2.3.7':
+    resolution: {integrity: sha512-jwxDvYbr3YB6vFuxwRdB/AqUUMwdtC1rIAc4tNN6VQR3weHbE+PrDoHKbe85zrtlBtcnG89/p8tlovrj8qyQWA==}
 
-  '@rivetkit/workflow-engine@2.3.5':
-    resolution: {integrity: sha512-T6xh8tLfU1bODFtHJHCvRkML2Ahy9C653mIZ2bsMnryEKBQE4uG5I4WczHSgdkSpUZk7+ZoKwiR52PFdqJYEyQ==}
+  '@rivetkit/workflow-engine@2.3.7':
+    resolution: {integrity: sha512-+C4kGuSNysrw2zs/LQoYxouOxufKHHMxiIXKF8Ab9GU2BCJ32RUST9dYU/gaQE/w9uM+hqAHUz0DTlOBYU6p6g==}
     engines: {node: '>=18.0.0'}
 
   '@rolldown/binding-android-arm64@1.2.0':
@@ -8503,11 +8510,20 @@ packages:
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
+  '@workflow/errors@5.0.0-beta.11':
+    resolution: {integrity: sha512-m8SFeLrckiWnefE5FmmCcrPiLsZM+qWM/f1MUmIoUbu2DUp280Cc5zV4yW22wyd2//CN4MJBklArwSKcFS6JxQ==}
+
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
+  '@workflow/utils@5.0.0-beta.6':
+    resolution: {integrity: sha512-YMZqvtRMzlmWkgshURp4ilvcY8VMrNxwXxDEXQ/gkppKWhJ1xdJBpq3plZLf8LWS7JHXd32Wqll/UvQeARu93Q==}
+
+  '@workflow/world@5.0.0-beta.21':
+    resolution: {integrity: sha512-XAOtSr7CGL/81EqEvUuDSWzil12sRJwQfU7ymVZlui33BKK8vbtgqzuY5vI6/OWt6NiAqPMeJVeahD9oMkii/A==}
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -12379,8 +12395,8 @@ packages:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
     engines: {node: '>= 0.8'}
 
-  rivetkit@2.3.5:
-    resolution: {integrity: sha512-RgRlK2Qj3eeqZtebBslj0XM6bMDv1hvBsJg/M/LRHg//1dx67dWS15hSYgkcZz1LQxCoAdc84fhaBvgKJtUQbA==}
+  rivetkit@2.3.7:
+    resolution: {integrity: sha512-V2IWlXq9SRLJWrcYVa8WUftELCpbdsBVWZIqz2WQjhhzRK9Aan65RfMoZVx62A9k8HuIO6MH1nAPLhOuk1xePQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       drizzle-kit: ^0.31.2
@@ -13048,6 +13064,10 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
+    hasBin: true
 
   ultrahtml@1.7.0:
     resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
@@ -17891,6 +17911,48 @@ snapshots:
     optionalDependencies:
       pyodide: 0.28.3(bufferutil@4.1.0)
 
+  '@rivet-dev/vercel-world@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(ws@8.21.0(bufferutil@4.1.0))':
+    dependencies:
+      '@workflow/errors': 5.0.0-beta.11
+      '@workflow/world': 5.0.0-beta.21
+      cbor-x: 1.6.4
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      ulid: 3.0.2
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - drizzle-kit
+      - eventsource
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - pyodide
+      - sql.js
+      - sqlite3
+      - ws
+
   '@rivet-gg/components@file:website/vendor/theme/vendor/components(@babel/core@7.29.7)(@babel/runtime@7.29.2)(@babel/template@7.29.7)(@codemirror/language@6.12.4)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(codemirror@6.0.2)(lodash@4.18.1)(posthog-js@1.406.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -17995,38 +18057,38 @@ snapshots:
 
   '@rivetkit/bare-ts@0.6.2': {}
 
-  '@rivetkit/engine-cli-darwin-arm64@2.3.5':
+  '@rivetkit/engine-cli-darwin-arm64@2.3.7':
     optional: true
 
-  '@rivetkit/engine-cli-darwin-x64@2.3.5':
+  '@rivetkit/engine-cli-darwin-x64@2.3.7':
     optional: true
 
-  '@rivetkit/engine-cli-linux-arm64-musl@2.3.5':
+  '@rivetkit/engine-cli-linux-arm64-musl@2.3.7':
     optional: true
 
-  '@rivetkit/engine-cli-linux-x64-musl@2.3.5':
+  '@rivetkit/engine-cli-linux-x64-musl@2.3.7':
     optional: true
 
-  '@rivetkit/engine-cli-win32-x64@2.3.5':
+  '@rivetkit/engine-cli-win32-x64@2.3.7':
     optional: true
 
-  '@rivetkit/engine-cli@2.3.5':
+  '@rivetkit/engine-cli@2.3.7':
     optionalDependencies:
-      '@rivetkit/engine-cli-darwin-arm64': 2.3.5
-      '@rivetkit/engine-cli-darwin-x64': 2.3.5
-      '@rivetkit/engine-cli-linux-arm64-musl': 2.3.5
-      '@rivetkit/engine-cli-linux-x64-musl': 2.3.5
-      '@rivetkit/engine-cli-win32-x64': 2.3.5
+      '@rivetkit/engine-cli-darwin-arm64': 2.3.7
+      '@rivetkit/engine-cli-darwin-x64': 2.3.7
+      '@rivetkit/engine-cli-linux-arm64-musl': 2.3.7
+      '@rivetkit/engine-cli-linux-x64-musl': 2.3.7
+      '@rivetkit/engine-cli-win32-x64': 2.3.7
 
-  '@rivetkit/engine-envoy-protocol@2.3.5':
+  '@rivetkit/engine-envoy-protocol@2.3.7':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
 
-  '@rivetkit/framework-base@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/framework-base@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@tanstack/store': 0.7.7
       fast-deep-equal: 3.1.3
-      rivetkit: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18064,13 +18126,13 @@ snapshots:
 
   '@rivetkit/on-change@6.0.1': {}
 
-  '@rivetkit/react@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
+  '@rivetkit/react@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
-      '@rivetkit/framework-base': 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      '@rivetkit/framework-base': 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
       '@tanstack/react-store': 0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      rivetkit: 2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
+      rivetkit: 2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18106,52 +18168,52 @@ snapshots:
       - sqlite3
       - ws
 
-  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.5':
+  '@rivetkit/rivetkit-napi-darwin-arm64@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-darwin-x64@2.3.5':
+  '@rivetkit/rivetkit-napi-darwin-x64@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.5':
+  '@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.5':
+  '@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.5':
+  '@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.5':
+  '@rivetkit/rivetkit-napi-linux-x64-musl@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.5':
+  '@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.7':
     optional: true
 
-  '@rivetkit/rivetkit-napi@2.3.5':
+  '@rivetkit/rivetkit-napi@2.3.7':
     dependencies:
       '@napi-rs/cli': 2.18.4
-      '@rivetkit/engine-envoy-protocol': 2.3.5
+      '@rivetkit/engine-envoy-protocol': 2.3.7
     optionalDependencies:
-      '@rivetkit/rivetkit-napi-darwin-arm64': 2.3.5
-      '@rivetkit/rivetkit-napi-darwin-x64': 2.3.5
-      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 2.3.5
-      '@rivetkit/rivetkit-napi-linux-arm64-musl': 2.3.5
-      '@rivetkit/rivetkit-napi-linux-x64-gnu': 2.3.5
-      '@rivetkit/rivetkit-napi-linux-x64-musl': 2.3.5
-      '@rivetkit/rivetkit-napi-win32-x64-msvc': 2.3.5
+      '@rivetkit/rivetkit-napi-darwin-arm64': 2.3.7
+      '@rivetkit/rivetkit-napi-darwin-x64': 2.3.7
+      '@rivetkit/rivetkit-napi-linux-arm64-gnu': 2.3.7
+      '@rivetkit/rivetkit-napi-linux-arm64-musl': 2.3.7
+      '@rivetkit/rivetkit-napi-linux-x64-gnu': 2.3.7
+      '@rivetkit/rivetkit-napi-linux-x64-musl': 2.3.7
+      '@rivetkit/rivetkit-napi-win32-x64-msvc': 2.3.7
 
-  '@rivetkit/rivetkit-wasm@2.3.2': {}
+  '@rivetkit/rivetkit-wasm@2.3.7': {}
 
-  '@rivetkit/traces@2.3.5':
+  '@rivetkit/traces@2.3.7':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
       fdb-tuple: 1.0.0
       vbare: 0.0.4
 
-  '@rivetkit/virtual-websocket@2.3.5': {}
+  '@rivetkit/virtual-websocket@2.3.7': {}
 
-  '@rivetkit/workflow-engine@2.3.5':
+  '@rivetkit/workflow-engine@2.3.7':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
       cbor-x: 1.6.4
@@ -19421,10 +19483,24 @@ snapshots:
 
   '@vue/shared@3.5.40': {}
 
+  '@workflow/errors@5.0.0-beta.11':
+    dependencies:
+      '@workflow/utils': 5.0.0-beta.6
+      ms: 2.1.3
+
   '@workflow/serde@4.1.0': {}
 
   '@workflow/serde@4.1.0-beta.2':
     optional: true
+
+  '@workflow/utils@5.0.0-beta.6':
+    dependencies:
+      ms: 2.1.3
+
+  '@workflow/world@5.0.0-beta.21':
+    dependencies:
+      ulid: 3.0.2
+      zod: 4.3.6
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
@@ -24051,19 +24127,19 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rivetkit@2.3.5(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
+  rivetkit@2.3.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)(pyodide@0.28.3(bufferutil@4.1.0))(ws@8.21.0(bufferutil@4.1.0)):
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.9)(zod@4.3.6)
       '@rivet-dev/agent-os-core': 0.1.1(pyodide@0.28.3(bufferutil@4.1.0))
       '@rivetkit/bare-ts': 0.6.2
-      '@rivetkit/engine-cli': 2.3.5
-      '@rivetkit/engine-envoy-protocol': 2.3.5
+      '@rivetkit/engine-cli': 2.3.7
+      '@rivetkit/engine-envoy-protocol': 2.3.7
       '@rivetkit/on-change': 6.0.1
-      '@rivetkit/rivetkit-napi': 2.3.5
-      '@rivetkit/rivetkit-wasm': 2.3.2
-      '@rivetkit/traces': 2.3.5
-      '@rivetkit/virtual-websocket': 2.3.5
-      '@rivetkit/workflow-engine': 2.3.5
+      '@rivetkit/rivetkit-napi': 2.3.7
+      '@rivetkit/rivetkit-wasm': 2.3.7
+      '@rivetkit/traces': 2.3.7
+      '@rivetkit/virtual-websocket': 2.3.7
+      '@rivetkit/workflow-engine': 2.3.7
       cbor-x: 1.6.4
       drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.8.0)
       hono: 4.12.9
@@ -24950,6 +25026,8 @@ snapshots:
   ufo@1.6.4: {}
 
   uint8array-extras@1.5.0: {}
+
+  ulid@3.0.2: {}
 
   ultrahtml@1.7.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,9 +58,9 @@ onlyBuiltDependencies:
 # pinned once here and referenced everywhere via `catalog:rivetkit`.
 catalogs:
   rivetkit:
-    rivetkit: 2.3.5
-    '@rivetkit/react': 2.3.5
+    rivetkit: 2.3.7
+    '@rivetkit/react': 2.3.7
 
 overrides:
-  '@rivetkit/rivetkit-wasm': 2.3.5
+  '@rivetkit/rivetkit-wasm': 2.3.7
   web-streams-polyfill: 3.3.3

--- a/website/public/docs/docs/frameworks/vercel-eve.md
+++ b/website/public/docs/docs/frameworks/vercel-eve.md
@@ -1,8 +1,8 @@
 # Vercel Eve
 
-Use agentOS as the durable sandbox backend for Vercel Eve.
+Run Vercel Eve with agentOS and Rivet World.
 
-Eve owns the agent runtime and session lifecycle, while agentOS maps every sandbox session to an isolated VM actor with a durable `/workspace` filesystem.
+Eve owns the agent runtime and session lifecycle. agentOS maps every sandbox session to an isolated VM actor with a durable `/workspace` filesystem, while Rivet World runs Eve workflows on Rivet Actors.
 
 [View the complete example →](https://github.com/rivet-dev/agentos/tree/main/examples/vercel-eve)
 
@@ -14,11 +14,12 @@ cd my-agent
 ```
 
 ```sh
-npm add @rivet-dev/agentos @rivet-dev/agentos-eve
+npm add @rivet-dev/agentos @rivet-dev/agentos-eve @rivet-dev/vercel-world
 ```
 
-- `@rivet-dev/agentos`: Provides the durable VM actor.
+- `@rivet-dev/agentos`: Provides the agentOS VM.
 - `@rivet-dev/agentos-eve`: Connects Eve's sandbox API to agentOS.
+- `@rivet-dev/vercel-world`: Runs Eve workflows on [Rivet World](https://workflow-sdk.dev/worlds).
 
 Update `agent/agent.ts`:
 
@@ -26,6 +27,7 @@ Update `agent/agent.ts`:
 import { defineAgent } from "eve";
 
 export default defineAgent({
+	model: "anthropic/claude-sonnet-5",
 	build: {
 		externalDependencies: [
 			"@rivet-dev/agentos",
@@ -33,23 +35,55 @@ export default defineAgent({
 			"@rivet-dev/agentos-eve",
 			"@rivet-dev/agentos-runtime-core",
 			"@rivet-dev/agentos-sidecar",
+			"@rivet-dev/vercel-world",
 			"@rivetkit/engine-cli",
 		],
 	},
+	experimental: {
+		workflow: { world: "#world" },
+	},
 });
 ```
+
+Rivet World lets you run Eve on top of Rivet.
+
+Add the World module import to `package.json`:
+
+```json title="package.json"
+{
+	"imports": {
+		"#world": "./world.ts"
+	}
+}
+```
+
+Create `world.ts`:
+
+```ts title="world.ts"
+import { createWorld as createRivetWorld } from "@rivet-dev/vercel-world";
+import { registry } from "./registry";
+
+export const createWorld = () => createRivetWorld({ registry });
+```
+
+The first World operation starts this registry and waits for the Rivet envoy to
+be ready.
 
 Create `registry.ts`:
 
 ```ts title="registry.ts"
 import { agentOS, setup } from "@rivet-dev/agentos";
+import { vercelWorldActors } from "@rivet-dev/vercel-world/registry";
 
 const vm = agentOS({
 	// Configuration will go here.
 });
 
 export const registry = setup({
-	use: { vm },
+	use: {
+		...vercelWorldActors,
+		vm,
+	},
 });
 ```
 
@@ -65,10 +99,16 @@ export default defineSandbox({
 });
 ```
 
-Run the agent:
+Link Eve to Vercel once so it can call your configured model:
 
 ```sh
-eve dev
+npm exec -- eve link
+```
+
+Then run the agent:
+
+```sh
+npm exec -- eve dev
 ```
 
 ## Default Filesystem
@@ -90,6 +130,12 @@ See the `agentOS()` [configuration reference](/docs/core#configuration-reference
 | `actor` | Yes | Actor registered with `setup()`, such as `vm`. |
 | `registry` | Yes | The application registry containing that actor. It is started lazily and shared by Eve sessions. |
 | `client` | No | An existing client configured for the same registry. |
+
+### Rivet World
+
+Rivet World stores Eve workflow runs in Rivet Actors so they resume instead of restarting.
+
+[Read the Rivet World documentation →](https://rivet.dev/docs/integrations/vercel-workflows)
 
 ## Advanced
 

--- a/website/src/content/docs/docs/frameworks/vercel-eve.mdx
+++ b/website/src/content/docs/docs/frameworks/vercel-eve.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Vercel Eve"
-description: "Use agentOS as the durable sandbox backend for Vercel Eve."
+description: "Run Vercel Eve with agentOS and Rivet World."
 skill: true
 ---
 
-Eve owns the agent runtime and session lifecycle, while agentOS maps every sandbox session to an isolated VM actor with a durable `/workspace` filesystem.
+Eve owns the agent runtime and session lifecycle. agentOS maps every sandbox session to an isolated VM actor with a durable `/workspace` filesystem, while Rivet World runs Eve workflows on Rivet Actors.
 
 [View the complete example →](https://github.com/rivet-dev/agentos/tree/main/examples/vercel-eve)
 
@@ -24,11 +24,12 @@ cd my-agent
 <Step title="Install the integrations">
 
 ```sh
-npm add @rivet-dev/agentos @rivet-dev/agentos-eve
+npm add @rivet-dev/agentos @rivet-dev/agentos-eve @rivet-dev/vercel-world
 ```
 
-- `@rivet-dev/agentos`: Provides the durable VM actor.
+- `@rivet-dev/agentos`: Provides the agentOS VM.
 - `@rivet-dev/agentos-eve`: Connects Eve's sandbox API to agentOS.
+- `@rivet-dev/vercel-world`: Runs Eve workflows on [Rivet World](https://workflow-sdk.dev/worlds).
 
 </Step>
 
@@ -40,6 +41,7 @@ Update `agent/agent.ts`:
 import { defineAgent } from "eve";
 
 export default defineAgent({
+	model: "anthropic/claude-sonnet-5",
 	build: {
 		externalDependencies: [
 			"@rivet-dev/agentos",
@@ -47,33 +49,65 @@ export default defineAgent({
 			"@rivet-dev/agentos-eve",
 			"@rivet-dev/agentos-runtime-core",
 			"@rivet-dev/agentos-sidecar",
+			"@rivet-dev/vercel-world",
 			"@rivetkit/engine-cli",
 		],
+	},
+	experimental: {
+		workflow: { world: "#world" },
 	},
 });
 ```
 
 </Step>
 
-<Step title="Register agentOS">
+<Step title="Configure Rivet World">
+
+Rivet World lets you run Eve on top of Rivet.
+
+Add the World module import to `package.json`:
+
+```json title="package.json"
+{
+	"imports": {
+		"#world": "./world.ts"
+	}
+}
+```
+
+Create `world.ts`:
+
+```ts title="world.ts"
+import { createWorld as createRivetWorld } from "@rivet-dev/vercel-world";
+import { registry } from "./registry";
+
+export const createWorld = () => createRivetWorld({ registry });
+```
+
+The first World operation starts this registry and waits for the Rivet envoy to
+be ready.
+
+</Step>
+
+<Step title="Configure agentOS">
 
 Create `registry.ts`:
 
 ```ts title="registry.ts"
 import { agentOS, setup } from "@rivet-dev/agentos";
+import { vercelWorldActors } from "@rivet-dev/vercel-world/registry";
 
 const vm = agentOS({
 	// Configuration will go here.
 });
 
 export const registry = setup({
-	use: { vm },
+	use: {
+		...vercelWorldActors,
+		vm,
+	},
 });
 ```
-
-</Step>
-
-<Step title="Use agentOS as the sandbox">
 
 Create `agent/sandbox.ts`:
 
@@ -91,10 +125,16 @@ export default defineSandbox({
 
 <Step title="Run Eve">
 
-Run the agent:
+Link Eve to Vercel once so it can call your configured model:
 
 ```sh
-eve dev
+npm exec -- eve link
+```
+
+Then run the agent:
+
+```sh
+npm exec -- eve dev
 ```
 
 </Step>
@@ -120,6 +160,12 @@ See the `agentOS()` [configuration reference](/docs/core#configuration-reference
 | `actor` | Yes | Actor registered with `setup()`, such as `vm`. |
 | `registry` | Yes | The application registry containing that actor. It is started lazily and shared by Eve sessions. |
 | `client` | No | An existing client configured for the same registry. |
+
+### Rivet World
+
+Rivet World stores Eve workflow runs in Rivet Actors so they resume instead of restarting.
+
+[Read the Rivet World documentation →](https://rivet.dev/docs/integrations/vercel-workflows)
 
 ## Advanced
 

--- a/website/src/generated/routes.json
+++ b/website/src/generated/routes.json
@@ -212,6 +212,10 @@
       "title": "TLS & SSL",
       "description": "How agentOS uses in-guest mbedTLS plus a VM CA bundle for curl / wget / git, and a hermetic OpenSSL libcrypto build for OpenSSH."
     },
+    "/docs/docs/frameworks/vercel-eve": {
+      "title": "Vercel Eve",
+      "description": "Run Vercel Eve with agentOS and Rivet World."
+    },
     "/docs/docs/custom-software/building-wasm": {
       "title": "Building Binaries",
       "description": "Compile WASM command binaries for agentOS from source."
@@ -223,10 +227,6 @@
     "/docs/docs/custom-software/publishing": {
       "title": "Publishing Packages",
       "description": "Build, publish, and consume agentOS packages — locally, from npm, or from your own repo."
-    },
-    "/docs/docs/frameworks/vercel-eve": {
-      "title": "Vercel Eve",
-      "description": "Use agentOS as the durable sandbox backend for Vercel Eve."
     }
   }
 }


### PR DESCRIPTION
- Update agentOS to RivetKit 2.3.7 for registry readiness support
- Make the Vercel Eve example install and resolve the published World package
- Correct the Eve quickstart model, module mapping, and CLI commands