### PR TITLE
chore: configure frontend orb

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dependencies are persisted with the orb. Long-lived services declared in
+# .amp/services.yaml are repaired by Amp's service supervisor.
+echo "Frontend orb ready."

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly pnpm_version="10.13.1"
+readonly docs_theme_revision="450c498555135098c6a927adfdf13458be9be22a"
+readonly docs_theme_icons_revision="71c3e482fe43e4cbc4f4327a26c8899b6bd4aaa7"
+readonly docs_theme_dir="website/vendor/theme"
+
+if [[ "$(node --version | cut -d. -f1)" != "v24" ]]; then
+	echo "Installing Node.js 24..."
+	npm install --global n@10.2.0
+	n 24
+	hash -r
+fi
+
+echo "Installing pnpm ${pnpm_version}..."
+if ! command -v pnpm >/dev/null 2>&1 || [[ "$(pnpm --version)" != "$pnpm_version" ]]; then
+	npm install --global "pnpm@${pnpm_version}"
+fi
+
+if [[ ! -f "${docs_theme_dir}/package.json" || ! -f "${docs_theme_dir}/vendor/icons/dist/index.js" ]]; then
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "$tmp_dir"' EXIT
+	git clone --quiet https://github.com/rivet-dev/docs-theme.git "$tmp_dir/docs-theme"
+
+	if [[ ! -f "${docs_theme_dir}/package.json" ]]; then
+		echo "Vendoring the docs theme..."
+		git -C "$tmp_dir/docs-theme" checkout --quiet "$docs_theme_revision"
+		mkdir -p "$(dirname "$docs_theme_dir")"
+		cp -R "$tmp_dir/docs-theme/packages/theme" "$docs_theme_dir"
+	fi
+
+	if [[ ! -f "${docs_theme_dir}/vendor/icons/dist/index.js" ]]; then
+		echo "Vendoring the generated icon bundle..."
+		git -C "$tmp_dir/docs-theme" checkout --quiet "$docs_theme_icons_revision"
+		rm -rf "${docs_theme_dir}/vendor/icons/dist"
+		cp -R "$tmp_dir/docs-theme/packages/theme/vendor/icons/dist" \
+			"${docs_theme_dir}/vendor/icons/dist"
+	fi
+fi
+
+echo "Installing frontend dependencies..."
+pnpm install --frozen-lockfile --filter '@rivet-dev/agentos-website...'
+
+if [[ ! -f "${docs_theme_dir}/dist/mdx/remark.js" ]]; then
+	echo "Building the docs theme..."
+	pnpm --filter @rivet-dev/docs-theme build
+fi
+
+echo "Frontend setup complete."

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,6 @@
+services:
+  frontend:
+    command: public_host="$(node -p 'new URL(process.env.PUBLIC_URL).hostname')"; pnpm --dir website run gen:registry && __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS="$public_host" pnpm --dir website exec astro dev --host 0.0.0.0 --port "$PORT"
+    portal:
+      title: agentOS Docs
+      description: Frontend development server with hot reload.

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ scripts/ralph/.codex-last-msg-*
 # Agent working files live user-scoped in ~/.agents/; ignore any in-repo .agent/ as a safety net
 .agent/
 .claude/scheduled_tasks.lock
+.amp/portals/
 
 # Local caches and stray outputs
 .agentos/

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,6 +18,10 @@ export default defineConfig({
 		sitemap(),
 	],
 	vite: {
+		server: {
+			// Amp orbs can expose the dev server through an E2B portal hostname.
+			allowedHosts: [".e2b.app"],
+		},
 		resolve: {
 			dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
 		},


### PR DESCRIPTION
- Add frontend-only orb setup and resume hooks
- Run the Astro docs site as a supervised portal service
- Support Amp and E2B portal hostnames and vendor the pinned docs assets