### PR TITLE
Fix loading images in opencode by handling data:png in URL construction

### DIFF
--- a/crates/native-sidecar/tests/builtin_conformance.rs
+++ b/crates/native-sidecar/tests/builtin_conformance.rs
@@ -3714,6 +3714,9 @@ const url = new urlModule.URL("https://example.com/a/b?x=1&y=two#frag");
 url.searchParams.append("z", "3");
 const fileRelative = new urlModule.URL("file:.", "file:///tmp/base/entry.mjs");
 const fileRelativeNoBase = new urlModule.URL("file:./child");
+const dataUrl = new urlModule.URL("data:image/png;base64,aGVsbG8=");
+const dataUrlWithQuery = new urlModule.URL("data:text/plain,hello?x=1#frag");
+const mailto = new urlModule.URL("mailto:dev@example.com");
 const plusDecoded = new URLSearchParamsCtor("?a=foo+bar");
 const invalidPercentDecoded = new URLSearchParamsCtor("?a=%&b=%2&c=%GG&d=%E0%A4%A");
 const sortable = new URLSearchParamsCtor([
@@ -3741,6 +3744,18 @@ console.log(JSON.stringify({
   setSearchParamsSize: setSemantics.size,
   fileRelativeHref: fileRelative.href,
   fileRelativeNoBaseHref: fileRelativeNoBase.href,
+  dataUrlHref: dataUrl.href,
+  dataUrlProtocol: dataUrl.protocol,
+  dataUrlPathname: dataUrl.pathname,
+  dataUrlOrigin: dataUrl.origin,
+  dataUrlToString: dataUrl.toString(),
+  dataUrlWithQueryHref: dataUrlWithQuery.href,
+  dataUrlWithQueryPathname: dataUrlWithQuery.pathname,
+  dataUrlWithQuerySearch: dataUrlWithQuery.search,
+  dataUrlWithQueryHash: dataUrlWithQuery.hash,
+  mailtoHref: mailto.href,
+  mailtoProtocol: mailto.protocol,
+  mailtoPathname: mailto.pathname,
   formatted: urlModule.format(parsed),
   parsedPathname: parsed.pathname,
   parsedQuery: parsed.query,

--- a/packages/build-tools/bridge-src/builtins/whatwg-url.ts
+++ b/packages/build-tools/bridge-src/builtins/whatwg-url.ts
@@ -934,6 +934,39 @@ var NativeURL = canUseNativeUrlImplementation(nativeUrlCandidate)
 					}
 					return;
 				}
+				const opaqueSchemeMatch = full.match(
+					/^([a-zA-Z][a-zA-Z\d+\-.]*:)(?!\/\/)/,
+				);
+				if (opaqueSchemeMatch) {
+					const protocol = opaqueSchemeMatch[1];
+					this.protocol = protocol;
+					this.hostname = "";
+					this.port = "";
+					this.host = "";
+					this.pathname = full.slice(protocol.length, pathEnd);
+					this.search = searchValue;
+					this.hash = hashValue;
+					this.href = protocol + this.pathname + this.search + this.hash;
+					this.origin = "null";
+					this.searchParams = new URLSearchParams(this.search);
+					const syncHrefFromSearchParams = () => {
+						const query = this.searchParams.toString();
+						this.search = query ? `?${query}` : "";
+						this.href = protocol + this.pathname + this.search + this.hash;
+					};
+					for (const method of ["append", "delete", "set", "sort"]) {
+						const original = this.searchParams[method]?.bind(this.searchParams);
+						if (!original) {
+							continue;
+						}
+						this.searchParams[method] = (...args) => {
+							const result = original(...args);
+							syncHrefFromSearchParams();
+							return result;
+						};
+					}
+					return;
+				}
 				const match = full.match(/^(\w+:)\/\/([^/:?#]+)(:\d+)?(.*)$/);
 				this.protocol = match?.[1] || "";
 				this.hostname = match?.[2] || "";

--- a/packages/build-tools/bridge-src/builtins/whatwg-url.ts
+++ b/packages/build-tools/bridge-src/builtins/whatwg-url.ts
@@ -21,6 +21,7 @@ var kBlobUrlStore = /* @__PURE__ */ Symbol.for("secureExec.blobUrlStore");
 var kBlobUrlCounter = /* @__PURE__ */ Symbol.for("secureExec.blobUrlCounter");
 var SEARCH_PARAM_METHOD_NAMES = ["append", "delete", "get", "getAll", "has"];
 var SEARCH_PARAM_PAIR_METHOD_NAMES = ["append", "set"];
+var SEARCH_PARAM_SYNC_METHOD_NAMES = ["append", "delete", "set", "sort"];
 var URL_SCHEME_TYPES = {
 	"http:": 0,
 	"https:": 2,
@@ -897,6 +898,22 @@ var NativeURL = canUseNativeUrlImplementation(nativeUrlCandidate)
 				const searchValue =
 					queryIndex === -1 ? "" : full.slice(queryIndex, hashStart);
 				const hashValue = hashIndex === -1 ? "" : full.slice(hashIndex);
+				const bindSearchParams = (buildHref) => {
+					this.searchParams = new URLSearchParams(this.search);
+					for (const method of SEARCH_PARAM_SYNC_METHOD_NAMES) {
+						const original = this.searchParams[method]?.bind(this.searchParams);
+						if (!original) {
+							continue;
+						}
+						this.searchParams[method] = (...args) => {
+							const result = original(...args);
+							const query = this.searchParams.toString();
+							this.search = query ? `?${query}` : "";
+							this.href = buildHref();
+							return result;
+						};
+					}
+				};
 				if (full.startsWith("file:")) {
 					let pathname = full.slice(5, pathEnd);
 					if (pathname.startsWith("//")) {
@@ -915,23 +932,9 @@ var NativeURL = canUseNativeUrlImplementation(nativeUrlCandidate)
 					this.host = "";
 					this.href = `file://${this.pathname}${this.search}${this.hash}`;
 					this.origin = "null";
-					this.searchParams = new URLSearchParams(this.search);
-					const syncHrefFromSearchParams = () => {
-						const query = this.searchParams.toString();
-						this.search = query ? `?${query}` : "";
-						this.href = `file://${this.pathname}${this.search}${this.hash}`;
-					};
-					for (const method of ["append", "delete", "set", "sort"]) {
-						const original = this.searchParams[method]?.bind(this.searchParams);
-						if (!original) {
-							continue;
-						}
-						this.searchParams[method] = (...args) => {
-							const result = original(...args);
-							syncHrefFromSearchParams();
-							return result;
-						};
-					}
+					bindSearchParams(
+						() => `file://${this.pathname}${this.search}${this.hash}`,
+					);
 					return;
 				}
 				const opaqueSchemeMatch = full.match(
@@ -948,23 +951,9 @@ var NativeURL = canUseNativeUrlImplementation(nativeUrlCandidate)
 					this.hash = hashValue;
 					this.href = protocol + this.pathname + this.search + this.hash;
 					this.origin = "null";
-					this.searchParams = new URLSearchParams(this.search);
-					const syncHrefFromSearchParams = () => {
-						const query = this.searchParams.toString();
-						this.search = query ? `?${query}` : "";
-						this.href = protocol + this.pathname + this.search + this.hash;
-					};
-					for (const method of ["append", "delete", "set", "sort"]) {
-						const original = this.searchParams[method]?.bind(this.searchParams);
-						if (!original) {
-							continue;
-						}
-						this.searchParams[method] = (...args) => {
-							const result = original(...args);
-							syncHrefFromSearchParams();
-							return result;
-						};
-					}
+					bindSearchParams(
+						() => protocol + this.pathname + this.search + this.hash,
+					);
 					return;
 				}
 				const match = full.match(/^(\w+:)\/\/([^/:?#]+)(:\d+)?(.*)$/);
@@ -985,29 +974,15 @@ var NativeURL = canUseNativeUrlImplementation(nativeUrlCandidate)
 					this.search +
 					this.hash;
 				this.origin = this.protocol + "//" + this.host;
-				this.searchParams = new URLSearchParams(this.search);
-				const syncHrefFromSearchParams = () => {
-					const query = this.searchParams.toString();
-					this.search = query ? `?${query}` : "";
-					this.href =
+				bindSearchParams(
+					() =>
 						this.protocol +
 						"//" +
 						this.host +
 						this.pathname +
 						this.search +
-						this.hash;
-				};
-				for (const method of ["append", "delete", "set", "sort"]) {
-					const original = this.searchParams[method]?.bind(this.searchParams);
-					if (!original) {
-						continue;
-					}
-					this.searchParams[method] = (...args) => {
-						const result = original(...args);
-						syncHrefFromSearchParams();
-						return result;
-					};
-				}
+						this.hash,
+				);
 			}
 			toString() {
 				return this.href;


### PR DESCRIPTION
## Summary
I was trying to use opencode with AgentOS as the filesystem backend, but found that my agent would crash whenever it tried to load images.

Turns out:
- OpenCode's read tool returns images as a data URL (`data:image/png...`)
- This triggers the `NativeURL` parsing through some path 
- The parsing in `NativeURL` tries to match either `file:` or `full.match(/^([a-zA-Z][a-zA-Z\d+\-.]*:)(?!\/\/)/);` (which is `stuff like `scheme://host/`, I believe)
- However, this means urls like `data:` don't get processed and so nothing gets turned to the agent during image reading.

The change here is to add an opaque URL branch before the final backup regex above.


## Testing

- `AGENTOS_BUILTIN_CONFORMANCE_CASE=url cargo test -p agentos-native-sidecar --test builtin_conformance __builtin_conformance_case_runner -- --exact` — passes (guest fallback output matches host Node for the `data:`/`mailto:` cases and all pre-existing cases).

## Alternative appraoches considerd
- Thought about just addressing the data uri path, since that's the most important for me
- Thought about adding a raise on the path where nothing matches. 