### PR TITLE
fix(agentos): run npm package binaries from build scripts

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -9810,18 +9810,13 @@ const hostFsImport = {
       if (typeof target !== 'string') {
         return 0;
       }
-      const hostPath = resolveHostFsPath(target);
-      if (typeof hostPath !== 'string') {
-        return 0;
-      }
-      const stat =
-        Number(followSymlinks) === 0
-          ? fsModule.lstatSync(hostPath)
-          : fsModule.statSync(hostPath);
+      const stat = callSyncRpc(
+        Number(followSymlinks) === 0 ? 'fs.lstatSync' : 'fs.statSync',
+        [target],
+      );
       const mode = hostFsModeFromStat(stat);
       traceHostProcess('host-fs-path-mode', {
         target,
-        hostPath,
         followSymlinks: Number(followSymlinks) >>> 0,
         mode,
       });

--- a/crates/native-sidecar/src/execution/launch.rs
+++ b/crates/native-sidecar/src/execution/launch.rs
@@ -2570,6 +2570,32 @@ fn resolve_spawn_shebang(
         }
         interpreter_depth += 1;
 
+        if matches!(shebang.interpreter.as_str(), "/usr/bin/env" | "/bin/env") {
+            let (command, args) =
+                parse_javascript_shebang(&script_argument, &header, &request.args)?.ok_or_else(
+                    || {
+                        SidecarError::Kernel(format!(
+                            "ENOEXEC: invalid env shebang line: {resolved_path}"
+                        ))
+                    },
+                )?;
+            request.command = if is_path_like_specifier(&command) {
+                resolve_path_like_guest_specifier(&guest_cwd, &command)
+            } else {
+                let path_env = request
+                    .options
+                    .env
+                    .get("PATH")
+                    .or_else(|| vm.guest_env.get("PATH"))
+                    .cloned()
+                    .unwrap_or_else(|| String::from("/bin:/usr/bin"));
+                resolve_posix_spawn_path_candidate(vm, &guest_cwd, &command, &path_env)?.lookup_path
+            };
+            request.args = args;
+            request.options.argv0 = Some(command);
+            continue;
+        }
+
         let mut interpreter_args = Vec::with_capacity(request.args.len() + 2);
         if let Some(argument) = shebang.optional_argument {
             interpreter_args.push(argument);

--- a/crates/native-sidecar/tests/service.rs
+++ b/crates/native-sidecar/tests/service.rs
@@ -12787,6 +12787,40 @@ process.stdout.write(`${JSON.stringify(snapshot)}\n`);
             fs::set_permissions(&host_path, permissions).expect("chmod host fixture");
         }
 
+        fn write_posix_spawnp_symlink(
+            sidecar: &mut NativeSidecar<RecordingBridge>,
+            vm_id: &str,
+            target: &str,
+            link_path: &str,
+        ) {
+            let (host_path, host_target) = {
+                let vm = sidecar.vms.get_mut(vm_id).expect("created vm");
+                let parent = Path::new(link_path)
+                    .parent()
+                    .and_then(Path::to_str)
+                    .expect("symlink fixture parent path");
+                if parent != "/" {
+                    vm.kernel
+                        .mkdir(parent, true)
+                        .expect("create symlink fixture guest parent");
+                }
+                vm.kernel
+                    .symlink(target, link_path)
+                    .expect("create guest symlink fixture");
+                let host_target = if target.starts_with('/') {
+                    vm.cwd.join(target.trim_start_matches('/'))
+                } else {
+                    PathBuf::from(target)
+                };
+                (vm.cwd.join(link_path.trim_start_matches('/')), host_target)
+            };
+
+            fs::create_dir_all(host_path.parent().expect("symlink fixture host parent"))
+                .expect("create symlink fixture host parent");
+            std::os::unix::fs::symlink(host_target, host_path)
+                .expect("create host symlink fixture");
+        }
+
         fn posix_spawnp_request(
             command: &str,
             search_path: &str,
@@ -12913,10 +12947,23 @@ process.stdout.write(`${JSON.stringify(snapshot)}\n`);
                     b"#!/interpreter.wasm --inner\n".as_slice(),
                 ),
                 ("/scripts/nested", b"#!/scripts/inner --outer\n".as_slice()),
+                ("/scripts/env", b"#!/usr/bin/env node\n".as_slice()),
+                ("/scripts/env-target", b"#!/usr/bin/env node\n".as_slice()),
+                (
+                    "/scripts/env-s",
+                    b"#!/usr/bin/env -S node --flag\n".as_slice(),
+                ),
                 ("/scripts/missing", b"#!/missing-interpreter\n".as_slice()),
             ] {
                 write_posix_spawnp_fixture(&mut sidecar, &vm_id, path, contents, 0o755);
             }
+            write_posix_spawnp_symlink(&mut sidecar, &vm_id, "env-target", "/scripts/env-link");
+            write_posix_spawnp_symlink(
+                &mut sidecar,
+                &vm_id,
+                "/interpreter.wasm",
+                "/opt/agentos/bin/node",
+            );
 
             sidecar
                 .vms
@@ -12927,6 +12974,12 @@ process.stdout.write(`${JSON.stringify(snapshot)}\n`);
                     String::from("registered-only"),
                     String::from("/registered-only"),
                 );
+            sidecar
+                .vms
+                .get_mut(&vm_id)
+                .expect("created vm")
+                .command_guest_paths
+                .insert(String::from("node"), String::from("/interpreter.wasm"));
 
             for nested in [false, true] {
                 let scope = if nested { "nested" } else { "top-level" };
@@ -13039,6 +13092,56 @@ process.stdout.write(`${JSON.stringify(snapshot)}\n`);
                         "/scripts/nested",
                         "tail"
                     ])
+                );
+
+                let mut env_request = posix_spawnp_request("env", "/scripts", &["tail"]);
+                env_request
+                    .options
+                    .env
+                    .insert(String::from("PATH"), String::from("/opt/agentos/bin"));
+                let env = spawn_posix_spawnp_fixture(&mut sidecar, &vm_id, nested, env_request)
+                    .unwrap_or_else(|error| panic!("{scope} env shebang failed: {error}"));
+                assert_eq!(env["args"], json!(["node", "/scripts/env", "tail"]));
+
+                let mut env_link_request = posix_spawnp_request("env-link", "/scripts", &["tail"]);
+                env_link_request
+                    .options
+                    .env
+                    .insert(String::from("PATH"), String::from("/opt/agentos/bin"));
+                let env_link =
+                    spawn_posix_spawnp_fixture(&mut sidecar, &vm_id, nested, env_link_request)
+                        .unwrap_or_else(|error| {
+                            panic!("{scope} symlinked env shebang failed: {error}")
+                        });
+                assert_eq!(
+                    env_link["args"],
+                    json!(["node", "/scripts/env-link", "tail"])
+                );
+
+                let mut env_split_request = posix_spawnp_request("env-s", "/scripts", &["tail"]);
+                env_split_request
+                    .options
+                    .env
+                    .insert(String::from("PATH"), String::from("/opt/agentos/bin"));
+                let env_split =
+                    spawn_posix_spawnp_fixture(&mut sidecar, &vm_id, nested, env_split_request)
+                        .unwrap_or_else(|error| panic!("{scope} env -S shebang failed: {error}"));
+                assert_eq!(
+                    env_split["args"],
+                    json!(["node", "--flag", "/scripts/env-s", "tail"])
+                );
+
+                let mut excluded_env_request = posix_spawnp_request("env", "/scripts", &[]);
+                excluded_env_request
+                    .options
+                    .env
+                    .insert(String::from("PATH"), String::from("/nowhere"));
+                let error =
+                    spawn_posix_spawnp_fixture(&mut sidecar, &vm_id, nested, excluded_env_request)
+                        .expect_err("env shebang must honor its explicit PATH");
+                assert!(
+                    error.to_string().contains("ENOENT"),
+                    "{scope} excluded env interpreter returned {error}"
                 );
 
                 let error = spawn_posix_spawnp_fixture(

--- a/packages/agentos-apps/src/actors.ts
+++ b/packages/agentos-apps/src/actors.ts
@@ -1086,6 +1086,10 @@ async function buildRelease(
 						];
 						const reconcile = await build.execArgv("npm", reconcileArgs, {
 							cwd: "/workspace",
+							env: {
+								NODE_ENV: "development",
+								NPM_CONFIG_PRODUCTION: "false",
+							},
 							timeout: config.buildTimeoutMs,
 							captureStdio: true,
 						});
@@ -1114,6 +1118,10 @@ async function buildRelease(
 			];
 			const install = await build.execArgv("npm", installArgs, {
 				cwd: "/workspace",
+				env: {
+					NODE_ENV: "development",
+					NPM_CONFIG_PRODUCTION: "false",
+				},
 				timeout: config.buildTimeoutMs,
 				captureStdio: true,
 			});

--- a/toolchain/std-patches/crates/uu_dd/0001-wasi-compat.patch
+++ b/toolchain/std-patches/crates/uu_dd/0001-wasi-compat.patch
@@ -1,5 +1,14 @@
 --- a/src/dd.rs
 +++ b/src/dd.rs
+@@ -44,7 +44,7 @@ use std::os::unix::{
+     fs::FileTypeExt,
+     io::{AsRawFd, FromRawFd},
+ };
+-#[cfg(windows)]
++#[cfg(target_os = "windows")]
+ use std::os::windows::{fs::MetadataExt, io::AsHandle};
+ use std::path::Path;
+ use std::sync::atomic::AtomicU8;
 @@ -113,11 +113,13 @@ impl Alarm {
      pub fn with_interval(interval: Duration) -> Self {
          let trigger = Arc::new(AtomicU8::default());
@@ -14,6 +23,24 @@
              }
          });
  
+@@ -360,6 +362,6 @@ impl<'a> Input<'a> {
+     /// Instantiate this struct with stdin as a source.
+     fn new_stdin(settings: &'a Settings) -> UResult<Self> {
+-        #[cfg(not(unix))]
++        #[cfg(target_os = "windows")]
+         let mut src = {
+             let f = File::from(io::stdin().as_handle().try_clone_to_owned()?);
+             let is_file = if let Ok(metadata) = f.metadata() {
+@@ -376,7 +378,9 @@ impl<'a> Input<'a> {
+             } else {
+                 Source::Stdin(io::stdin())
+             }
+         };
++        #[cfg(target_os = "wasi")]
++        let mut src = Source::Stdin(io::stdin());
+         #[cfg(unix)]
+         let mut src = Source::stdin_as_file();
+         #[cfg(unix)]
 @@ -597,6 +601,9 @@ enum Dest {
  enum Dest {
      /// Output to stdout.


### PR DESCRIPTION
- execute npm-installed build tools through the VM kernel and virtual runtime commands
- install application build dependencies consistently in production environments
- fix the clean WASM command release build for uu_dd