### PR TITLE
fix(apps): harden standalone quickstart

### DIFF
--- a/examples/apps-hello-world/src/deploy.ts
+++ b/examples/apps-hello-world/src/deploy.ts
@@ -9,6 +9,8 @@ await deployApp({
 			name: "hello-world-app",
 			version: "0.0.0",
 			private: true,
+			type: "module",
+			main: "src/index.ts",
 			dependencies: {
 				hono: "^4.12.9",
 			},

--- a/packages/agentos-apps/README.md
+++ b/packages/agentos-apps/README.md
@@ -8,6 +8,8 @@ Install agentOS Apps in a Node.js 22 or newer project:
 ```sh
 npm add @rivet-dev/agentos @rivet-dev/agentos-apps
 npm add @hono/node-server hono
+npm add --save-dev tsx
+npm pkg set type=module
 ```
 
 RivetKit starts a local Engine automatically. For an existing Rivet deployment,

--- a/packages/runtime-core/src/frame-stream.ts
+++ b/packages/runtime-core/src/frame-stream.ts
@@ -208,6 +208,7 @@ export class StdioFrameTransport<TReadFrame, TWriteFrame = TReadFrame>
 	private readonly stdout: Readable;
 	private readonly encodeFrame: (frame: TWriteFrame) => Uint8Array;
 	private readonly decodeFrame: (payload: Uint8Array) => TReadFrame;
+	private readonly sharedStdio: boolean;
 	private readonly frameListeners = new Set<(frame: TReadFrame) => void>();
 	private readonly errorListeners = new Set<(error: Error) => void>();
 	private readonly endListeners = new Set<() => void>();
@@ -218,6 +219,10 @@ export class StdioFrameTransport<TReadFrame, TWriteFrame = TReadFrame>
 		this.stdout = options.stdout;
 		this.encodeFrame = options.encodeFrame;
 		this.decodeFrame = options.decodeFrame;
+		this.sharedStdio = this.stdin === (this.stdout as unknown as Writable);
+		if (!this.sharedStdio) {
+			this.stdin.on("error", this.handleError);
+		}
 		this.stdout.on("data", this.handleData);
 		this.stdout.on("end", this.handleEnd);
 		this.stdout.on("error", this.handleError);
@@ -259,6 +264,9 @@ export class StdioFrameTransport<TReadFrame, TWriteFrame = TReadFrame>
 	}
 
 	dispose(): void {
+		if (!this.sharedStdio) {
+			this.stdin.off("error", this.handleError);
+		}
 		this.stdout.off("data", this.handleData);
 		this.stdout.off("end", this.handleEnd);
 		this.stdout.off("error", this.handleError);

--- a/packages/runtime-core/tests/frame-stream.test.ts
+++ b/packages/runtime-core/tests/frame-stream.test.ts
@@ -65,6 +65,52 @@ describe("stdio frame transport", () => {
 		transport.dispose();
 	});
 
+	test("reports stdin errors instead of emitting an unhandled stream error", async () => {
+		const stdin = new PassThrough();
+		const stdout = new PassThrough();
+		const transport = new StdioFrameTransport<string>({
+			stdin,
+			stdout,
+			encodeFrame: (frame) => Buffer.from(frame, "utf8"),
+			decodeFrame: (payload) => Buffer.from(payload).toString("utf8"),
+		});
+		const error = new Promise<Error>((resolve) => {
+			transport.onError(resolve);
+		});
+
+		const brokenPipe = Object.assign(new Error("write EPIPE"), {
+			code: "EPIPE",
+		});
+		stdin.destroy(brokenPipe);
+
+		await expect(error).resolves.toBe(brokenPipe);
+		await expect(transport.writeFrame("late")).rejects.toThrow();
+		transport.dispose();
+	});
+
+	test("uses one error listener when stdin and stdout share a duplex stream", () => {
+		const stdio = new PassThrough();
+		const initialErrorListeners = stdio.listenerCount("error");
+		const transport = new StdioFrameTransport<string>({
+			stdin: stdio,
+			stdout: stdio,
+			encodeFrame: (frame) => Buffer.from(frame, "utf8"),
+			decodeFrame: (payload) => Buffer.from(payload).toString("utf8"),
+		});
+		const errors: Error[] = [];
+		transport.onError((error) => errors.push(error));
+
+		expect(stdio.listenerCount("error")).toBe(initialErrorListeners + 1);
+		const brokenPipe = Object.assign(new Error("write EPIPE"), {
+			code: "EPIPE",
+		});
+		stdio.emit("error", brokenPipe);
+		expect(errors).toEqual([brokenPipe]);
+
+		transport.dispose();
+		expect(stdio.listenerCount("error")).toBe(initialErrorListeners);
+	});
+
 	test("reports decode errors", async () => {
 		const stdin = new PassThrough();
 		const stdout = new PassThrough();

--- a/website/public/docs/docs/apps.md
+++ b/website/public/docs/docs/apps.md
@@ -59,6 +59,8 @@ orchestrates the pool of prewarmed VMs.
 ```sh
 npm add @rivet-dev/agentos @rivet-dev/agentos-apps
 npm add @hono/node-server hono
+npm add --save-dev tsx
+npm pkg set type=module
 ```
 
 Setup the HTTP server that will serve requests for AI-generated apps. Also set

--- a/website/src/content/docs/docs/apps.mdx
+++ b/website/src/content/docs/docs/apps.mdx
@@ -69,6 +69,8 @@ orchestrates the pool of prewarmed VMs.
 ```sh
 npm add @rivet-dev/agentos @rivet-dev/agentos-apps
 npm add @hono/node-server hono
+npm add --save-dev tsx
+npm pkg set type=module
 ```
 
 </Step>


### PR DESCRIPTION
- make the published Quickstart runnable from a fresh npm project
- declare the generated Hono app entrypoint and ESM mode
- handle sidecar stdin errors without an unhandled shutdown EPIPE