### PR TITLE
fix(toolchain): avoid bash / scripting issues on MacOS

### DIFF
--- a/toolchain/c/scripts/build-duckdb.sh
+++ b/toolchain/c/scripts/build-duckdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Reference only:

--- a/toolchain/c/scripts/build-llvm-runtimes.sh
+++ b/toolchain/c/scripts/build-llvm-runtimes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Build the libc++/libc++abi/libunwind runtime set ourselves so C++ exception

--- a/toolchain/c/scripts/build-llvm-runtimes.sh
+++ b/toolchain/c/scripts/build-llvm-runtimes.sh
@@ -19,9 +19,11 @@ WASI_NM="$WASI_SDK_DIR/bin/llvm-nm"
 
 if [ -d "$PATCH_DIR" ]; then
   while IFS= read -r patch_file; do
-    if patch --dry-run -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null 2>&1; then
-      patch --no-backup-if-mismatch -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null
-    elif patch --dry-run -R -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null 2>&1; then
+    # -f/--force avoids a prompt some non-GNU patch impls (e.g. BSD/Apple
+    # patch) answer non-deterministically in non-interactive use.
+    if patch --dry-run -f -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null 2>&1; then
+      patch --no-backup-if-mismatch -f -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null
+    elif patch --dry-run -R -f -p1 -d "$LLVM_PROJECT_SRC_DIR" < "$patch_file" >/dev/null 2>&1; then
       :
     else
       echo "failed to apply llvm-project patch: $patch_file" >&2

--- a/toolchain/scripts/clone-and-build-codex-wasi.sh
+++ b/toolchain/scripts/clone-and-build-codex-wasi.sh
@@ -63,6 +63,15 @@ STOP_AFTER="${STOP_AFTER:-}"
 }
 command -v cargo >/dev/null 2>&1 || { echo "ERROR: cargo not on PATH" >&2; exit 1; }
 
+if command -v sha256sum >/dev/null 2>&1; then
+	SHA256=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+	SHA256=(shasum -a 256)
+else
+	echo "ERROR: neither sha256sum nor shasum is available" >&2
+	exit 1
+fi
+
 # --- 1. parse the pin --------------------------------------------------------
 REF="$(tr -d '[:space:]' < "$CODEX_REF_FILE")"
 REPO="${REF%@*}"      # owner/repo
@@ -70,7 +79,7 @@ SHA="${REF#*@}"       # commit sha
 [ -n "$REPO" ] && [ -n "$SHA" ] && [ "$REPO" != "$SHA" ] || {
 	echo "ERROR: malformed codex-ref '$REF' (expected '<owner>/<repo>@<sha>')" >&2; exit 1; }
 URL="$CODEX_GIT_BASE/$REPO.git"
-PATCH_DIGEST="$({ find "$CODEX_PATCH_DIR" -maxdepth 1 -type f -name '*.patch' -print0 | sort -z | xargs -0 sha256sum; } | sha256sum | cut -d ' ' -f1)"
+PATCH_DIGEST="$({ find "$CODEX_PATCH_DIR" -maxdepth 1 -type f -name '*.patch' -print0 | sort -z | xargs -0 "${SHA256[@]}"; } | "${SHA256[@]}" | cut -d ' ' -f1)"
 EXPECTED_STAMP="$SHA:$PATCH_DIGEST"
 
 echo "== codex-ref: $REPO @ $SHA =="

--- a/toolchain/scripts/patch-std.sh
+++ b/toolchain/scripts/patch-std.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # patch-std.sh — Apply wasmVM patches to the Rust std source tree
 #
 # Patches modify the WASI platform implementation in std to support

--- a/toolchain/scripts/patch-vendor.sh
+++ b/toolchain/scripts/patch-vendor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # patch-vendor.sh — Apply crate-level patches to vendored dependencies
 #
 # Iterates std-patches/crates/<crate-name>/*.patch, finds the matching

--- a/toolchain/scripts/patch-wasi-libc.sh
+++ b/toolchain/scripts/patch-wasi-libc.sh
@@ -124,11 +124,16 @@ if [ "$MODE" = "apply" ] || [ "$MODE" = "check" ]; then
 fi
 
 # Find patch files
-if [ "$MODE" = "reverse" ]; then
-    mapfile -t PATCH_FILES < <(find "$PATCHES_DIR" -name '*.patch' -type f 2>/dev/null | sort -r)
-else
-    mapfile -t PATCH_FILES < <(find "$PATCHES_DIR" -name '*.patch' -type f 2>/dev/null | sort)
-fi
+PATCH_FILES=()
+while IFS= read -r patch; do
+    PATCH_FILES+=("$patch")
+done < <(
+    if [ "$MODE" = "reverse" ]; then
+        find "$PATCHES_DIR" -name '*.patch' -type f 2>/dev/null | sort -r
+    else
+        find "$PATCHES_DIR" -name '*.patch' -type f 2>/dev/null | sort
+    fi
+)
 
 if [ "${#PATCH_FILES[@]}" -eq 0 ]; then
     echo "No patch files found in $PATCHES_DIR"

--- a/toolchain/scripts/patch-wasi-libc.sh
+++ b/toolchain/scripts/patch-wasi-libc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # patch-wasi-libc.sh — Vendor, patch, and build wasi-libc as a custom sysroot
 #
 # Clones wasi-libc at the commit pinned by wasi-sdk-25, applies patches from

--- a/toolchain/std-patches/codex-source/build-codex-wasip1.sh
+++ b/toolchain/std-patches/codex-source/build-codex-wasip1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # build-codex-wasip1.sh — reproduce the codex-core wasm32-wasip1 build frontier.
 #
 # Captures every fix discovered while driving `cargo build -p codex-core


### PR DESCRIPTION
This is a series of small script fixes.
1. `toolchain/scripts/patch-wasi-libc.sh` uses `#!/bin/bash` shebang, as well as `mapfile` builtin. `mapfile` bash builtin is only available for `bash 4.x`
- MacOS's `/bin/bash` is stuck on version `3.2.57` (on MacOS `26.5`) and will not update. Does not have access to `mapfile`, leading to failure running `make sysroot`, with error `mapfile: command not found`
- This PR replaces both call sites with an equivalent `while read` loop over the same process substitution
2. Support using `shasum` if `sha256sum` is not installed.
3. Support use of BSD `patch` along with GNU `patch`.
4. Replaces `#!/bin/bash` with `#!/usr/bin/env bash`, which is more standard, and will use `$PATH` (ex, if user used `brew`'s `bash`, which is more up-to-date, this would not have happened)