### PR TITLE
fix(toolchain): apply complete Codex WASI patch chain

### DIFF
--- a/toolchain/std-patches/codex/0005-wasi-build-sysroot-cleanup.patch
+++ b/toolchain/std-patches/codex/0005-wasi-build-sysroot-cleanup.patch
@@ -1,6 +1,6 @@
 --- a/scripts/build-wasi-codex-exec.sh
 +++ b/scripts/build-wasi-codex-exec.sh
-@@ -34,5 +34,6 @@
+@@ -34,6 +34,7 @@
  SYSROOT="$(rustc "+$TOOLCHAIN" --print sysroot)"
  LIBDIR="$SYSROOT/lib/rustlib/wasm32-wasip1/lib"
  STASH="$LIBDIR/.prebuilt-stash"


### PR DESCRIPTION
- Correct the malformed first hunk in the Codex WASI sysroot patch.
- Ensure the full patch chain applies during release builds.