### PR TITLE
fix(execution): migrate Eve and shell process adapters

### DIFF
--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -376,9 +376,6 @@ function coreConnection(vm: AgentOs): AgentOSActorConnection {
 	const methods = vm as unknown as Record<string, unknown>;
 	for (const method of [
 		"dispose",
-		"spawn",
-		"waitProcess",
-		"killProcess",
 		"readFile",
 		"writeFile",
 		"exists",
@@ -386,6 +383,16 @@ function coreConnection(vm: AgentOs): AgentOSActorConnection {
 		"remove",
 	]) {
 		if (typeof methods?.[method] !== "function") {
+			throw new TypeError(
+				"agentOSCoreBackend create() must return an AgentOs instance",
+			);
+		}
+	}
+	const processMethods = vm.process as unknown as
+		| Record<string, unknown>
+		| undefined;
+	for (const method of ["spawn", "wait", "kill"]) {
+		if (typeof processMethods?.[method] !== "function") {
 			throw new TypeError(
 				"agentOSCoreBackend create() must return an AgentOs instance",
 			);
@@ -420,7 +427,7 @@ function coreConnection(vm: AgentOs): AgentOSActorConnection {
 					listener({ pid: processPid, stream, data });
 				}
 			};
-			const process = vm.spawn(command, args, {
+			const process = await vm.process.spawn(command, args, {
 				...options,
 				onStdout: (data) => emit("stdout", data),
 				onStderr: (data) => emit("stderr", data),
@@ -429,10 +436,11 @@ function coreConnection(vm: AgentOs): AgentOSActorConnection {
 			for (const event of earlyOutput) emit(event.stream, event.data);
 			return process;
 		},
-		waitProcess: (pid) => vm.waitProcess(pid),
-		async killProcess(pid) {
-			vm.killProcess(pid);
+		async waitProcess(pid) {
+			const exit = await vm.process.wait(pid);
+			return exit.exitCode ?? 1;
 		},
+		killProcess: (pid) => vm.process.kill(pid),
 		readFile: (path) => vm.readFile(path),
 		writeFile: (path, content) => vm.writeFile(path, content),
 		exists: (path) => vm.exists(path),

--- a/packages/eve/tests/provider.test.ts
+++ b/packages/eve/tests/provider.test.ts
@@ -313,20 +313,26 @@ describe("agentOSBackend", () => {
 	it("adapts and disposes a caller-created standalone Core VM", async () => {
 		const vm = {
 			dispose: vi.fn(async () => {}),
-			spawn: vi.fn(
-				(
-					_command: string,
-					_args: string[],
-					options: { onStdout(data: Uint8Array): void },
-				) => {
-					queueMicrotask(() =>
-						options.onStdout(new TextEncoder().encode("from core")),
-					);
-					return { pid: 31 };
-				},
-			),
-			waitProcess: vi.fn(async () => 0),
-			killProcess: vi.fn(),
+			process: {
+				spawn: vi.fn(
+					async (
+						_command: string,
+						_args: string[],
+						options: { onStdout(data: Uint8Array): void },
+					) => {
+						queueMicrotask(() =>
+							options.onStdout(new TextEncoder().encode("from core")),
+						);
+						return { pid: 31 };
+					},
+				),
+				wait: vi.fn(async (pid: number) => ({
+					pid,
+					outcome: "exited" as const,
+					exitCode: 0,
+				})),
+				kill: vi.fn(async () => {}),
+			},
 			readFile: vi.fn(async () => new Uint8Array()),
 			writeFile: vi.fn(async () => {}),
 			exists: vi.fn(async () => true),
@@ -349,7 +355,7 @@ describe("agentOSBackend", () => {
 			stdout: "from core",
 			stderr: "",
 		});
-		expect(vm.spawn).toHaveBeenCalledWith(
+		expect(vm.process.spawn).toHaveBeenCalledWith(
 			"sh",
 			["-lc", "echo ignored"],
 			expect.objectContaining({ cwd: "/workspace" }),

--- a/packages/shell/src/main.ts
+++ b/packages/shell/src/main.ts
@@ -679,18 +679,39 @@ async function runTerminalAttempt(
 	}
 }
 
+function coreShellVm(vm: AgentOs): ShellVmHandle {
+	return {
+		spawn: (command, args, options) => vm.process.spawn(command, args, options),
+		writeProcessStdin: (pid, data) => vm.process.writeStdin(pid, data),
+		closeProcessStdin: (pid) => vm.process.closeStdin(pid),
+		async waitProcess(pid) {
+			const exit = await vm.process.wait(pid);
+			return exit.exitCode ?? 1;
+		},
+		openShell: (options) => vm.terminal.open(options),
+		writeShell: (shellId, data) => vm.terminal.write(shellId, data),
+		resizeShell: (shellId, cols, rows) =>
+			vm.terminal.resize(shellId, cols, rows),
+		onShellData: (shellId, handler) => vm.onShellData(shellId, handler),
+		waitShell: (shellId) => vm.terminal.wait(shellId),
+		dispose: () => vm.dispose(),
+	};
+}
+
 const cli = parseCli(process.argv.slice(2));
 const env = buildEnv(cli);
 const mounts = buildMounts(cli);
 
 const vm: ShellVmHandle = cli.actor
 	? await createActorShellVm({ software, mounts, defaultSoftware: false })
-	: await AgentOs.create({
-			mounts,
-			permissions: allowAll,
-			software,
-			defaultSoftware: false,
-		});
+	: coreShellVm(
+			await AgentOs.create({
+				mounts,
+				permissions: allowAll,
+				software,
+				defaultSoftware: false,
+			}),
+		);
 
 let exitCode = 1;
 try {


### PR DESCRIPTION
- Update Eve's standalone Core adapter to the nested process API.
- Adapt agentos-shell to process and terminal namespaces.
- Update the Eve provider fixture for asynchronous process descriptors.