### PR TITLE
refactor(agentos): apply inspector review feedback

### DIFF
--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -6,3 +6,17 @@
 - secure-exec packages must never depend on agent-os packages; dependency direction is strictly agent-os to secure-exec and must be CI-enforced after the split.
 - The sidecar remains the source of truth for runtime behavior; TypeScript package code should forward generated requests instead of reimplementing sidecar state machines.
 - Cron and agent configuration types are Rust-owned after the split; TypeScript packages may re-export or mirror them only in lockstep.
+
+## React UI (dashboard inspector)
+
+- Never `setState` from a `useEffect` to derive state from props, query data, or
+  other state. Derive it during render (`useMemo`), or reset it during render by
+  comparing against the value it is keyed on. Effects are for subscriptions,
+  timers, and imperative cleanup only.
+- Server mutations use `useMutation`; do not hand-roll `busy`/`error` state
+  around an `async` handler.
+- Coupled state that always changes together belongs in one `useReducer` (or one
+  state object), not in a pile of independent `useState` calls updated in
+  sequence.
+- Imperative browser resources (object URLs, observers, listeners) belong in a
+  self-contained hook that owns both creation and cleanup.

--- a/packages/agentos/src/inspector-tabs/lib/hooks.ts
+++ b/packages/agentos/src/inspector-tabs/lib/hooks.ts
@@ -1,0 +1,69 @@
+// Shared React hooks for the inspector tabs: imperative browser resources and
+// timers, each owning its own cleanup.
+import { useEffect, useMemo, useRef, useState } from "react";
+
+/** Blob URL for in-memory bytes, revoked when they change or on unmount. */
+export function useObjectUrl(bytes: Uint8Array | null | undefined): string | null {
+	const url = useMemo(
+		() => (bytes ? URL.createObjectURL(new Blob([bytes as BlobPart])) : null),
+		[bytes],
+	);
+	useEffect(() => {
+		return () => {
+			if (url) URL.revokeObjectURL(url);
+		};
+	}, [url]);
+	return url;
+}
+
+/** Call `onSettled` once `value` has stopped changing for `delayMs` — a pending
+ * timer is cancelled by the next change and by unmount. `onSettled` need not be
+ * stable: the latest one is used. */
+export function useSettledValue<T>(
+	value: T,
+	delayMs: number,
+	onSettled: (value: T) => void,
+): void {
+	const latest = useRef(onSettled);
+	useEffect(() => {
+		latest.current = onSettled;
+	});
+	useEffect(() => {
+		const id = setTimeout(() => latest.current(value), delayMs);
+		return () => clearTimeout(id);
+	}, [value, delayMs]);
+}
+
+/** Two-step confirm for irreversible actions: the first press arms an action,
+ * a second press within `timeoutMs` runs it. Disarms on timeout, on unmount,
+ * and whenever `resetKey` changes — an armed delete must never carry over to a
+ * different target. */
+export function useArmedConfirm<K extends string>({
+	timeoutMs = 3_000,
+	resetKey,
+}: { timeoutMs?: number; resetKey?: unknown } = {}): {
+	armed: K | null;
+	confirm: (action: K, run: () => void) => void;
+} {
+	const [stored, setStored] = useState<{ armed: K | null; key: unknown }>({
+		armed: null,
+		key: resetKey,
+	});
+	const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+	if (stored.key !== resetKey) setStored({ armed: null, key: resetKey });
+	const armed = stored.key === resetKey ? stored.armed : null;
+	useEffect(() => () => clearTimeout(timer.current), []);
+
+	const confirm = (action: K, run: () => void) => {
+		clearTimeout(timer.current);
+		if (armed === action) {
+			setStored({ armed: null, key: resetKey });
+			run();
+			return;
+		}
+		setStored({ armed: action, key: resetKey });
+		timer.current = setTimeout(() => setStored({ armed: null, key: resetKey }), timeoutMs);
+	};
+
+	return { armed, confirm };
+}

--- a/packages/agentos/src/inspector-tabs/permission-prompts.tsx
+++ b/packages/agentos/src/inspector-tabs/permission-prompts.tsx
@@ -2,13 +2,12 @@
 // tab is its own iframe, so "global" means "in every iframe's chrome"). An
 // agent blocked on a permission request otherwise looks frozen: the session
 // sits in durable "waiting" until someone answers. Cards come from two sources
-// merged on `sessionId:requestId`: a one-off backfill on mount (durable
-// "waiting" sessions via `listSessions`, so requests raised while no inspector
-// iframe was open still surface) plus live `sessionEvent` entries of type
-// `permission_request`. A `permission_response` entry drops the card another
-// viewer already answered.
+// merged on `sessionId:requestId`: a backfill fetch (durable "waiting" sessions
+// via `listSessions`, so requests raised while no inspector iframe was open
+// still surface) plus live `sessionEvent` entries of type `permission_request`.
+// A `permission_response` entry drops the card another viewer already answered.
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronRight } from "./common";
 import { isInspectorActionError } from "./lib/actor-client";
 import { useAgentOsActor } from "./lib/rivet";
@@ -18,27 +17,54 @@ import React from "react";
 
 // Bounded queue: drop the oldest card beyond this (an unbounded queue would
 // just stack dead cards; resolutions arrive as `permission_response` entries).
+// The same bound caps the per-request status map.
 const MAX_CARDS = 32;
 
-interface PermissionCard {
+interface PermissionRequest {
 	sessionId: string;
 	requestId: string;
 	/** The request's OWN ACP options — one button per entry (never a fixed set). */
 	options: PendingPermissionDisplay["options"];
 	toolCall: PendingPermissionDisplay["toolCall"];
-	state: "pending" | "busy" | "resolved" | "failed";
-	/** `PermissionTerminalReason` when the request resolved out from under us. */
-	reason?: string;
-	error?: string;
 }
 
-function cardKey(card: Pick<PermissionCard, "sessionId" | "requestId">): string {
+/** Per-request status, kept apart from the request itself so the rendered list
+ * can be derived from (backfill + live) instead of copied into state. */
+type CardStatus =
+	| { state: "pending" }
+	| { state: "busy" }
+	/** `PermissionTerminalReason` when the request resolved out from under us. */
+	| { state: "resolved"; reason?: string }
+	| { state: "failed"; error: string }
+	/** Answered here, answered elsewhere, or dismissed: no card. */
+	| { state: "hidden" };
+
+const PENDING: CardStatus = { state: "pending" };
+
+function cardKey(card: Pick<PermissionRequest, "sessionId" | "requestId">): string {
 	return `${card.sessionId}:${card.requestId}`;
+}
+
+/** Insert into a bounded, insertion-ordered map; oldest key drops first. */
+function withStatus(
+	prev: ReadonlyMap<string, CardStatus>,
+	key: string,
+	status: CardStatus,
+): Map<string, CardStatus> {
+	const next = new Map(prev);
+	next.delete(key);
+	next.set(key, status);
+	while (next.size > MAX_CARDS) {
+		const oldest = next.keys().next().value;
+		if (oldest === undefined) break;
+		next.delete(oldest);
+	}
+	return next;
 }
 
 /** Detail payload for the collapsible block: the tool call's raw input,
  * hidden when absent or an empty object. */
-function toolCallDetail(toolCall: PermissionCard["toolCall"]): unknown {
+function toolCallDetail(toolCall: PermissionRequest["toolCall"]): unknown {
 	const raw = toolCall?.rawInput;
 	if (raw == null) return undefined;
 	if (typeof raw === "object" && !Array.isArray(raw) && Object.keys(raw).length === 0) {
@@ -48,35 +74,37 @@ function toolCallDetail(toolCall: PermissionCard["toolCall"]): unknown {
 }
 
 export function PermissionPrompts({ actorId }: { actorId: string }) {
-	const [cards, setCards] = useState<PermissionCard[]>([]);
+	// Requests seen live on this iframe's subscription.
+	const [liveRequests, setLiveRequests] = useState<PermissionRequest[]>([]);
+	const [statuses, setStatuses] = useState<ReadonlyMap<string, CardStatus>>(() => new Map());
 
-	// One-off backfill of requests raised before this iframe subscribed.
-	// `data === null` means the runtime predates the durable-sessions contract
-	// (contract-layer error) — stay live-only silently.
+	// Backfill of requests raised before this iframe subscribed. `data === null`
+	// means the runtime predates the durable-sessions contract (contract-layer
+	// error) — stay live-only silently.
 	const backfill = useQuery(pendingPermissionsQueryOptions(actorId));
 	const backfillRows = backfill.data;
-	useEffect(() => {
-		if (!backfillRows || backfillRows.length === 0) return;
-		setCards((prev) => {
-			// Live cards win the dedupe: a `sessionEvent` that raced the fetch
-			// already carries the same request (identity is sessionId:requestId).
-			const have = new Set(prev.map(cardKey));
-			const added = backfillRows
-				.filter((row) => !have.has(cardKey(row)))
-				.map(
-					(row): PermissionCard => ({
-						sessionId: row.sessionId,
-						requestId: row.requestId,
-						options: row.options,
-						toolCall: row.toolCall,
-						state: "pending",
-					}),
-				);
-			if (added.length === 0) return prev;
-			// Backfilled requests predate anything received live: keep them first.
-			return [...added, ...prev].slice(-MAX_CARDS);
-		});
-	}, [backfillRows]);
+
+	// Live cards win the dedupe: a `sessionEvent` that raced the fetch already
+	// carries the same request (identity is sessionId:requestId). Backfilled
+	// requests predate anything received live, so they stay first.
+	const cards = useMemo(() => {
+		const liveKeys = new Set(liveRequests.map(cardKey));
+		const merged: PermissionRequest[] = [
+			...(backfillRows ?? [])
+				.filter((row) => !liveKeys.has(cardKey(row)))
+				.map((row) => ({
+					sessionId: row.sessionId,
+					requestId: row.requestId,
+					options: row.options,
+					toolCall: row.toolCall,
+				})),
+			...liveRequests,
+		];
+		return merged
+			.map((request) => ({ request, status: statuses.get(cardKey(request)) ?? PENDING }))
+			.filter((card) => card.status.state !== "hidden")
+			.slice(-MAX_CARDS);
+	}, [backfillRows, liveRequests, statuses]);
 
 	// Live stream: durable `sessionEvent` entries carry both new requests and
 	// their resolutions — same cast pattern as transcript.tsx (the handler
@@ -91,17 +119,16 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 		if (!entry) return;
 		if (entry.type === "permission_request") {
 			if (!entry.sessionId || !entry.requestId) return;
-			const next: PermissionCard = {
+			const next: PermissionRequest = {
 				sessionId: entry.sessionId,
 				requestId: entry.requestId,
 				options: entry.options,
 				toolCall: entry.toolCall,
-				state: "pending",
 			};
-			setCards((prev) => {
-				const deduped = prev.filter((c) => cardKey(c) !== cardKey(next));
-				return [...deduped, next].slice(-MAX_CARDS);
-			});
+			const key = cardKey(next);
+			setLiveRequests((prev) => [...prev.filter((c) => cardKey(c) !== key), next].slice(-MAX_CARDS));
+			// A re-raised request is pending again, whatever its last outcome was.
+			setStatuses((prev) => withStatus(prev, key, PENDING));
 			return;
 		}
 		// Another viewer (or a headless client) answered: its card is stale here,
@@ -111,23 +138,24 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 		if (entry.type === "permission_response") {
 			if (!entry.sessionId || !entry.requestId) return;
 			const key = cardKey(entry);
-			setCards((prev) => prev.filter((c) => cardKey(c) !== key || c.state === "busy"));
+			setStatuses((prev) =>
+				prev.get(key)?.state === "busy" ? prev : withStatus(prev, key, { state: "hidden" }),
+			);
 		}
 	});
 
-	const respond = async (card: PermissionCard, optionId: string) => {
-		const key = cardKey(card);
-		const patch = (changes: Partial<PermissionCard>) =>
-			setCards((prev) => prev.map((c) => (cardKey(c) === key ? { ...c, ...changes } : c)));
+	const respond = async (request: PermissionRequest, optionId: string) => {
+		const key = cardKey(request);
+		const patch = (status: CardStatus) => setStatuses((prev) => withStatus(prev, key, status));
 		patch({ state: "busy" });
 		try {
 			const result = await agentOsSource.respondPermission(
-				card.sessionId,
-				card.requestId,
+				request.sessionId,
+				request.requestId,
 				optionId,
 			);
 			if (result.status === "accepted") {
-				setCards((prev) => prev.filter((c) => cardKey(c) !== key));
+				patch({ state: "hidden" });
 				return;
 			}
 			// `not_pending`: another viewer answered first or the prompt ended —
@@ -140,18 +168,18 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 		}
 	};
 
-	const dismiss = (card: PermissionCard) =>
-		setCards((prev) => prev.filter((c) => cardKey(c) !== cardKey(card)));
+	const dismiss = (request: PermissionRequest) =>
+		setStatuses((prev) => withStatus(prev, cardKey(request), { state: "hidden" }));
 
 	if (cards.length === 0) return null;
 
 	return (
 		<div className="shrink-0 border-b">
-			{cards.map((card) => {
-				const detail = toolCallDetail(card.toolCall);
+			{cards.map(({ request, status }) => {
+				const detail = toolCallDetail(request.toolCall);
 				return (
 					<div
-						key={cardKey(card)}
+						key={cardKey(request)}
 						className="flex flex-col gap-1.5 border-b border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs last:border-b-0"
 					>
 						<div className="flex items-start gap-2">
@@ -159,11 +187,11 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 								<div className="text-amber-500">
 									Agent requests permission
 									<span className="ml-2 font-mono text-[10px] text-muted-foreground/70">
-										session …{card.sessionId.slice(-10)}
+										session …{request.sessionId.slice(-10)}
 									</span>
 								</div>
 								<div className="mt-0.5 text-foreground/90">
-									{card.toolCall?.title ?? card.requestId}
+									{request.toolCall?.title ?? request.requestId}
 								</div>
 								{detail !== undefined ? (
 									<details className="group mt-1 text-muted-foreground/70">
@@ -177,14 +205,14 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 									</details>
 								) : null}
 							</div>
-							{card.state === "pending" || card.state === "busy" ? (
+							{status.state === "pending" || status.state === "busy" ? (
 								<div className="flex shrink-0 items-center gap-1.5">
-									{card.options.map((option) => (
+									{request.options.map((option) => (
 										<button
 											key={option.optionId}
 											type="button"
-											disabled={card.state === "busy"}
-											onClick={() => void respond(card, option.optionId)}
+											disabled={status.state === "busy"}
+											onClick={() => void respond(request, option.optionId)}
 											className={
 												option.kind === "reject_once" || option.kind === "reject_always"
 													? "rounded-md border border-destructive/50 px-2.5 py-1 text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-40"
@@ -198,13 +226,15 @@ export function PermissionPrompts({ actorId }: { actorId: string }) {
 							) : (
 								<div className="flex shrink-0 items-center gap-2">
 									<span className="text-muted-foreground">
-										{card.state === "resolved"
-											? `No longer pending (${(card.reason ?? "already resolved").replace(/_/g, " ")})`
-											: (card.error ?? "Reply failed")}
+										{status.state === "resolved"
+											? `No longer pending (${(status.reason ?? "already resolved").replace(/_/g, " ")})`
+											: status.state === "failed"
+												? status.error
+												: "Reply failed"}
 									</span>
 									<button
 										type="button"
-										onClick={() => dismiss(card)}
+										onClick={() => dismiss(request)}
 										className="rounded border px-2 py-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 									>
 										Dismiss

--- a/packages/agentos/src/inspector-tabs/styles.css
+++ b/packages/agentos/src/inspector-tabs/styles.css
@@ -55,7 +55,9 @@ body,
 }
 
 body {
-	background: hsl(var(--background));
+	/* Each tab is an iframe mounted inside a dashboard panel, whose surface is
+	   `--card`, not the dashboard's page `--background`. */
+	background: hsl(var(--card));
 	color: hsl(var(--foreground));
 	font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
 	-webkit-font-smoothing: antialiased;

--- a/packages/agentos/src/inspector-tabs/tab-boundary.tsx
+++ b/packages/agentos/src/inspector-tabs/tab-boundary.tsx
@@ -41,7 +41,7 @@ class ErrorBoundary extends Component<
 		}
 		return (
 			<div className="flex h-full flex-1 flex-col items-center justify-center p-8">
-				<div className="flex w-full max-w-md flex-col items-center gap-3 rounded-xl border bg-card p-6 text-center">
+				<div className="flex w-full max-w-md flex-col items-center gap-3 rounded-xl border bg-secondary p-6 text-center">
 					<ActionErrorNote error={error} className="items-center p-0 text-center" />
 					<button
 						type="button"

--- a/packages/agentos/src/inspector-tabs/tabs/filesystem.tsx
+++ b/packages/agentos/src/inspector-tabs/tabs/filesystem.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useReducer, useRef, useState } from "react";
 import {
 	ActionErrorNote,
 	AgentOsEmpty,
@@ -19,6 +19,7 @@ import {
 	UploadIcon,
 } from "../common";
 import { cn } from "../lib/cn";
+import { useArmedConfirm, useObjectUrl, useSettledValue } from "../lib/hooks";
 import { agentOsSource } from "../lib/source";
 import type { FsEntry } from "../lib/types";
 import { ScrollArea } from "../ui/scroll-area";
@@ -127,6 +128,22 @@ function downloadBytes(bytes: Uint8Array, filename: string): void {
 	URL.revokeObjectURL(url);
 }
 
+/** Per-file view state, one object so switching files resets it in a single
+ * transition instead of a setState pile in an effect. */
+interface FileView {
+	path: string | null;
+	force: boolean;
+	renameDraft: string | null;
+	error: unknown;
+}
+
+const freshFileView = (path: string | null): FileView => ({
+	path,
+	force: false,
+	renameDraft: null,
+	error: null,
+});
+
 function FileViewer({
 	actorId,
 	path,
@@ -140,30 +157,20 @@ function FileViewer({
 	onDeleted: () => void;
 	onRenamed: (to: string) => void;
 }) {
-	const [force, setForce] = useState(false);
-	const [renameDraft, setRenameDraft] = useState<string | null>(null);
-	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [mutationError, setMutationError] = useState<unknown>(null);
-	// Per-file view state resets when the selection changes.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on path change
-	useEffect(() => {
-		setForce(false);
-		setRenameDraft(null);
-		setConfirmingDelete(false);
-		setMutationError(null);
-	}, [path]);
+	const [stored, setStored] = useState<FileView>(() => freshFileView(path));
+	// Reset during render, not in an effect: no intermediate paint of the
+	// previous file's rename draft against the new selection.
+	if (stored.path !== path) setStored(freshFileView(path));
+	const view = stored.path === path ? stored : freshFileView(path);
+	const patch = (changes: Partial<FileView>) =>
+		setStored((prev) => ({ ...prev, ...changes }));
 	const { data, error } = useQuery(
-		agentOsSource.fileContentQueryOptions(actorId, path, force),
+		agentOsSource.fileContentQueryOptions(actorId, path, view.force),
 	);
-	const imageUrl = useMemo(() => {
-		if (!data?.bytes || data.text !== null || !IMAGE_EXTENSIONS.test(data.path)) return null;
-		return URL.createObjectURL(new Blob([data.bytes as BlobPart]));
-	}, [data]);
-	useEffect(() => {
-		return () => {
-			if (imageUrl) URL.revokeObjectURL(imageUrl);
-		};
-	}, [imageUrl]);
+	const isImage = !!data?.bytes && data.text === null && IMAGE_EXTENSIONS.test(data.path);
+	const imageUrl = useObjectUrl(isImage ? data?.bytes : null);
+	// Arming is per-file: selecting another file must not inherit it.
+	const { armed, confirm } = useArmedConfirm<"delete">({ resetKey: path });
 
 	if (!path)
 		return (
@@ -181,47 +188,42 @@ function FileViewer({
 
 	const filename = data.path.split("/").pop() ?? data.path;
 	const rename = async () => {
-		const to = renameDraft?.trim();
+		const to = view.renameDraft?.trim();
 		if (!to || to === data.path) {
-			setRenameDraft(null);
+			patch({ renameDraft: null });
 			return;
 		}
-		setMutationError(null);
+		patch({ error: null });
 		try {
 			await agentOsSource.moveEntry(data.path, to);
-			setRenameDraft(null);
+			patch({ renameDraft: null });
 			onRenamed(to);
 			onMutated();
 		} catch (err) {
-			setMutationError(err);
+			patch({ error: err });
 		}
 	};
 	const remove = async () => {
-		if (!confirmingDelete) {
-			setConfirmingDelete(true);
-			setTimeout(() => setConfirmingDelete(false), 3_000);
-			return;
-		}
-		setMutationError(null);
+		patch({ error: null });
 		try {
 			await agentOsSource.deleteFile(data.path, {});
 			onDeleted();
 			onMutated();
 		} catch (err) {
-			setMutationError(err);
+			patch({ error: err });
 		}
 	};
 
 	return (
 		<div className="flex h-full flex-col">
 			<div className="flex items-center gap-2 border-b px-4 py-2.5">
-				{renameDraft !== null ? (
+				{view.renameDraft !== null ? (
 					<input
-						value={renameDraft}
-						onChange={(e) => setRenameDraft(e.target.value)}
+						value={view.renameDraft}
+						onChange={(e) => patch({ renameDraft: e.target.value })}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") void rename();
-							if (e.key === "Escape") setRenameDraft(null);
+							if (e.key === "Escape") patch({ renameDraft: null });
 						}}
 						spellCheck={false}
 						autoFocus
@@ -241,10 +243,12 @@ function FileViewer({
 					<DownloadIcon className="size-3.5" />
 				</IconButton>
 				<IconButton
-					title={renameDraft !== null ? "Save new name" : "Rename this file"}
-					onClick={() => (renameDraft !== null ? void rename() : setRenameDraft(data.path))}
+					title={view.renameDraft !== null ? "Save new name" : "Rename this file"}
+					onClick={() =>
+						view.renameDraft !== null ? void rename() : patch({ renameDraft: data.path })
+					}
 				>
-					{renameDraft !== null ? (
+					{view.renameDraft !== null ? (
 						<CheckIcon className="size-3.5" />
 					) : (
 						<PencilIcon className="size-3.5" />
@@ -252,21 +256,25 @@ function FileViewer({
 				</IconButton>
 				{/* Delete keeps a two-step confirm: the icon arms it, the explicit
 				    text disarms accidental clicks on an irreversible action. */}
-				{confirmingDelete ? (
+				{armed === "delete" ? (
 					<button
 						type="button"
-						onClick={() => void remove()}
+						onClick={() => confirm("delete", () => void remove())}
 						className="shrink-0 rounded border border-destructive/50 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/10"
 					>
 						Confirm delete?
 					</button>
 				) : (
-					<IconButton title="Delete this file" destructive onClick={() => void remove()}>
+					<IconButton
+						title="Delete this file"
+						destructive
+						onClick={() => confirm("delete", () => void remove())}
+					>
 						<TrashIcon className="size-3.5" />
 					</IconButton>
 				)}
 			</div>
-			{mutationError ? <ActionErrorNote error={mutationError} className="border-b py-2" /> : null}
+			{view.error ? <ActionErrorNote error={view.error} className="border-b py-2" /> : null}
 			<ScrollArea className="min-h-0 flex-1">
 				{data.special ? (
 					<div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
@@ -280,7 +288,7 @@ function FileViewer({
 						</span>
 						<button
 							type="button"
-							onClick={() => setForce(true)}
+							onClick={() => patch({ force: true })}
 							className="rounded border px-2.5 py-1 text-xs transition-colors hover:bg-muted hover:text-foreground"
 						>
 							Load anyway
@@ -374,30 +382,83 @@ function loadFsState(actorId: string): {
 	return { root: "/", selectedPath: null, openPaths: [] };
 }
 
-function FilesystemLoaded({ actorId }: { actorId: string }) {
-	// `root` drives the listing/refetch; `draft` tracks keystrokes locally so
-	// typing never refetches. `root` is committed 500ms after typing stops (or
-	// immediately on Enter) so we don't refetch on every keystroke.
-	const initial = useRef(loadFsState(actorId)).current;
-	const [root, setRoot] = useState(initial.root);
-	const [draft, setDraft] = useState(initial.root);
-	const [selectedPath, setSelectedPath] = useState<string | null>(initial.selectedPath);
-	const [openPaths, setOpenPaths] = useState<ReadonlySet<string>>(
-		() => new Set(initial.openPaths),
-	);
-	const toggleOpen = (path: string) =>
-		setOpenPaths((prev) => {
-			const next = new Set(prev);
-			if (next.has(path)) next.delete(path);
+/** `root` drives the listing/refetch; `draft` tracks keystrokes locally so
+ * typing never refetches. The four fields move together (a tree click retargets
+ * the path bar, Enter commits it), so they are one reducer, not four setStates. */
+interface BrowseState {
+	root: string;
+	draft: string;
+	selectedPath: string | null;
+	openPaths: ReadonlySet<string>;
+}
+
+type BrowseAction =
+	| { type: "type"; value: string }
+	/** Enter: normalize what was typed and commit it. */
+	| { type: "commitDraft" }
+	/** Debounce fired: commit the normalized draft as the root, leave it as typed. */
+	| { type: "commitDebounced" }
+	| { type: "goUp" }
+	| { type: "openDir"; path: string }
+	| { type: "selectFile"; path: string }
+	| { type: "reselect"; path: string | null }
+	| { type: "toggleOpen"; path: string };
+
+function browseReducer(state: BrowseState, action: BrowseAction): BrowseState {
+	switch (action.type) {
+		case "type":
+			return { ...state, draft: action.value };
+		case "commitDraft": {
+			const next = normalizeRoot(state.draft);
+			return next === state.root && next === state.draft
+				? state
+				: { ...state, root: next, draft: next };
+		}
+		case "commitDebounced": {
+			const next = normalizeRoot(state.draft);
+			return next === state.root ? state : { ...state, root: next };
+		}
+		case "goUp": {
+			const up = parentDir(normalizeRoot(state.draft));
+			return { ...state, root: up, draft: up };
+		}
+		case "openDir":
+			return { ...state, draft: action.path };
+		case "selectFile":
+			return { ...state, selectedPath: action.path, draft: parentDir(action.path) };
+		case "reselect":
+			return { ...state, selectedPath: action.path };
+		case "toggleOpen": {
+			const openPaths = new Set(state.openPaths);
+			if (openPaths.has(action.path)) openPaths.delete(action.path);
 			else {
-				next.add(path);
-				if (next.size > MAX_PERSISTED_OPEN_DIRS) {
-					const oldest = next.values().next().value;
-					if (oldest !== undefined) next.delete(oldest);
+				openPaths.add(action.path);
+				if (openPaths.size > MAX_PERSISTED_OPEN_DIRS) {
+					const oldest = openPaths.values().next().value;
+					if (oldest !== undefined) openPaths.delete(oldest);
 				}
 			}
-			return next;
-		});
+			return { ...state, openPaths };
+		}
+	}
+}
+
+function FilesystemLoaded({ actorId }: { actorId: string }) {
+	// The root is committed 500ms after typing stops (or immediately on Enter)
+	// so we don't refetch on every keystroke.
+	const [{ root, draft, selectedPath, openPaths }, dispatch] = useReducer(
+		browseReducer,
+		actorId,
+		(id): BrowseState => {
+			const stored = loadFsState(id);
+			return {
+				root: stored.root,
+				draft: stored.root,
+				selectedPath: stored.selectedPath,
+				openPaths: new Set(stored.openPaths),
+			};
+		},
+	);
 	useEffect(() => {
 		try {
 			sessionStorage.setItem(
@@ -409,7 +470,6 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 		}
 	}, [actorId, root, selectedPath, openPaths]);
 	const [newFolderDraft, setNewFolderDraft] = useState<string | null>(null);
-	const [treeError, setTreeError] = useState<unknown>(null);
 	const uploadInputRef = useRef<HTMLInputElement>(null);
 	const queryClient = useQueryClient();
 
@@ -419,14 +479,8 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 	const notADir = rootsQuery.data === null;
 	const roots = rootsQuery.data ?? [];
 
-	// Debounce: commit the normalized draft once the user pauses for 500ms.
-	useEffect(() => {
-		const id = setTimeout(() => {
-			const next = normalizeRoot(draft);
-			setRoot((cur) => (next !== cur ? next : cur));
-		}, 500);
-		return () => clearTimeout(id);
-	}, [draft]);
+	// Commit the normalized draft once the user pauses typing.
+	useSettledValue(draft, 500, () => dispatch({ type: "commitDebounced" }));
 
 	// Every directory listing under this actor (the tree fetches per-level).
 	const refreshTree = () =>
@@ -436,32 +490,31 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 	// tree clicks (a folder moves it there; a file moves it to its parent).
 	const currentDir = normalizeRoot(draft);
 
-	const createFolder = async () => {
+	const createFolder = useMutation({
+		mutationFn: (name: string) =>
+			agentOsSource.mkdir(name.startsWith("/") ? name : joinRoot(currentDir, name)),
+		onSuccess: async () => {
+			setNewFolderDraft(null);
+			await refreshTree();
+		},
+	});
+	const submitNewFolder = () => {
 		const name = newFolderDraft?.trim();
 		if (!name) {
 			setNewFolderDraft(null);
 			return;
 		}
-		setTreeError(null);
-		try {
-			await agentOsSource.mkdir(name.startsWith("/") ? name : joinRoot(currentDir, name));
-			setNewFolderDraft(null);
-			await refreshTree();
-		} catch (error) {
-			setTreeError(error);
-		}
+		createFolder.mutate(name);
 	};
 
-	const upload = async (file: File) => {
-		setTreeError(null);
-		try {
+	const upload = useMutation({
+		mutationFn: async (file: File) => {
 			const bytes = new Uint8Array(await file.arrayBuffer());
 			await agentOsSource.writeFile(joinRoot(currentDir, file.name), bytes);
-			await refreshTree();
-		} catch (error) {
-			setTreeError(error);
-		}
-	};
+		},
+		onSuccess: () => refreshTree(),
+	});
+	const treeError = createFolder.error ?? upload.error;
 
 	return (
 		<div className="flex h-full min-h-0">
@@ -491,7 +544,7 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 						onChange={(e) => {
 							const file = e.target.files?.[0];
 							e.target.value = "";
-							if (file) void upload(file);
+							if (file) upload.mutate(file);
 						}}
 					/>
 				</div>
@@ -502,24 +555,16 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 					<IconButton
 						title={currentDir === "/" ? "Already at the root" : `Up to ${parentDir(currentDir)}`}
 						disabled={currentDir === "/"}
-						onClick={() => {
-							const up = parentDir(currentDir);
-							setDraft(up);
-							setRoot((cur) => (up !== cur ? up : cur));
-						}}
+						onClick={() => dispatch({ type: "goUp" })}
 						className="size-5"
 					>
 						<ArrowLeftIcon className="size-3.5" />
 					</IconButton>
 					<input
 						value={draft}
-						onChange={(e) => setDraft(e.target.value)}
+						onChange={(e) => dispatch({ type: "type", value: e.target.value })}
 						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								const next = normalizeRoot(draft);
-								setDraft(next);
-								setRoot((cur) => (next !== cur ? next : cur));
-							}
+							if (e.key === "Enter") dispatch({ type: "commitDraft" });
 						}}
 						spellCheck={false}
 						autoComplete="off"
@@ -534,7 +579,7 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 							value={newFolderDraft}
 							onChange={(e) => setNewFolderDraft(e.target.value)}
 							onKeyDown={(e) => {
-								if (e.key === "Enter") void createFolder();
+								if (e.key === "Enter") submitNewFolder();
 								if (e.key === "Escape") setNewFolderDraft(null);
 							}}
 							spellCheck={false}
@@ -568,16 +613,15 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 								entry={entry}
 								depth={0}
 								selectedPath={selectedPath}
-								onSelect={(e) => {
-									if (e.dir) {
-										setDraft(e.path);
-									} else {
-										setSelectedPath(e.path);
-										setDraft(parentDir(e.path));
-									}
-								}}
+								onSelect={(e) =>
+									dispatch(
+										e.dir
+											? { type: "openDir", path: e.path }
+											: { type: "selectFile", path: e.path },
+									)
+								}
 								openPaths={openPaths}
-								onToggle={toggleOpen}
+								onToggle={(path) => dispatch({ type: "toggleOpen", path })}
 							/>
 						))
 					)}
@@ -594,8 +638,8 @@ function FilesystemLoaded({ actorId }: { actorId: string }) {
 					actorId={actorId}
 					path={selectedPath}
 					onMutated={() => void refreshTree()}
-					onDeleted={() => setSelectedPath(null)}
-					onRenamed={(to) => setSelectedPath(to)}
+					onDeleted={() => dispatch({ type: "reselect", path: null })}
+					onRenamed={(to) => dispatch({ type: "reselect", path: to })}
 				/>
 			</div>
 		</div>

--- a/packages/agentos/src/inspector-tabs/tabs/processes.tsx
+++ b/packages/agentos/src/inspector-tabs/tabs/processes.tsx
@@ -5,6 +5,7 @@ import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { ActionErrorNote, ChevronRight, relativeTime, StatusDot } from "../common";
 import { cn } from "../lib/cn";
+import { useArmedConfirm } from "../lib/hooks";
 import { useAgentOsActor } from "../lib/rivet";
 import { agentOsSource, decodeActionBytes } from "../lib/source";
 import type { KernelProcessInfo, ProcessExitPayload, ProcessOutputPayload, ProcessTreeNode } from "../lib/types";
@@ -87,19 +88,8 @@ function ExpandedDetail({
 	onKill: () => void;
 	actionError: unknown;
 }) {
-	const [confirming, setConfirming] = useState<"stop" | "kill" | null>(null);
-	const confirmTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-	const arm = (which: "stop" | "kill", run: () => void) => {
-		if (confirming === which) {
-			clearTimeout(confirmTimer.current);
-			setConfirming(null);
-			run();
-			return;
-		}
-		setConfirming(which);
-		clearTimeout(confirmTimer.current);
-		confirmTimer.current = setTimeout(() => setConfirming(null), 3_000);
-	};
+	// Arming is per-process: expanding another row must not inherit it.
+	const { armed, confirm } = useArmedConfirm<"stop" | "kill">({ resetKey: p.pid });
 	return (
 		<div className="flex flex-col gap-3 px-4 py-3 text-xs">
 			<div className="grid grid-cols-2 gap-x-8 gap-y-2 sm:grid-cols-4">
@@ -116,17 +106,17 @@ function ExpandedDetail({
 				<div className="flex items-center gap-2">
 					<button
 						type="button"
-						onClick={() => arm("stop", onStop)}
+						onClick={() => confirm("stop", onStop)}
 						className="rounded border px-2 py-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					>
-						{confirming === "stop" ? "Confirm stop?" : "Stop"}
+						{armed === "stop" ? "Confirm stop?" : "Stop"}
 					</button>
 					<button
 						type="button"
-						onClick={() => arm("kill", onKill)}
+						onClick={() => confirm("kill", onKill)}
 						className="rounded border border-destructive/40 px-2 py-0.5 text-destructive transition-colors hover:bg-destructive/10"
 					>
-						{confirming === "kill" ? "Confirm kill?" : "Kill"}
+						{armed === "kill" ? "Confirm kill?" : "Kill"}
 					</button>
 				</div>
 			) : null}
@@ -211,7 +201,7 @@ export function ProcessTable({ actorId }: { actorId: string }) {
 	return (
 		<div className="max-h-96 overflow-y-auto">
 			<table className="w-full text-sm">
-				<thead className="sticky top-0 bg-background text-[11px] text-muted-foreground">
+				<thead className="sticky top-0 bg-secondary text-[11px] text-muted-foreground">
 					<tr className="border-b">
 						<th className="w-8 px-3 py-2" aria-label="Expand" />
 						<th className="w-16 px-2 py-2 text-left font-medium">PID</th>

--- a/packages/agentos/src/inspector-tabs/tabs/system.tsx
+++ b/packages/agentos/src/inspector-tabs/tabs/system.tsx
@@ -2,7 +2,7 @@
 // installed software, configured mounts, preview links, and the actor id in
 // one scroll view, keeping the tab bar to the high-traffic surfaces
 // (transcript, filesystem).
-import { useSuspenseQueries } from "@tanstack/react-query";
+import { useMutation, useSuspenseQueries } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { ActionErrorNote, ChevronRight, CopyButton } from "../common";
 import { cn } from "../lib/cn";
@@ -139,35 +139,26 @@ function MountsTable({ mounts }: { mounts: MountInfo[] }) {
 function PreviewLinks() {
 	const [portDraft, setPortDraft] = useState("3000");
 	const [links, setLinks] = useState<SignedPreviewUrl[]>([]);
-	const [busy, setBusy] = useState(false);
-	const [error, setError] = useState<unknown>(null);
 
-	const create = async () => {
-		const port = Number.parseInt(portDraft, 10);
-		if (!Number.isInteger(port) || port < 1 || port > 65535) {
-			setError(new Error(`Not a valid port: ${portDraft}`));
-			return;
-		}
-		setBusy(true);
-		setError(null);
-		try {
-			const link = await agentOsSource.createSignedPreviewUrl(port, 900);
-			setLinks((prev) => [...prev.filter((l) => l.token !== link.token), link]);
-		} catch (err) {
-			setError(err);
-		} finally {
-			setBusy(false);
-		}
-	};
-	const revoke = async (link: SignedPreviewUrl) => {
-		setError(null);
-		try {
+	const create = useMutation({
+		mutationFn: async (draft: string) => {
+			const port = Number.parseInt(draft, 10);
+			if (!Number.isInteger(port) || port < 1 || port > 65535) {
+				throw new Error(`Not a valid port: ${draft}`);
+			}
+			return agentOsSource.createSignedPreviewUrl(port, 900);
+		},
+		onSuccess: (link) =>
+			setLinks((prev) => [...prev.filter((l) => l.token !== link.token), link]),
+	});
+	const revoke = useMutation({
+		mutationFn: async (link: SignedPreviewUrl) => {
 			await agentOsSource.expireSignedPreviewUrl(link.token);
-			setLinks((prev) => prev.filter((l) => l.token !== link.token));
-		} catch (err) {
-			setError(err);
-		}
-	};
+			return link;
+		},
+		onSuccess: (link) => setLinks((prev) => prev.filter((l) => l.token !== link.token)),
+	});
+	const error = create.error ?? revoke.error;
 
 	return (
 		<div className="text-xs">
@@ -179,17 +170,17 @@ function PreviewLinks() {
 					id="agentos-preview-port"
 					value={portDraft}
 					onChange={(e) => setPortDraft(e.target.value)}
-					onKeyDown={(e) => e.key === "Enter" && void create()}
+					onKeyDown={(e) => e.key === "Enter" && create.mutate(portDraft)}
 					inputMode="numeric"
 					className="w-20 rounded border bg-background px-2 py-1 font-mono focus:outline-none"
 				/>
 				<button
 					type="button"
-					disabled={busy}
-					onClick={() => void create()}
+					disabled={create.isPending}
+					onClick={() => create.mutate(portDraft)}
 					className="rounded-md border px-2.5 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40"
 				>
-					{busy ? "Creating…" : "Create preview link"}
+					{create.isPending ? "Creating…" : "Create preview link"}
 				</button>
 				<span className="text-muted-foreground/60">
 					Signed URL to an HTTP server on that port, valid 15 minutes. Boots the VM if asleep.
@@ -213,7 +204,7 @@ function PreviewLinks() {
 							</span>
 							<button
 								type="button"
-								onClick={() => void revoke(link)}
+								onClick={() => revoke.mutate(link)}
 								className="rounded border px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 							>
 								Revoke
@@ -238,7 +229,7 @@ function Card({
 	children: ReactNode;
 }) {
 	return (
-		<section className="rounded-xl border bg-card p-4">
+		<section className="rounded-xl border bg-secondary p-4">
 			<div className="mb-3 flex items-center gap-2">
 				<span className="text-sm font-semibold">{title}</span>
 				<span className="ml-auto" />


### PR DESCRIPTION
Addresses the review comments on #1780, stacked on that branch.

- Permission cards are derived from the `listSessions` backfill plus live `sessionEvent` entries; per-request status lives in a bounded map, so no `setState` runs inside `useEffect`
- Filesystem browsing state (root, draft, selection, expanded dirs) is one `useReducer`; per-file view state resets during render instead of in an effect
- `mkdir`, upload, and signed preview links go through `useMutation`, dropping the hand-rolled busy/error state
- New `lib/hooks.ts`: `useObjectUrl`, `useSettledValue` (path-bar debounce), and `useArmedConfirm`, which resets per target and clears its timer on unmount — an armed delete could previously carry over to the next selected file
- Tab surfaces use the dashboard panel colour (`#0C0C0E`) rather than the page colour (`#0A0A0B`), with cards a step above it
- `packages/CLAUDE.md` records the React rules these follow

Verified in a Linux container against a booted VM: delete/kill arming per target and its timeout, real delete and kill, mkdir success/failure/error-reset, preview-link create/revoke/validation, the debounced path bar, and the backfilled permission card. The live-event, respond-state, and multi-viewer legs of the permission banner are not verified — they need a working agent credential.